### PR TITLE
Various updates to bring in line with latest netcdf-java

### DIFF
--- a/gradle/any/dependencies.gradle
+++ b/gradle/any/dependencies.gradle
@@ -195,11 +195,6 @@ libraries["jcommander"] = "com.beust:jcommander:1.48"
 
 libraries["jdom2"] = "org.jdom:jdom2:2.0.6"
 
-libraries["jna"] = "net.java.dev.jna:jna:5.4.0"
-
-// replaces the one that we exclude from chronicle-map
-libraries["jna-platform"] = "net.java.dev.jna:jna-platform:4.2.2"
-
 // used by wms server
 libraries["joda-time"] = "joda-time:joda-time:2.10.3"
 
@@ -242,22 +237,18 @@ libraries["jackson-core"] = "com.fasterxml.jackson.core:jackson-core:2.9.9"
 libraries["jackson-annotations"] = "com.fasterxml.jackson.core:jackson-annotations:2.9.9"
 libraries["jackson-databind"] = "com.fasterxml.jackson.core:jackson-databind:2.9.9.1"
 
-libraries["chronicle-map"] = dependencies.create("net.openhft:chronicle-map:3.17.0") {
-    // the version of jna shipped with chronicle-map requires GLIBC 2.14
-    // which prevents the use of the TDS on several versions of linux, such
-    // as CentOS and Hed Hat 6. We already include jna in netCDF-Java for
-    // netCDF-C support, so we will rely on that version instead.
-    // We should be able to get rid of this on the next release of chronicle-map,
-    // as their snapshot BOM pom shows that they pulled back on jna.
+libraries["chronicle-map"] = dependencies.create("net.openhft:chronicle-map:3.17.4") {
+    // The TDS pulls in jna via the netcdf4 module in netcdf-java, so let's exclude
+    // the one pulled in by chronicle-map and make sure we use the same version
+    // netcdf4 uses
     exclude group: 'net.java.dev.jna', module: 'jna'
     exclude group: 'net.java.dev.jna', module: 'jna-platform'
-    // We do not need XStream for our use of chronicle-map.
-    // Nuke it. [SEC]
-    exclude group: 'com.thoughtworks.xstream', module: 'xstream'
-    // We do not need pax-url-aether
-    // Nuke it. [SEC]
-    exclude group: 'org.ops4j.pax.url', module: 'pax-url-aether'
 }
+
+// replaces the one that we exclude from chronicle-map
+// Match the version of jna used by the netcdf4 module of the netcdf-java project
+libraries["jna"] = "net.java.dev.jna:jna:5.4.0"
+libraries["jna-platform"] = "net.java.dev.jna:jna-platform:5.4.0"
 
 libraries["javax.servlet-api"] = "javax.servlet:javax.servlet-api:3.1.0"
 

--- a/it/src/test/java/thredds/server/catalog/TestTdsFCcatalogs.java
+++ b/it/src/test/java/thredds/server/catalog/TestTdsFCcatalogs.java
@@ -1,6 +1,7 @@
 /* Copyright */
 package thredds.server.catalog;
 
+import java.nio.charset.StandardCharsets;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -10,7 +11,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import thredds.TestOnLocalServer;
 import thredds.util.ContentType;
-import ucar.nc2.constants.CDM;
 import ucar.unidata.util.test.category.NeedsCdmUnitTest;
 
 import java.lang.invoke.MethodHandles;
@@ -58,7 +58,7 @@ public class TestTdsFCcatalogs {
     String endpoint = TestOnLocalServer.withHttpPath("catalog/"+path+".xml"+query);
     byte[] response = TestOnLocalServer.getContent(endpoint, 200, ContentType.xml);
     Assert.assertNotNull(response);
-    logger.debug(new String(response, CDM.utf8Charset));
+    logger.debug(new String(response, StandardCharsets.UTF_8));
   }
 
   @Test
@@ -66,6 +66,6 @@ public class TestTdsFCcatalogs {
     String endpoint = TestOnLocalServer.withHttpPath("catalog/"+path+".html"+query);
     byte[] response = TestOnLocalServer.getContent(endpoint, 200, ContentType.html);
     Assert.assertNotNull(response);
-    logger.debug(new String(response, CDM.utf8Charset));
+    logger.debug(new String(response, StandardCharsets.UTF_8));
   }
 }

--- a/it/src/test/java/thredds/server/ncss/TestGridAsPointP.java
+++ b/it/src/test/java/thredds/server/ncss/TestGridAsPointP.java
@@ -4,6 +4,7 @@
  */
 package thredds.server.ncss;
 
+import java.nio.charset.StandardCharsets;
 import org.jdom2.Document;
 import org.jdom2.Element;
 import org.jdom2.JDOMException;
@@ -27,7 +28,6 @@ import ucar.httpservices.HTTPMethod;
 import ucar.httpservices.HTTPSession;
 import ucar.nc2.NetcdfFile;
 import ucar.nc2.VariableSimpleIF;
