### PR TITLE
Use new netcdf-java modules.

### DIFF
--- a/dap4/d4tests/build.gradle
+++ b/dap4/d4tests/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     testCompile project(':dap4:d4servlet')
     testCompile project(':dap4:d4ts')
     testCompile libraries["d4cdm"]
-    testCompile libraries["cdm"]
+    testCompile libraries["cdm-core"]
     testCompile libraries["httpservices"]
     
     testCompile(project(":tds")) {

--- a/gradle/any/dependencies.gradle
+++ b/gradle/any/dependencies.gradle
@@ -77,15 +77,16 @@ libraries["spotless"] = "com.diffplug.spotless:spotless-plugin-gradle:3.22.0"
 versions["ncj"] = "5.2.0-SNAPSHOT"
 
 libraries["bufr"] = "edu.ucar:bufr:${versions["ncj"]}"
-libraries["cdm"] = "edu.ucar:cdm:${versions["ncj"]}"
-libraries["clcommon"] = "edu.ucar:clcommon:${versions["ncj"]}"
+libraries["cdm-core"] = "edu.ucar:cdm-core:${versions["ncj"]}"
+libraries["cdm-radial"] = "edu.ucar:cdm-radial:${versions["ncj"]}"
+libraries["cdm-misc"] = "edu.ucar:cdm-misc:${versions["ncj"]}"
+libraries["cdm-image"] = "edu.ucar:cdm-image:${versions["ncj"]}"
+libraries["cdm-mcidas"] = "edu.ucar:cdm-mcidas:${versions["ncj"]}"
 libraries["grib"] = "edu.ucar:grib:${versions["ncj"]}"
 libraries["httpservices"] = "edu.ucar:httpservices:${versions["ncj"]}"
 libraries["netcdf4"] = "edu.ucar:netcdf4:${versions["ncj"]}"
 libraries["opendap"] = "edu.ucar:opendap:${versions["ncj"]}"
-libraries["visadCdm"] = "edu.ucar:visadCdm:${versions["ncj"]}"
 libraries["waterml"] = "edu.ucar:waterml:${versions["ncj"]}"
-
 libraries["d4cdm"] = "edu.ucar:d4cdm:${versions["ncj"]}"
 libraries["d4servlet"] = "edu.ucar:d4servlet:${versions["ncj"]}"
 libraries["d4core"] = "edu.ucar:d4core:${versions["ncj"]}"
@@ -207,8 +208,6 @@ libraries["jsoup"] = "org.jsoup:jsoup:1.11.2"
 libraries["jsr305"] = "com.google.code.findbugs:jsr305:3.0.2"
 
 libraries["protobuf-java"] = "com.google.protobuf:protobuf-java:3.9.1"
-
-libraries["visad"] = "edu.wisc.ssec:visad:2.0-20130124"
 
 // replace ??
 libraries["commons-lang3"] = "org.apache.commons:commons-lang3:3.4"

--- a/it/build.gradle
+++ b/it/build.gradle
@@ -19,17 +19,18 @@ apply from: "$rootDir/gradle/any/gretty.gradle"
 apply plugin: 'groovy'  // For Spock tests.
 
 dependencies {
-    testCompile libraries["cdm"]
+    testCompile libraries["cdm-core"]
     testCompile libraries["httpservices"]
     testCompile project(":tdcommon")
     testCompile(project(":tds")) {
         exclude group: "org.apache.logging.log4j"  // We don't want TDS's log4j cruft.
     }
 
-    testRuntime libraries["clcommon"]
+    testRuntime libraries["cdm-image"]
+    testRuntime libraries["cdm-radial"]
     testRuntime libraries["grib"]
     testRuntime libraries["opendap"]
-    testRuntime libraries["visadCdm"]
+    testRuntime libraries["cdm-mcidas"]
     testRuntime libraries["d4cdm"]
 
     testCompile libraries["jdom2"]

--- a/it/src/test/java/ucar/nc2/util/net/TestMisc.java
+++ b/it/src/test/java/ucar/nc2/util/net/TestMisc.java
@@ -32,7 +32,6 @@
 
 package ucar.nc2.util.net;
 
-import HTTPClient.HTTPResponse;
 import org.apache.http.HttpResponse;
 import org.apache.http.conn.ConnectionPoolTimeoutException;
 import org.junit.Assert;

--- a/opendap/dtswar/build.gradle
+++ b/opendap/dtswar/build.gradle
@@ -9,7 +9,7 @@ apply from: "$rootDir/gradle/any/publishing.gradle"
 apply plugin: 'war'
 
 dependencies {
-    compile libraries["cdm"]
+    compile libraries["cdm-core"]
     compile libraries["opendap"]
     compile project(":opendap:server")
 

--- a/opendap/server/build.gradle
+++ b/opendap/server/build.gradle
@@ -7,7 +7,7 @@ apply from: "$rootDir/gradle/any/testing.gradle"
 apply from: "$rootDir/gradle/any/publishing.gradle"
 
 dependencies {
-    compile libraries["cdm"]
+    compile libraries["cdm-core"]
     compile libraries["opendap"]
     compile libraries["slf4j-api"]
 

--- a/tdcommon/build.gradle
+++ b/tdcommon/build.gradle
@@ -8,7 +8,7 @@ apply from: "$rootDir/gradle/any/archiving.gradle"
 apply from: "$rootDir/gradle/any/publishing.gradle"
 
 dependencies {
-    compile libraries["cdm"]
+    compile libraries["cdm-core"]
     compile libraries["grib"]
 
     compile libraries["jdom2"]        // Required for reading THREDDS, NcML, BUFR, HDF-EOS, NEXRAD2, OPeNDAP files.

--- a/tdm/build.gradle
+++ b/tdm/build.gradle
@@ -8,7 +8,7 @@ apply from: "$rootDir/gradle/any/publishing.gradle"
 
 dependencies {
     compile libraries["httpservices"]
-    compile libraries["cdm"]
+    compile libraries["cdm-core"]
     compile libraries["grib"]
     compile project(':tdcommon')
 

--- a/tds/build.gradle
+++ b/tds/build.gradle
@@ -18,15 +18,17 @@ apply plugin: 'war'
 
 dependencies {
     compile libraries["bufr"]
-    compile libraries["cdm"]
-    compile libraries["clcommon"]
+    compile libraries["cdm-core"]
+    compile libraries["cdm-radial"]
+    compile libraries["cdm-misc"]
+    compile libraries["cdm-image"]
     compile libraries["grib"]
     compile libraries["httpservices"]
     compile libraries["netcdf4"]
     compile libraries["opendap"]
     compile project(":opendap:server")
     compile project(":tdcommon")
-    runtime libraries["visadCdm"]
+    compile libraries["cdm-mcidas"]
     compile libraries["waterml"]
 
     // DAP4 Dependencies (technically forward)

--- a/testUtil/build.gradle
+++ b/testUtil/build.gradle
@@ -7,7 +7,7 @@ apply from: "$rootDir/gradle/any/java.gradle"
 // testUtil is not published
 
 dependencies {
-    compile libraries["cdm"]
+    compile libraries["cdm-core"]
     compile libraries["httpservices"]
     
     compile libraries["junit"]


### PR DESCRIPTION
Use the new modules introduced in netcdf-java 5.2 (currently snapshot) (brings TDS up-to-date with Unidata/netcdf-java#124).