### PR TITLE
Update TDS WMS configuration to support SLD parameter

### DIFF
--- a/gradle/any/dependencies.gradle
+++ b/gradle/any/dependencies.gradle
@@ -272,7 +272,7 @@ libraries["oro"] = "oro:oro:2.0.8"
 
 libraries["thymeleaf-spring4"] = "org.thymeleaf:thymeleaf-spring4:3.0.11.RELEASE"
 
-versions["edal"] = "1.4.2-SNAPSHOT"
+versions["edal"] = "1.4.2"
 
 // needed for edal-common but this pulls in a newer version.
 libraries["ehcache"] = "net.sf.ehcache:ehcache:2.10.6"

--- a/it/src/test/java/thredds/server/wms/TestWmsServer.java
+++ b/it/src/test/java/thredds/server/wms/TestWmsServer.java
@@ -59,12 +59,41 @@ public class TestWmsServer {
   @Test
   public void testGetPng() {
     String endpoint = TestOnLocalServer.withHttpPath(
-        "/wms/scanCdmUnitTests/conventions/cf/ipcc/tas_A1.nc?service=WMS&version=1.3.0&request=GetMap&CRS=CRS:84&WIDTH=512&HEIGHT=512&LAYERS=%20tas&BBOX=0,-90,360,90&format=image/png;mode=32bit&time=1850-01-16T12:00:00Z");
+        "/wms/scanCdmUnitTests/conventions/cf/ipcc/tas_A1.nc?service=WMS&version=1.3.0&request=GetMap&CRS=CRS:84&WIDTH=512&HEIGHT=512&LAYERS=tas&BBOX=0,-90,360,90&format=image/png&time=1850-01-16T12:00:00Z");
     byte[] result = TestOnLocalServer.getContent(endpoint, 200, null);
     // make sure we get a png back
     // first byte (unsigned) should equal 137 (decimal)
     assertEquals(result[0] & 0xFF, 137);
     // bytes 1, 2, and 3, when interperted as ASCII, should be P N G
     assertEquals(new String(((byte[]) Arrays.copyOfRange(result, 1, 4)), Charset.forName("US-ASCII")), "PNG");
+  }
+
+  @Test
+  public void testGetLegendGraphic() {
+    String endpoint = TestOnLocalServer.withHttpPath(
+        "/wms/scanCdmUnitTests/conventions/cf/ipcc/tas_A1.nc?service=WMS&version=1.3.0&request=GetLegendGraphic&Layers=tas&colorscalerange=225.0,310.0&style=default-scalar/x-Rainbow");
+    byte[] result = TestOnLocalServer.getContent(endpoint, 200, null);
+    // make sure we get a png back
+    // first byte (unsigned) should equal 137 (decimal)
+    assertEquals(result[0] & 0xFF, 137);
+    // bytes 1, 2, and 3, when interperted as ASCII, should be P N G
+    assertEquals(new String(((byte[]) Arrays.copyOfRange(result, 1, 4)), Charset.forName("US-ASCII")), "PNG");
+  }
+
+  @Test
+  public void testGetLegendGraphicWithSLD() {
+    System.setProperty("httpservices.urlencode", "false");
+    try {
+      String endpoint = TestOnLocalServer.withHttpPath(
+          "/wms/scanCdmUnitTests/conventions/cf/ipcc/tas_A1.nc?service=WMS&version=1.3.0&request=GetLegendGraphic&Layers=tas&SLD_BODY=%3C%3Fxml%20version%3D%221.0%22%20encoding%3D%22ISO-8859-1%22%3F%3E%20%3CStyledLayerDescriptor%20version%3D%221.1.0%22%20xsi%3AschemaLocation%3D%22http%3A%2F%2Fwww.opengis.net%2Fsld%20StyledLayerDescriptor.xsd%22%20xmlns%3D%22http%3A%2F%2Fwww.opengis.net%2Fsld%22%20xmlns%3Aogc%3D%22http%3A%2F%2Fwww.opengis.net%2Fogc%22%20xmlns%3Ase%3D%22http%3A%2F%2Fwww.opengis.net%2Fse%22%20xmlns%3Axlink%3D%22http%3A%2F%2Fwww.w3.org%2F1999%2Fxlink%22%20xmlns%3Axsi%3D%22http%3A%2F%2Fwww.w3.org%2F2001%2FXMLSchema-instance%22%3E%20%3CNamedLayer%3E%20%3Cse%3AName%3Etas%3C%2Fse%3AName%3E%20%3CUserStyle%3E%20%3Cse%3AName%3EThesholded%20colour%20scheme%3C%2Fse%3AName%3E%20%3Cse%3ACoverageStyle%3E%20%3Cse%3ARule%3E%20%3Cse%3ARasterSymbolizer%3E%20%3Cse%3AOpacity%3E1.0%3C%2Fse%3AOpacity%3E%20%3Cse%3AColorMap%3E%20%3Cse%3ACategorize%20fallbackValue%3D%22%2300000000%22%3E%20%3Cse%3ALookupValue%3ERasterdata%3C%2Fse%3ALookupValue%3E%20%3Cse%3AValue%3E%23FF0000FF%3C%2Fse%3AValue%3E%20%3Cse%3AThreshold%3E275.0%3C%2Fse%3AThreshold%3E%20%3Cse%3AValue%3E%23FF00FFFF%3C%2Fse%3AValue%3E%20%3Cse%3AThreshold%3E280.0%3C%2Fse%3AThreshold%3E%20%3Cse%3AValue%3E%23FF00FF00%3C%2Fse%3AValue%3E%20%3Cse%3AThreshold%3E285.0%3C%2Fse%3AThreshold%3E%20%3Cse%3AValue%3E%23FFFFFF00%3C%2Fse%3AValue%3E%20%3Cse%3AThreshold%3E290.0%3C%2Fse%3AThreshold%3E%20%3Cse%3AValue%3E%23FFFFC800%3C%2Fse%3AValue%3E%20%3Cse%3AThreshold%3E295.0%3C%2Fse%3AThreshold%3E%20%3Cse%3AValue%3E%23FFFFAFAF%3C%2Fse%3AValue%3E%20%3Cse%3AThreshold%3E300.0%3C%2Fse%3AThreshold%3E%20%3Cse%3AValue%3E%23FFFF0000%3C%2Fse%3AValue%3E%20%3C%2Fse%3ACategorize%3E%20%3C%2Fse%3AColorMap%3E%20%3C%2Fse%3ARasterSymbolizer%3E%20%3C%2Fse%3ARule%3E%20%3C%2Fse%3ACoverageStyle%3E%20%3C%2FUserStyle%3E%20%3C%2FNamedLayer%3E%20%3C%2FStyledLayerDescriptor%3E");
+      byte[] result = TestOnLocalServer.getContent(endpoint, 200, null);
+      // make sure we get a png back
+      // first byte (unsigned) should equal 137 (decimal)
+      assertEquals(result[0] & 0xFF, 137);
+      // bytes 1, 2, and 3, when interperted as ASCII, should be P N G
+      assertEquals(new String(((byte[]) Arrays.copyOfRange(result, 1, 4)), Charset.forName("US-ASCII")), "PNG");
+    } finally {
+      System.setProperty("httpservices.urlencode", "true");
+    }
   }
 }