-import ucar.nc2.constants.CDM;
 import ucar.nc2.constants.FeatureType;
 import ucar.nc2.dataset.NetcdfDataset;
 import ucar.nc2.ft.FeatureDataset;
@@ -96,7 +96,7 @@ public class TestGridAsPointP {
     String endpoint = TestOnLocalServer.withHttpPath(ds + "?var=" + varName + query + "&accept=csv");
     byte[] result = TestOnLocalServer.getContent(endpoint, 200, ContentType.csv);
     Assert.assertNotNull(result);
-    logger.debug("CSV\n{}", new String( result, CDM.utf8Charset));
+    logger.debug("CSV\n{}", new String( result, StandardCharsets.UTF_8));
   }
 
   @Test

--- a/it/src/test/java/thredds/server/opendap/TestTdsDodsServer.java
+++ b/it/src/test/java/thredds/server/opendap/TestTdsDodsServer.java
@@ -4,6 +4,7 @@
  */
 package thredds.server.opendap;
 
+import java.nio.charset.StandardCharsets;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -18,7 +19,6 @@ import ucar.ma2.Array;
 import ucar.nc2.NetcdfFile;
 import ucar.nc2.Variable;
 import ucar.nc2.VariableSimpleIF;
-import ucar.nc2.constants.CDM;
 import ucar.nc2.constants.FeatureType;
 import ucar.nc2.dataset.CoordinateAxis;
 import ucar.nc2.dataset.NetcdfDataset;
@@ -50,7 +50,7 @@ public class TestTdsDodsServer {
     String endpoint = TestOnLocalServer.withHttpPath("/dodsC/scanCdmUnitTests/tds/ncep/NAM_CONUS_20km_selectsurface_20100913_0000.grib2.ascii?Visibility_surface[0:1:0][0:1:0][0:1:0]");
     byte[] result = TestOnLocalServer.getContent(endpoint, 200, null);
     Assert.assertNotNull(result);
-    String results = new String(result, CDM.utf8Charset);
+    String results = new String(result, StandardCharsets.UTF_8);
     assert results.contains("scanCdmUnitTests/tds/ncep/NAM_CONUS_20km_selectsurface_20100913_0000.grib2");
     assert results.contains("15636.879");
   }

--- a/it/src/test/java/thredds/server/services/ConsistentDatesTest.java
+++ b/it/src/test/java/thredds/server/services/ConsistentDatesTest.java
@@ -1,5 +1,6 @@
 package thredds.server.services;
 
+import java.nio.charset.StandardCharsets;
 import org.jdom2.Document;
 import org.jdom2.Element;
 import org.jdom2.JDOMException;
