### PR TITLE
Ignore dap4 tests when running from netcdf-java ci

### DIFF
--- a/gradle/any/testing.gradle
+++ b/gradle/any/testing.gradle
@@ -37,5 +37,9 @@ tasks.withType(Test).all {
         if (!isRdaDataAvailable) {
             excludeCategories 'ucar.unidata.util.test.category.NeedsRdaData'
         }
+
+        if (skipDap4) {
+            exclude 'dap4/test/**'
+        }
     }
 }

--- a/gradle/root/testing.gradle
+++ b/gradle/root/testing.gradle
@@ -42,6 +42,17 @@ ext {
     }
     
     isRdaDataAvailable = false  // figure out how to set later
+
+    // for now, ignore dap4 tests when checking against netcdf-java pull requests
+    skipDap4 = false
+    ciWorkspace = System.getenv('GITHUB_WORKSPACE')
+    if (ciWorkspace != null) {
+        ciWorkspace = ciWorkspace.replace('/', '')
+        skipDap4 = ciWorkspace != null && ciWorkspace.endsWith('netcdf-java')
+    }
+    if (skipDap4) {
+        logger.warn "Skipping dap4 tests when running against netCDF-Java PRs."
+    }
 }
 
 import java.nio.file.*


### PR DESCRIPTION
For now, ignore dap4 tests when running the tds check from the
netCDF-Java GitHub Action.