--- a/tds/src/main/java/thredds/server/wms/ThreddsWmsCatalogue.java
+++ b/tds/src/main/java/thredds/server/wms/ThreddsWmsCatalogue.java
@@ -97,7 +97,7 @@ public class ThreddsWmsCatalogue implements WmsCatalogue {
    * DatasetFactory types, it may be better off being passed into this
    * catalogue.
    */
-  static TdsWmsDatasetFactory datasetFactory = new TdsWmsDatasetFactory();
+  TdsWmsDatasetFactory datasetFactory = new TdsWmsDatasetFactory();
 
   /*
    * The Dataset associated with this catalogue

--- a/tds/src/main/webapp/WEB-INF/applicationContext.xml
+++ b/tds/src/main/webapp/WEB-INF/applicationContext.xml
@@ -37,6 +37,11 @@
            requestQueryFilterAllowAngleBrackets,
            requestCORSFilter,
            requestBracketingLogMessageFilter"/>
+                <security:filter-chain pattern="/wms/**" filters="
+           httpHeadFilter,
+           requestQueryFilterAllowAngleBrackets,
+           requestCORSFilter,
+           requestBracketingLogMessageFilter"/>
                 <security:filter-chain pattern="/**" filters="
            httpHeadFilter,
            requestQueryFilter,

--- a/tds/src/main/webapp/WEB-INF/web.xml
+++ b/tds/src/main/webapp/WEB-INF/web.xml
@@ -76,16 +76,6 @@
     <url-pattern>/wms/*</url-pattern>
   </servlet-mapping>
 
-  <filter>
-    <filter-name>RequestQueryFilter</filter-name>
-    <filter-class>thredds.servlet.filter.RequestQueryFilter</filter-class>
-  </filter>
-
-  <filter-mapping>
-    <filter-name>RequestQueryFilter</filter-name>
-    <servlet-name>wms</servlet-name>
-  </filter-mapping>
-
   <!-- end edal-wms servlet -->
 
   <!-- edal-wms screenshot servlet -->
@@ -101,6 +91,10 @@
     <url-pattern>/screenshots/*</url-pattern>
   </servlet-mapping>
 
+  <filter>
+    <filter-name>RequestQueryFilter</filter-name>
+    <filter-class>thredds.servlet.filter.RequestQueryFilter</filter-class>
+  </filter>
 
   <filter-mapping>
     <filter-name>RequestQueryFilter</filter-name>


### PR DESCRIPTION
Update TDS WMS configuration so that TDS request filters don't block `GetLegendGraphic` requests that use the `SLD` or `SLD_BODY` parameters. Switch filter used in Spring config to allow angle brackets ('<' and '>') in query string and remove duplicate filter from `web.xml`. 

(This PR also updates the edal-wms dependency to 1.4.2, from SNAPSHOT.)