### PR TITLE
Large NcML and ChronicleMap

### DIFF
--- a/tdcommon/src/main/java/thredds/server/catalog/tracker/DatasetTrackerChronicle.java
+++ b/tdcommon/src/main/java/thredds/server/catalog/tracker/DatasetTrackerChronicle.java
@@ -3,6 +3,7 @@ package thredds.server.catalog.tracker;
 import net.openhft.chronicle.map.ChronicleMap;
 import net.openhft.chronicle.map.ChronicleMapBuilder;
 import org.jdom2.Element;
+import org.jdom2.output.Format;
 import org.jdom2.output.XMLOutputter;
 import thredds.client.catalog.Access;
 import thredds.client.catalog.Dataset;
@@ -176,8 +177,8 @@ public class DatasetTrackerChronicle implements DatasetTracker {
     if (hasNcml) {
       // want the ncml string representation
       Element ncmlElem = dataset.getNcmlElement();
-      XMLOutputter xmlOut = new XMLOutputter();
-      ncml = xmlOut.outputString(ncmlElem);
+      // make string representation of ncml "compact"
+      ncml = ncmlToCompactString(ncmlElem);
     }
 
     // changed = true;
@@ -185,6 +186,22 @@ public class DatasetTrackerChronicle implements DatasetTracker {
     datasetMap.put(path, dsext);
     changed = true;
     return true;
+  }
+
+  /**
+   * Make a block of NcML compact and remove comments to minimize size stored in chronicle database
+   *
+   * @param ncmlElem
+   * @return compact ncml string
+   */
+  static String ncmlToCompactString(Element ncmlElem) {
+    // set the string output to be "compact"
+    XMLOutputter xmlOut = new XMLOutputter(Format.getCompactFormat());
+    String ncml = xmlOut.outputString(ncmlElem);
+    // strip out xml comments
+    // pattern from https://superuser.com/a/1153242
+    ncml = ncml.replaceAll("<!--[\\s\\S\\n]*?-->", "");
+    return ncml;
   }
 
   public String findResourceControl(String path) {

--- a/tds/src/test/data/configCatalogs/README
+++ b/tds/src/test/data/configCatalogs/README
@@ -1,0 +1,1 @@
+This is a directory for stand alone config catalogs used by tests.

--- a/tds/src/test/data/configCatalogs/bigNcml.xml
+++ b/tds/src/test/data/configCatalogs/bigNcml.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<catalog name="TDS Test Big NcML"
+         xmlns="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0"
+         xmlns:xlink="http://www.w3.org/1999/xlink"
+         xmlns:ncml="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2" version="1.2">
+
+  <dataset name="Big NcML test 1 - opendap" ID="bigNcmlTest1" urlPath="ExampleNcML/bigNcml1.nc">
+    <serviceName>opendap</serviceName>
+    <ncml:netcdf xmlns="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2">
+      <!-- when NcML blocks get too large, DatasetExt.readExternal barfs, so let's trigger that here -->
+      <attribute name="name" value="value"/>
+      <!-- I want to be bigger than a block and I shall be
+      I want to be bigger than a block and I shall be
+      I want to be bigger than a block and I shall be
+      I want to be bigger than a block and I shall be
+      I want to be bigger than a block and I shall be
+      I want to be bigger than a block and I shall be
+      I want to be bigger than a block and I shall be
+      I want to be bigger than a block and I shall be
+      I want to be bigger than a block and I shall be
+      I want to be bigger than a block and I shall be
+      I want to be bigger than a block and I shall be
+      I want to be bigger than a block and I shall be
+      I want to be bigger than a block and I shall be
+      I want to be bigger than a block and I shall be
+      I want to be bigger than a block and I shall be
+      I want to be bigger than a block and I shall be
+      I want to be bigger than a block and I shall be
+      I want to be bigger than a block and I shall be
+      I want to be bigger than a block and I shall be
+      I want to be bigger than a block and I shall be
+      I want to be bigger than a block and I shall be
+      I want to be bigger than a block and I shall be
+      I want to be bigger than a block and I shall be
+      I want to be bigger than a block and I shall be
+      I want to be bigger than a block and I shall be
+      I want to be bigger than a block and I shall be
+      I want to be bigger than a block and I shall be
+      I want to be bigger than a block and I shall be
+      I want to be bigger than a block and I shall be
+      I want to be bigger than a block and I shall be
+      I want to be bigger than a block and I shall be
+      I want to be bigger than a block and I shall be
+      I want to be bigger than a block and I shall be
+      I want to be bigger than a block and I shall be
+      I want to be bigger than a block and I shall be
+      I want to be bigger than a block and I shall be
+      I want to be bigger than a block and I shall be
+      I want to be bigger than a block and I shall be
+      I want to be bigger than a block and I shall be
+      I want to be bigger than a block and I shall be
+      I want to be bigger than a block and I shall be
+      I want to be bigger than a block and I shall be
+      I want to be bigger than a block and I shall be
+      I want to be bigger than a block and I shall be
+      I want to be bigger than a block and I shall be
+      I want to be bigger than a block and I shall be
+      I want to be bigger than a block and I shall be
+      I want to be bigger than a block and I shall be
+      I want to be bigger than a block and I shall be
+      I want to be bigger than a block and I shall be -->
+    </ncml:netcdf>
+  </dataset>
+</catalog>

--- a/tds/src/test/java/thredds/server/catalog/tracker/TestChronicleTrackerBigNcml.java
+++ b/tds/src/test/java/thredds/server/catalog/tracker/TestChronicleTrackerBigNcml.java
@@ -1,0 +1,137 @@
+/* Copyright */
+package thredds.server.catalog.tracker;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Optional;
+import org.apache.commons.io.FileUtils;
+import org.jdom2.Element;
+import org.jdom2.output.XMLOutputter;
+import org.junit.Assert;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import thredds.client.catalog.Catalog;
+import thredds.client.catalog.Dataset;
+import thredds.client.catalog.builder.CatalogBuilder;
+import thredds.client.catalog.tools.CatalogCrawler;
+import thredds.server.catalog.ConfigCatalog;
+import thredds.server.catalog.TestConfigCatalogBuilder;
+
+/**
+ * Test the ability of the chronicle based DatasetTracker to deal with "big" NcML.
+ *
+ * @author sarms
+ * @since 12/27/2019
+ */
+public class TestChronicleTrackerBigNcml {
+
+  private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+  private Path tdsTestDataDir = Paths.get("../tds/src/test/data").toAbsolutePath().normalize();
+  private Path bigNcmlConfigCatalog = tdsTestDataDir.resolve("configCatalogs/bigNcml.xml");
+
+  /**
+   * Manage a standalone dataset tracker for testing purposes
+   */
+  final class TestDatasetTracker implements Closeable {
+
+    private final Path tempDbPath;
+    private final DatasetTrackerChronicle datasetTracker;
+
+    public TestDatasetTracker() throws IOException {
+      tempDbPath = Files.createTempDirectory("tdsTests");
+      datasetTracker = new DatasetTrackerChronicle(tempDbPath.toString(), 10, 0);
+    }
+
+    public DatasetTrackerChronicle getDatasetTracker() {
+      return datasetTracker;
+    }
+
+    @Override
+    public void close() throws IOException {
+      datasetTracker.close();
+      FileUtils.deleteDirectory(tempDbPath.toFile());
+    }
+  }
+
+  /**
+   * Build a client catalog from a config catalog
+   * 
+   * @param configCatalog URI to an on disk config catalog
+   * @return a client catalog {@link Catalog} wrapped in an {@link Optional}. The Optional may be empty.
+   * @throws IOException
+   */
+  private Optional<Catalog> buildClientCatalog(URI configCatalog) throws IOException {
+    ConfigCatalog configCat = TestConfigCatalogBuilder.open(configCatalog.toString());
+    CatalogBuilder catalogBuilder = configCat.makeCatalogBuilder();
+    Catalog clientCatalog = catalogBuilder.makeCatalog();
+    return Optional.ofNullable(clientCatalog);
+  }
+
+  /**
+   * crawl a client catalog to get its datasets into the dataset tracker
+   * 
+   * @param catalog client catalog
+   * @param datasetTracker dataset Tracker to use
+   * @throws IOException
+   */
+  private void crawl(Catalog catalog, DatasetTracker datasetTracker) throws IOException {
+    CatalogCrawler crawler = new CatalogCrawler(CatalogCrawler.Type.all, -1, null, new CatalogCrawler.Listener() {
+      public void getDataset(Dataset dd, Object context) {
+        datasetTracker.trackDataset(0, dd, null);
+      }
+    }, null, null, null);
+    crawler.crawl(catalog);
+  }
+
+  private Element getNcmlFromClientCatalog(Catalog clientCatalog) {
+    Dataset ds = clientCatalog.findDatasetByID("bigNcmlTest1");
+    return ds.getNcmlElement();
+  }
+
+  /**
+   * Read in a config catalog with some "really big" ncml (thanks to lots of comments).
+   * Make sure the NcML can be added to the chronicle database and restored properly.
+   * In order for this to work, the NcML must striped of unnecessary whitespace and
+   * comments must be removed.
+   *
+   *
+   *
+   * @throws IOException
+   */
+  @Test
+  public void testBigNcML() throws IOException {
+
+    try (TestDatasetTracker datasetTracker = new TestDatasetTracker()) {
+      DatasetTrackerChronicle datasetTrackerDb = datasetTracker.getDatasetTracker();
+
+      // generate client catalog from config catalog
+      Optional<Catalog> clientCatalogOp = buildClientCatalog(bigNcmlConfigCatalog.toUri());
+      Catalog clientCatalog = clientCatalogOp.orElseThrow(() -> new RuntimeException(
+          "Config Catalog %s did not produce a client catalog.".format(bigNcmlConfigCatalog.toUri().toString())));
+
+      // get ncml string as found in catalog
+      Element ncml = getNcmlFromClientCatalog(clientCatalog);
+      String ncmlFromCatalog = (new XMLOutputter()).outputString(ncml);
+
+      // read the client catalog, and add to dataset tracker
+      crawl(clientCatalog, datasetTrackerDb);
+
+      // persist to disk then reopen
+      datasetTrackerDb.save();
+
+      // get ncml as restored from dataset tracker
+      String ncmlFromDb = datasetTrackerDb.findNcml("ExampleNcML/bigNcml1.nc");
+
+      // compare actual ncml from catalog and ncml from dataset tracker
+      Assert.assertEquals(ncmlFromCatalog, ncmlFromDb);
+
+    }
+  }
+}

--- a/tds/src/test/java/thredds/server/catalog/tracker/TestChronicleTrackerBigNcml.java
+++ b/tds/src/test/java/thredds/server/catalog/tracker/TestChronicleTrackerBigNcml.java
@@ -130,8 +130,12 @@ public class TestChronicleTrackerBigNcml {
       String ncmlFromDb = datasetTrackerDb.findNcml("ExampleNcML/bigNcml1.nc");
 
       // compare actual ncml from catalog and ncml from dataset tracker
-      Assert.assertEquals(ncmlFromCatalog, ncmlFromDb);
+      // the ncml from the catalog should have comments, etc. Should not match
+      Assert.assertNotEquals(ncmlFromCatalog, ncmlFromDb);
 
+      // make the NcML from the catalog compact
+      String compactNcmlFromCatalog = DatasetTrackerChronicle.ncmlToCompactString(ncml);
+      Assert.assertEquals(compactNcmlFromCatalog, ncmlFromDb);
     }
   }
 }


### PR DESCRIPTION
DatasetTrackerChronicle does not work when the NcML found in a catalog
become too large for the read() method of ObjectInput to fully consume.
Changing the read() method to readFully() does not help, as there appears
to be other issues related to the non-blocking design of ChronicleMap.

While this does not fix the issue of an arbitrarily large block of
NcML not working with ChronicleMap, it does reduce the size of what is
trying to be stored by removing unnecessary whitespace, and stripping
out all comments. This might help mitigate the issue reported in
Unidata/tds#56.