@@ -75,7 +76,7 @@ public class ConsistentDatesTest {
   public void checkWMSDates() throws JDOMException, IOException {
     String endpoint = TestOnLocalServer.withHttpPath("/wms/cdmUnitTest/ncss/climatology/PF5_SST_Climatology_Monthly_1985_2001.nc?service=WMS&version=1.3.0&request=GetCapabilities");
     byte[] result = TestOnLocalServer.getContent(endpoint, 200, ContentType.xml);
-    Reader in = new StringReader( new String(result, CDM.utf8Charset));
+    Reader in = new StringReader( new String(result, StandardCharsets.UTF_8));
     SAXBuilder sb = new SAXBuilder();
     Document doc = sb.build(in);
 
@@ -102,7 +103,7 @@ public class ConsistentDatesTest {
   public void checkWCSDates() throws JDOMException, IOException {
     String endpoint = TestOnLocalServer.withHttpPath("/wcs/cdmUnitTest/ncss/climatology/PF5_SST_Climatology_Monthly_1985_2001.nc?service=WCS&version=1.0.0&request=DescribeCoverage&coverage=sst");
     byte[] result = TestOnLocalServer.getContent(endpoint, 200, ContentType.xml);
-    Reader in = new StringReader( new String(result, CDM.utf8Charset));
+    Reader in = new StringReader( new String(result, StandardCharsets.UTF_8));
     SAXBuilder sb = new SAXBuilder();
     Document doc = sb.build(in);
 
@@ -127,7 +128,7 @@ public class ConsistentDatesTest {
   public void checkNCSSDates() throws JDOMException, IOException {
     String endpoint = TestOnLocalServer.withHttpPath("/ncss/grid/cdmUnitTest/ncss/climatology/PF5_SST_Climatology_Monthly_1985_2001.nc?var=sst&latitude=45&longitude=-20&temporal=all&accept=xml");
     byte[] result = TestOnLocalServer.getContent(endpoint, 200, ContentType.xml);
-    String results = new String(result, CDM.utf8Charset);
+    String results = new String(result, StandardCharsets.UTF_8);
     if (show) System.out.printf("checkNCSSDates%n%s%n", results);
     Reader in = new StringReader( results );
     SAXBuilder sb = new SAXBuilder();

--- a/it/src/test/java/thredds/server/services/TestAdminDebug.java
+++ b/it/src/test/java/thredds/server/services/TestAdminDebug.java
@@ -1,5 +1,6 @@
 package thredds.server.services;
 
+import java.nio.charset.StandardCharsets;
 import org.apache.http.HttpStatus;
 import org.apache.http.auth.Credentials;
 import org.apache.http.auth.UsernamePasswordCredentials;
@@ -10,7 +11,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import thredds.TestOnLocalServer;
 import thredds.util.ContentType;
-import ucar.nc2.constants.CDM;
 
 import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
@@ -52,7 +52,7 @@ public class TestAdminDebug {
         String endpoint = urlPrefix + path;
         byte[] response = TestOnLocalServer.getContent(goodCred, endpoint, new int[] { 200 }, ContentType.html);
         if (response != null) {
-            logger.debug(new String(response, CDM.utf8Charset));
+            logger.debug(new String(response, StandardCharsets.UTF_8));
         }
     }
 
@@ -62,7 +62,7 @@ public class TestAdminDebug {
                 .getContent(badCred, endpoint, new int[] { HttpStatus.SC_UNAUTHORIZED, HttpStatus.SC_FORBIDDEN }, ContentType.html);
 
         if (response != null) {
-            logger.debug(new String(response, CDM.utf8Charset));
+            logger.debug(new String(response, StandardCharsets.UTF_8));
         }
     }
 }

--- a/it/src/test/java/thredds/server/services/TestMetadataService.java
+++ b/it/src/test/java/thredds/server/services/TestMetadataService.java
@@ -1,6 +1,7 @@
 /* Copyright */
 package thredds.server.services;
 
+import java.nio.charset.StandardCharsets;
 import org.apache.http.HttpStatus;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -10,7 +11,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import thredds.TestOnLocalServer;
 import thredds.util.ContentType;
-import ucar.nc2.constants.CDM;
 import ucar.unidata.util.test.category.NeedsCdmUnitTest;
 
 import java.lang.invoke.MethodHandles;
@@ -53,7 +53,7 @@ public class TestMetadataService {
     String endpoint = TestOnLocalServer.withHttpPath(url+"&accept=xml");
     byte[] response = TestOnLocalServer.getContent(endpoint, statusCodes, ContentType.xml);
     if (show && response != null)
-      System.out.printf("%s%n", new String(response, CDM.utf8Charset));
+      System.out.printf("%s%n", new String(response, StandardCharsets.UTF_8));
   }
 
   @Test
@@ -61,7 +61,7 @@ public class TestMetadataService {
     String endpoint = TestOnLocalServer.withHttpPath(url);
     byte[] response = TestOnLocalServer.getContent(endpoint, statusCodes, ContentType.html);
     if (show && response != null)
-      System.out.printf("%s%n", new String(response, CDM.utf8Charset));
+      System.out.printf("%s%n", new String(response, StandardCharsets.UTF_8));
   }
 }
 

--- a/it/src/test/java/thredds/server/wcs/TestWcsServer.java
+++ b/it/src/test/java/thredds/server/wcs/TestWcsServer.java
@@ -3,6 +3,7 @@
  */
 package thredds.server.wcs;
 
+import java.nio.charset.StandardCharsets;
 import org.jdom2.Document;
 import org.jdom2.Element;
 import org.jdom2.JDOMException;
@@ -32,7 +33,6 @@ import thredds.TestOnLocalServer;
 import thredds.util.ContentType;
 import ucar.nc2.NetcdfFile;
 import ucar.nc2.constants.AxisType;
-import ucar.nc2.constants.CDM;
 import ucar.nc2.dataset.NetcdfDataset;
 import ucar.nc2.ft2.coverage.Coverage;
 import ucar.nc2.ft2.coverage.CoverageCollection;
@@ -78,7 +78,7 @@ public class TestWcsServer {
     String endpoint = TestOnLocalServer.withHttpPath(dataset1+"&request=GetCapabilities");
     byte[] result = TestOnLocalServer.getContent(endpoint, 200, ContentType.xml);
 
-    Reader in = new StringReader( new String(result, CDM.utf8Charset));
+    Reader in = new StringReader( new String(result, StandardCharsets.UTF_8));
     SAXBuilder sb = new SAXBuilder();
     Document doc = sb.build(in);
 
@@ -291,7 +291,7 @@ public class TestWcsServer {
 
   private boolean isGetCoverageWcsDoc(String url) throws JDOMException, IOException {
     byte[] result = TestOnLocalServer.getContent(url+baloney+"&request=GetCapabilities", 200, ContentType.xml);
-    Reader in = new StringReader( new String(result, CDM.utf8Charset));
+    Reader in = new StringReader( new String(result, StandardCharsets.UTF_8));
     SAXBuilder sb = new SAXBuilder();
     Document doc = sb.build(in);
 

--- a/it/src/test/java/thredds/server/wms/TestWmsServer.java
+++ b/it/src/test/java/thredds/server/wms/TestWmsServer.java
@@ -5,6 +5,7 @@
 
 package thredds.server.wms;
 
+import java.nio.charset.StandardCharsets;
 import org.jdom2.Document;
 import org.jdom2.Element;
 import org.jdom2.JDOMException;
@@ -28,7 +29,6 @@ import java.util.List;
 
 import thredds.TestOnLocalServer;
 import thredds.util.ContentType;
-import ucar.nc2.constants.CDM;
 import ucar.unidata.util.test.category.NeedsCdmUnitTest;
 
 import static org.junit.Assert.assertEquals;
@@ -43,7 +43,7 @@ public class TestWmsServer {
     public void testCapabilites() throws IOException, JDOMException {
         String endpoint = TestOnLocalServer.withHttpPath("/wms/scanCdmUnitTests/conventions/coards/sst.mnmean.nc?service=WMS&version=1.3.0&request=GetCapabilities");
         byte[] result = TestOnLocalServer.getContent(endpoint, 200, ContentType.xmlwms);
-        Reader in = new StringReader(new String(result, CDM.utf8Charset));
+        Reader in = new StringReader(new String(result, StandardCharsets.UTF_8));
         SAXBuilder sb = new SAXBuilder();
         Document doc = sb.build(in);
 

--- a/opendap/dtswar/src/main/java/opendap/dts/DTSServlet.java
+++ b/opendap/dtswar/src/main/java/opendap/dts/DTSServlet.java
@@ -59,6 +59,8 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.*;
 import java.util.*;
+import java.nio.charset.StandardCharsets;
+
 import java.util.zip.DeflaterOutputStream;
 
 /**
@@ -688,7 +690,7 @@ public class DTSServlet extends AbstractServlet
                 CEEvaluator ce = new CEEvaluator(myDDS);
                 ce.parseConstraint(rs);
                 // Send the constrained DDS back to the client
-                PrintWriter pw = new PrintWriter(new OutputStreamWriter(Out, Util.UTF8));
+                PrintWriter pw = new PrintWriter(new OutputStreamWriter(Out, StandardCharsets.UTF_8));
                 myDDS.printConstrained(pw);
                 pw.flush();
             }
@@ -764,7 +766,7 @@ public class DTSServlet extends AbstractServlet
                 ce.parseConstraint(rs);
 
                 // Send the constrained DDS back to the client
-                PrintWriter pw = new PrintWriter(new OutputStreamWriter(Out, Util.UTF8));
+                PrintWriter pw = new PrintWriter(new OutputStreamWriter(Out, StandardCharsets.UTF_8));
                 myDDS.printConstrainedXML(pw);
                 pw.flush();
             }
@@ -947,7 +949,7 @@ public class DTSServlet extends AbstractServlet
             // myDDS.printConstrained(System.out);
 
             // Send the constrained DDS back to the client
-            PrintWriter pw = new PrintWriter(new OutputStreamWriter(bOut, Util.UTF8));
+            PrintWriter pw = new PrintWriter(new OutputStreamWriter(bOut, StandardCharsets.UTF_8));
             myDDS.printConstrained(pw);
 
             // Send the Data delimiter back to the client
@@ -1047,7 +1049,7 @@ public class DTSServlet extends AbstractServlet
         // Commented because of a bug in the OPeNDAP C++ stuff...
         //rs.getResponse().setHeader("Content-Encoding", "plain");
 
-        PrintWriter pw = new PrintWriter(new OutputStreamWriter(rs.getResponse().getOutputStream(), Util.UTF8));
+        PrintWriter pw = new PrintWriter(new OutputStreamWriter(rs.getResponse().getOutputStream(), StandardCharsets.UTF_8));
 
         pw.println("Server Version: " + getServerVersion());
         pw.flush();
@@ -1076,7 +1078,7 @@ public class DTSServlet extends AbstractServlet
         // Commented because of a bug in the OPeNDAP C++ stuff...
         //rs.getResponse().setHeader("Content-Encoding", "plain");
 
-        PrintWriter pw = new PrintWriter(new OutputStreamWriter(rs.getResponse().getOutputStream(), Util.UTF8));
+        PrintWriter pw = new PrintWriter(new OutputStreamWriter(rs.getResponse().getOutputStream(), StandardCharsets.UTF_8));
         printHelpPage(pw);
         pw.flush();
 
@@ -1106,7 +1108,7 @@ public class DTSServlet extends AbstractServlet
         // Commented because of a bug in the OPeNDAP C++ stuff...
         //rs.getResponse().setHeader("Content-Encoding", "plain");
 
-        PrintWriter pw = new PrintWriter(new OutputStreamWriter(response.getOutputStream(), Util.UTF8));
+        PrintWriter pw = new PrintWriter(new OutputStreamWriter(response.getOutputStream(), StandardCharsets.UTF_8));
 
         printBadURLPage(pw);
         printHelpPage(pw);
@@ -1165,7 +1167,7 @@ public class DTSServlet extends AbstractServlet
 
             testEngine te = new testEngine(seqLength);
 
-            PrintWriter pw = new PrintWriter(new OutputStreamWriter(rs.getResponse().getOutputStream(), Util.UTF8));
+            PrintWriter pw = new PrintWriter(new OutputStreamWriter(rs.getResponse().getOutputStream(), StandardCharsets.UTF_8));
             dds.printConstrained(pw);
             pw.println("---------------------------------------------");
 
@@ -1214,7 +1216,7 @@ public class DTSServlet extends AbstractServlet
             ds = getDataset(rs);
             if(ds == null) return;
 
-            PrintWriter pw = new PrintWriter(new OutputStreamWriter(rs.getResponse().getOutputStream(), Util.UTF8));
+            PrintWriter pw = new PrintWriter(new OutputStreamWriter(rs.getResponse().getOutputStream(), StandardCharsets.UTF_8));
             rs.getResponse().setHeader("XDODS-Server", getServerVersion());
             rs.getResponse().setContentType("text/html");
             rs.getResponse().setHeader("Content-Description", "dods-description");
@@ -1297,7 +1299,7 @@ public class DTSServlet extends AbstractServlet
         rs.getResponse().setContentType("text/xml");
         rs.getResponse().setHeader("Content-Description", "dods-catalog");
 
-        PrintWriter pw = new PrintWriter(new OutputStreamWriter(rs.getResponse().getOutputStream(), Util.UTF8));
+        PrintWriter pw = new PrintWriter(new OutputStreamWriter(rs.getResponse().getOutputStream(), StandardCharsets.UTF_8));
         printCatalog(rs, pw);
         pw.flush();
         rs.getResponse().setStatus(HttpServletResponse.SC_OK);
@@ -1325,7 +1327,7 @@ public class DTSServlet extends AbstractServlet
 
         PrintWriter pw = null;
         try {
-            pw = new PrintWriter(new OutputStreamWriter(rs.getResponse().getOutputStream(), Util.UTF8));
+            pw = new PrintWriter(new OutputStreamWriter(rs.getResponse().getOutputStream(), StandardCharsets.UTF_8));
         } catch (IOException e) {
             return;
         }
@@ -1400,7 +1402,7 @@ public class DTSServlet extends AbstractServlet
         rs.getResponse().setContentType("text/html");
         rs.getResponse().setHeader("Content-Description", "dods-status");
 
-        PrintWriter pw = new PrintWriter(new OutputStreamWriter(rs.getResponse().getOutputStream(), Util.UTF8));
+        PrintWriter pw = new PrintWriter(new OutputStreamWriter(rs.getResponse().getOutputStream(), StandardCharsets.UTF_8));
         pw.println("<html>");
         pw.println("<title>System Properties</title>");
         pw.println("<hr>");
@@ -1451,7 +1453,7 @@ public class DTSServlet extends AbstractServlet
         rs.getResponse().setContentType("text/html");
         rs.getResponse().setHeader("Content-Description", "dods-status");
 
-        PrintWriter pw = new PrintWriter(new OutputStreamWriter(rs.getResponse().getOutputStream(), Util.UTF8));
+        PrintWriter pw = new PrintWriter(new OutputStreamWriter(rs.getResponse().getOutputStream(), StandardCharsets.UTF_8));
         pw.println("<title>Server Status</title>");
         pw.println("<body><ul>");
         printStatus(pw);

--- a/tds/src/main/java/thredds/server/ncss/view/dsg/point/PointSubsetWriterCSV.java
+++ b/tds/src/main/java/thredds/server/ncss/view/dsg/point/PointSubsetWriterCSV.java
@@ -4,6 +4,7 @@
 
 package thredds.server.ncss.view.dsg.point;
 
+import java.nio.charset.StandardCharsets;
 import org.springframework.http.HttpHeaders;
 
 import thredds.server.ncss.exception.NcssException;
@@ -12,7 +13,6 @@ import thredds.util.TdsPathUtils;
 import ucar.ma2.Array;
 import ucar.ma2.StructureData;
 import ucar.nc2.VariableSimpleIF;
-import ucar.nc2.constants.CDM;
 import ucar.nc2.ft.FeatureDatasetPoint;
 import ucar.nc2.ft.PointFeature;
 import ucar.nc2.ft2.coverage.SubsetParams;
@@ -34,7 +34,7 @@ public class PointSubsetWriterCSV extends AbstractPointSubsetWriter {
     public PointSubsetWriterCSV(FeatureDatasetPoint fdPoint, SubsetParams ncssParams, OutputStream out)
             throws NcssException, IOException {
         super(fdPoint, ncssParams);
-        this.writer = new PrintWriter(new OutputStreamWriter(out, CDM.utf8Charset));
+        this.writer = new PrintWriter(new OutputStreamWriter(out, StandardCharsets.UTF_8));
     }
 
     @Override

--- a/tds/src/main/java/thredds/server/ncss/view/dsg/station/StationSubsetWriterCSV.java
+++ b/tds/src/main/java/thredds/server/ncss/view/dsg/station/StationSubsetWriterCSV.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
 import org.springframework.http.HttpHeaders;
 
 import thredds.server.ncss.exception.NcssException;
@@ -15,7 +16,6 @@ import thredds.util.ContentType;
 import thredds.util.TdsPathUtils;
 import ucar.ma2.Array;
 import ucar.nc2.VariableSimpleIF;
-import ucar.nc2.constants.CDM;
 import ucar.nc2.ft.FeatureDatasetPoint;
 import ucar.nc2.ft.point.StationPointFeature;
 import ucar.nc2.ft2.coverage.SubsetParams;
@@ -32,7 +32,7 @@ public class StationSubsetWriterCSV extends AbstractStationSubsetWriter {
     public StationSubsetWriterCSV(FeatureDatasetPoint fdPoint, SubsetParams ncssParams, OutputStream out)
             throws NcssException, IOException {
         super(fdPoint, ncssParams);
-        this.writer = new PrintWriter(new OutputStreamWriter(out, CDM.utf8Charset));
+        this.writer = new PrintWriter(new OutputStreamWriter(out, StandardCharsets.UTF_8));
     }
 
     @Override

--- a/tds/src/main/java/thredds/server/opendap/NcSDString.java
+++ b/tds/src/main/java/thredds/server/opendap/NcSDString.java
@@ -8,6 +8,7 @@
 
 package thredds.server.opendap;
 
+import java.nio.charset.StandardCharsets;
 import opendap.servers.*;
 
 import java.io.IOException;
@@ -15,7 +16,6 @@ import java.io.DataOutputStream;
 
 import ucar.ma2.*;
 import ucar.nc2.*;
-import ucar.nc2.constants.CDM;
 
 /**
  * Wraps a netcdf scalar or 1D char variable.
@@ -75,7 +75,7 @@ public class NcSDString extends SDString implements HasNetcdfVariable {
         ArrayChar a = (ArrayChar) data;
         byte[] b = new byte[1];
         b[0] = (byte) a.getChar(0);
-        localVal = new String(b, CDM.utf8Charset);
+        localVal = new String(b, StandardCharsets.UTF_8);
       } else {
         // 1D
         ArrayChar a = (ArrayChar) data;

--- a/tds/src/main/java/thredds/server/radarServer2/RadarServerController.java
+++ b/tds/src/main/java/thredds/server/radarServer2/RadarServerController.java
@@ -7,6 +7,7 @@
 package thredds.server.radarServer2;
 
 import com.google.common.base.Joiner;
+import java.nio.charset.StandardCharsets;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -316,7 +317,7 @@ public class RadarServerController {
         if (makeIDVCatalog) {
             String xml = os.toString(CDM.UTF8);
             xml = idvDatasetCatalog(xml);
-            xmlBytes = xml.getBytes(CDM.utf8Charset);
+            xmlBytes = xml.getBytes(StandardCharsets.UTF_8);
         } else {
             xmlBytes = os.toByteArray();
         }
@@ -359,7 +360,7 @@ public class RadarServerController {
 
     HttpEntity<byte[]> simpleString(String str)
     {
-        byte[] bytes = str.getBytes(CDM.utf8Charset);
+        byte[] bytes = str.getBytes(StandardCharsets.UTF_8);
         HttpHeaders header = new HttpHeaders();
         header.setContentType(new MediaType("application", "text"));
         header.setContentLength(bytes.length);

--- a/tds/src/main/java/thredds/servlet/ServletUtil.java
+++ b/tds/src/main/java/thredds/servlet/ServletUtil.java
@@ -5,10 +5,10 @@
 
 package thredds.servlet;
 
+import java.nio.charset.StandardCharsets;
 import thredds.core.ConfigCatalogHtmlWriter;
 import thredds.util.ContentType;
 import thredds.util.RequestForwardUtils;
-import ucar.nc2.constants.CDM;
 import ucar.nc2.util.EscapeStrings;
 import ucar.nc2.util.IO;
 import ucar.unidata.io.RandomAccessFile;
@@ -259,7 +259,7 @@ public class ServletUtil {
 
     try {
       ServletOutputStream out = res.getOutputStream();
-      IO.copy(new ByteArrayInputStream(contents.getBytes(CDM.utf8Charset)), out);
+      IO.copy(new ByteArrayInputStream(contents.getBytes(StandardCharsets.UTF_8)), out);
     } catch (IOException e) {
       log.error(" IOException sending string: ", e);
       res.sendError(HttpServletResponse.SC_NOT_FOUND, "Problem sending string: " + e.getMessage());

--- a/tds/src/test/java/thredds/server/ncss/view/dsg/DsgSubsetWriterTest.java
+++ b/tds/src/test/java/thredds/server/ncss/view/dsg/DsgSubsetWriterTest.java
@@ -2,8 +2,6 @@ package thredds.server.ncss.view.dsg;
 
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -25,6 +23,7 @@ import ucar.nc2.ft2.coverage.SubsetParams;
 import ucar.nc2.iosp.netcdf4.Nc4;
 import ucar.nc2.jni.netcdf.Nc4Iosp;
 import ucar.nc2.ogc.MarshallingUtil;
+import ucar.nc2.time.Calendar;
 import ucar.nc2.time.CalendarDate;
 import ucar.nc2.time.CalendarDateRange;
 import ucar.nc2.util.CompareNetcdf2;
@@ -66,8 +65,8 @@ public class DsgSubsetWriterTest {
         // The WaterML marshaller usually initializes wml2:generationDate and om:resultTime to "now". This is a problem,
         // because those values will always differ from the fixed values we have in our expectedResultResource files.
         // So, to facilitate testing, we're going to fix the values that the marshaller emits.
-        MarshallingUtil.fixedGenerationDate = new DateTime(1970, 1, 1, 0, 0, DateTimeZone.UTC);
-        MarshallingUtil.fixedResultTime     = new DateTime(1970, 1, 1, 0, 0, DateTimeZone.UTC);
+        MarshallingUtil.fixedGenerationDate = CalendarDate.of(Calendar.gregorian, 1970, 1, 1, 0, 0, 0);
+        MarshallingUtil.fixedResultTime     = CalendarDate.of(Calendar.gregorian,1970, 1, 1, 0, 0, 0);
 
         ncssDiskCache = new NcssDiskCache(DiskCache2.getDefault().getRootDirectory());
 

--- a/tds/src/test/resources/thredds/server/ncss/view/dsg/station/waterml2/outputAll.xml
+++ b/tds/src/test/resources/thredds/server/ncss/view/dsg/station/waterml2/outputAll.xml
@@ -15,7 +15,7 @@
             </om:phenomenonTime>
             <om:resultTime>
                 <gml:TimeInstant gml:id="TimeInstantType.1">
-                    <gml:timePosition>1970-01-01T00:00:00.000Z</gml:timePosition>
+                    <gml:timePosition>1970-01-01T00:00:00Z</gml:timePosition>
                 </gml:TimeInstant>
             </om:resultTime>
             <om:procedure xlink:title="Unknown" xlink:href="http://www.opengis.net/def/nil/OGC/0/unknown"/>
@@ -84,7 +84,7 @@
             </om:phenomenonTime>
             <om:resultTime>
                 <gml:TimeInstant gml:id="TimeInstantType.2">
-                    <gml:timePosition>1970-01-01T00:00:00.000Z</gml:timePosition>
+                    <gml:timePosition>1970-01-01T00:00:00Z</gml:timePosition>
                 </gml:TimeInstant>
             </om:resultTime>
             <om:procedure xlink:title="Unknown" xlink:href="http://www.opengis.net/def/nil/OGC/0/unknown"/>
@@ -153,7 +153,7 @@
             </om:phenomenonTime>
             <om:resultTime>
                 <gml:TimeInstant gml:id="TimeInstantType.3">
-                    <gml:timePosition>1970-01-01T00:00:00.000Z</gml:timePosition>
+                    <gml:timePosition>1970-01-01T00:00:00Z</gml:timePosition>
                 </gml:TimeInstant>
             </om:resultTime>
             <om:procedure xlink:title="Unknown" xlink:href="http://www.opengis.net/def/nil/OGC/0/unknown"/>
@@ -222,7 +222,7 @@
             </om:phenomenonTime>
             <om:resultTime>
                 <gml:TimeInstant gml:id="TimeInstantType.4">
-                    <gml:timePosition>1970-01-01T00:00:00.000Z</gml:timePosition>
+                    <gml:timePosition>1970-01-01T00:00:00Z</gml:timePosition>
                 </gml:TimeInstant>
             </om:resultTime>
             <om:procedure xlink:title="Unknown" xlink:href="http://www.opengis.net/def/nil/OGC/0/unknown"/>
@@ -291,7 +291,7 @@
             </om:phenomenonTime>
             <om:resultTime>
                 <gml:TimeInstant gml:id="TimeInstantType.5">
-                    <gml:timePosition>1970-01-01T00:00:00.000Z</gml:timePosition>
+                    <gml:timePosition>1970-01-01T00:00:00Z</gml:timePosition>
                 </gml:TimeInstant>
             </om:resultTime>
             <om:procedure xlink:title="Unknown" xlink:href="http://www.opengis.net/def/nil/OGC/0/unknown"/>
@@ -360,7 +360,7 @@
             </om:phenomenonTime>
             <om:resultTime>
                 <gml:TimeInstant gml:id="TimeInstantType.6">
-                    <gml:timePosition>1970-01-01T00:00:00.000Z</gml:timePosition>
+                    <gml:timePosition>1970-01-01T00:00:00Z</gml:timePosition>
                 </gml:TimeInstant>
             </om:resultTime>
             <om:procedure xlink:title="Unknown" xlink:href="http://www.opengis.net/def/nil/OGC/0/unknown"/>

--- a/tds/src/test/resources/thredds/server/ncss/view/dsg/station/waterml2/outputSubset1.xml
+++ b/tds/src/test/resources/thredds/server/ncss/view/dsg/station/waterml2/outputSubset1.xml
@@ -15,7 +15,7 @@
             </om:phenomenonTime>
             <om:resultTime>
                 <gml:TimeInstant gml:id="TimeInstantType.1">
-                    <gml:timePosition>1970-01-01T00:00:00.000Z</gml:timePosition>
+                    <gml:timePosition>1970-01-01T00:00:00Z</gml:timePosition>
                 </gml:TimeInstant>
             </om:resultTime>
             <om:procedure xlink:title="Unknown" xlink:href="http://www.opengis.net/def/nil/OGC/0/unknown"/>
@@ -72,7 +72,7 @@
             </om:phenomenonTime>
             <om:resultTime>
                 <gml:TimeInstant gml:id="TimeInstantType.2">
-                    <gml:timePosition>1970-01-01T00:00:00.000Z</gml:timePosition>
+                    <gml:timePosition>1970-01-01T00:00:00Z</gml:timePosition>
                 </gml:TimeInstant>
             </om:resultTime>
             <om:procedure xlink:title="Unknown" xlink:href="http://www.opengis.net/def/nil/OGC/0/unknown"/>

--- a/tds/src/test/resources/thredds/server/ncss/view/dsg/station/waterml2/outputSubset2.xml
+++ b/tds/src/test/resources/thredds/server/ncss/view/dsg/station/waterml2/outputSubset2.xml
@@ -15,7 +15,7 @@
             </om:phenomenonTime>
             <om:resultTime>
                 <gml:TimeInstant gml:id="TimeInstantType.1">
-                    <gml:timePosition>1970-01-01T00:00:00.000Z</gml:timePosition>
+                    <gml:timePosition>1970-01-01T00:00:00Z</gml:timePosition>
                 </gml:TimeInstant>
             </om:resultTime>
             <om:procedure xlink:title="Unknown" xlink:href="http://www.opengis.net/def/nil/OGC/0/unknown"/>
@@ -60,7 +60,7 @@
             </om:phenomenonTime>
             <om:resultTime>
                 <gml:TimeInstant gml:id="TimeInstantType.2">
-                    <gml:timePosition>1970-01-01T00:00:00.000Z</gml:timePosition>
+                    <gml:timePosition>1970-01-01T00:00:00Z</gml:timePosition>
                 </gml:TimeInstant>
             </om:resultTime>
             <om:procedure xlink:title="Unknown" xlink:href="http://www.opengis.net/def/nil/OGC/0/unknown"/>
@@ -105,7 +105,7 @@
             </om:phenomenonTime>
             <om:resultTime>
                 <gml:TimeInstant gml:id="TimeInstantType.3">
-                    <gml:timePosition>1970-01-01T00:00:00.000Z</gml:timePosition>
+                    <gml:timePosition>1970-01-01T00:00:00Z</gml:timePosition>
                 </gml:TimeInstant>
             </om:resultTime>
             <om:procedure xlink:title="Unknown" xlink:href="http://www.opengis.net/def/nil/OGC/0/unknown"/>
@@ -150,7 +150,7 @@
             </om:phenomenonTime>
             <om:resultTime>
                 <gml:TimeInstant gml:id="TimeInstantType.4">
-                    <gml:timePosition>1970-01-01T00:00:00.000Z</gml:timePosition>
+                    <gml:timePosition>1970-01-01T00:00:00Z</gml:timePosition>
                 </gml:TimeInstant>
             </om:resultTime>
             <om:procedure xlink:title="Unknown" xlink:href="http://www.opengis.net/def/nil/OGC/0/unknown"/>
@@ -195,7 +195,7 @@
             </om:phenomenonTime>
             <om:resultTime>
                 <gml:TimeInstant gml:id="TimeInstantType.5">
-                    <gml:timePosition>1970-01-01T00:00:00.000Z</gml:timePosition>
+                    <gml:timePosition>1970-01-01T00:00:00Z</gml:timePosition>
                 </gml:TimeInstant>
             </om:resultTime>
             <om:procedure xlink:title="Unknown" xlink:href="http://www.opengis.net/def/nil/OGC/0/unknown"/>
@@ -240,7 +240,7 @@
             </om:phenomenonTime>
             <om:resultTime>
                 <gml:TimeInstant gml:id="TimeInstantType.6">
-                    <gml:timePosition>1970-01-01T00:00:00.000Z</gml:timePosition>
+                    <gml:timePosition>1970-01-01T00:00:00Z</gml:timePosition>
                 </gml:TimeInstant>
             </om:resultTime>
             <om:procedure xlink:title="Unknown" xlink:href="http://www.opengis.net/def/nil/OGC/0/unknown"/>


### PR DESCRIPTION
* Make sure we use the same JNA version as netcdf-java (was causing a chronicle-map error on windows)
* use `java.nio.charset.StandardCharsets.UTF_8` instead of `opendap.dap.Util.UTF8`, `ucar.nc2.constants.CDM`
* Use `ucar.nc2.time.CalendarDate` over joda time