### PR TITLE
Prep to use local maven repository

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,9 @@ buildscript {
     // The buildscript {} block is odd: even though we applied dependencies.gradle above, the repositories therein
     // do not get included here. Instead, we must explicitly define the repos again. Yay for duplication.
     repositories {
+        // This next line is for use by the netcdf-java library travis test. Do not edit. See note in
+        // tds/gradle/any/dependencies.gradle
+        //mavenLocal()
         jcenter()
         maven {
             url "https://plugins.gradle.org/m2/"  // For Gradle plugins.

--- a/gradle/any/dependencies.gradle
+++ b/gradle/any/dependencies.gradle
@@ -4,6 +4,13 @@
 //================================================ Repositories ================================================//
 
 repositories {
+    // When running one version of the netcdf-java tests on travis, we want to test the TDS against the changes
+    // proposed by a netCDF-Java PR. In order to do this, we need to publish snapshot artifacts of netcdf-java to
+    // the local maven repository and build the TDS with those. In the netCDF-java travis build script, 
+    // we use sed to uncomment the following line so that the tds build uses those local snapshot artifacts in its
+    // build.
+    //mavenLocal()
+    
     // Prefer JCenter to Maven Central. See
     // https://blog.bintray.com/2015/02/09/android-studio-migration-from-maven-central-to-jcenter/
     jcenter()


### PR DESCRIPTION
These changes are in preparation for the netcdf-java build on travis-ci
to test PRs against the TDS master branch. To do so, we need to tell the
TDS build to look in the local maven repository for snapshots. Normally,
this is not something you'd want to do unless you were testing
netcdf-java changes against the TDS locally, therefore these are
commended out. The netcdf-java travis script will use sed to take care of
uncommenting the two entries.