### PR TITLE
Explicitly validate RemoteCatalogRequest only

### DIFF
--- a/tds/src/main/java/thredds/server/catalogservice/RemoteCatalogServiceController.java
+++ b/tds/src/main/java/thredds/server/catalogservice/RemoteCatalogServiceController.java
@@ -53,8 +53,8 @@ public class RemoteCatalogServiceController {
   @Autowired
   private CatalogViewContextParser parser;
 
-  @InitBinder // ("RemoteCatalogRequest")  LOOK
-  protected void initBinder(WebDataBinder binder) {
+  @InitBinder("remoteCatalogRequest")
+  protected void initRemoteCatalogRequestBinder(WebDataBinder binder) {
     binder.setValidator(new RemoteCatalogRequestValidator());
   }
 


### PR DESCRIPTION
Fixes Unidata/tds#33

Without explicitly setting the InitBinder for remoteCatalogRequest,
spring will also try to validate the DatasetContext object (set in the
model that gets returned) against the RemoteCatalogRequestValidator.