### PR TITLE
Use new CFGridCoverageWriter2 write API

### DIFF
--- a/tds/src/main/java/thredds/server/ncss/controller/NcssGridController.java
+++ b/tds/src/main/java/thredds/server/ncss/controller/NcssGridController.java
@@ -143,8 +143,8 @@ public class NcssGridController extends AbstractNcssController {
     // Test maxFileDownloadSize
     long maxFileDownloadSize = ThreddsConfig.getBytes("NetcdfSubsetService.maxFileDownloadSize", -1L);
     if (maxFileDownloadSize > 0) {
-      Optional<Long> estimatedSizeo = CFGridCoverageWriter2.writeOrTestSize(
-              gcd, params.getVar(), subset, params.isAddLatLon(), true, null);
+      Optional<Long> estimatedSizeo = CFGridCoverageWriter2.getSizeOfOutput(
+              gcd, params.getVar(), subset, params.isAddLatLon());
       if (!estimatedSizeo.isPresent())
         throw new InvalidRangeException("Request contains no data: " + estimatedSizeo.getErrorMessage());
 
@@ -161,8 +161,8 @@ public class NcssGridController extends AbstractNcssController {
     NetcdfFileWriter writer = NetcdfFileWriter.createNew(
             version, responseFilename, null);  // default chunking - let user control at some point
 
-    Optional<Long> estimatedSizeo = CFGridCoverageWriter2.writeOrTestSize(
-            gcd, params.getVar(), subset, params.isAddLatLon(), false, writer);
+    Optional<Long> estimatedSizeo = CFGridCoverageWriter2.write(
+            gcd, params.getVar(), subset, params.isAddLatLon(),writer);
     if (!estimatedSizeo.isPresent())
       throw new InvalidRangeException("Request contains no data: " + estimatedSizeo.getErrorMessage());
 

--- a/tds/src/main/java/thredds/server/wcs/v1_0_0_1/WcsCoverage.java
+++ b/tds/src/main/java/thredds/server/wcs/v1_0_0_1/WcsCoverage.java
@@ -191,9 +191,9 @@ public class WcsCoverage {
 
         // netCDF File Checks
         // this will estimate the size of a single coverage.
-        Optional<Long> estimatedSize = CFGridCoverageWriter2.writeOrTestSize(this.wcsDataset.getDataset(),
+        Optional<Long> estimatedSize = CFGridCoverageWriter2.getSizeOfOutput(this.wcsDataset.getDataset(),
                 Collections.singletonList(this.coverage.getName()),
-                params, true, true, null);
+                params, true);
 
         if (estimatedSize.isPresent()) {
           // check to make sure estimated size isn't greater than the netCDf-3 limit, otherwise
@@ -207,9 +207,9 @@ public class WcsCoverage {
         }
 
         try (NetcdfFileWriter writer = NetcdfFileWriter.createNew(NetcdfFileWriter.Version.netcdf3, outFile.getAbsolutePath())) {
-          estimatedSize = CFGridCoverageWriter2.writeOrTestSize(this.wcsDataset.getDataset(),
+          estimatedSize = CFGridCoverageWriter2.write(this.wcsDataset.getDataset(),
                   Collections.singletonList(this.coverage.getName()),
-                  params, true, false, writer);
+                  params, true, writer);
         }
 
         return outFile;


### PR DESCRIPTION
CFGridCoverageWriter2.writeOrTestSize is now split into two different
methods:

CFGridCoverageWriter2.write
CFGridCoverageWriter2.getSizeOfOutput