### PR TITLE
TDS doc fixes

### DIFF
--- a/docs/src/private/website/netcdf-java/reference/DatasetUrls.adoc
+++ b/docs/src/private/website/netcdf-java/reference/DatasetUrls.adoc
@@ -111,7 +111,7 @@ NetcdfDataset can open *_THREDDS Resolver_* datasets, which have the form
 
 The *_resolverURL_* must return a catalog with a single top level dataset, which is the target dataset. For example:
 
-* _thredds:resolve:http://thredds.ucar.edu:8080/thredds/catalog/model/NCEP/NAM/CONUS_12km/latest.xml_
+* _thredds:resolve:https://thredds.ucar.edu:8080/thredds/catalog/model/NCEP/NAM/CONUS_12km/latest.xml_
 
 In this case, _\http://motherlode.ucar.edu:8080/thredds/catalog/model/NCEP/NAM/CONUS_12km/latest.xml_
 returns a catalog contining the latest dataset in the *NCEP/NAM/CONUS_12km* collection.

--- a/docs/src/private/website/netcdf-java/reference/stream/CdmrFeaturePoint.adoc
+++ b/docs/src/private/website/netcdf-java/reference/stream/CdmrFeaturePoint.adoc
@@ -164,7 +164,7 @@ The protobuf messages are defined by
 
 === Current notes on motherlode dev
 
-* List of cdm datasets: http://thredds.ucar.edu/thredds/idd/newPointObs.html
+* List of cdm datasets: https://thredds.ucar.edu/thredds/idd/newPointObs.html
 
 ==== Nov-11-2010
 

--- a/docs/src/private/website/tds/README.adoc
+++ b/docs/src/private/website/tds/README.adoc
@@ -33,7 +33,7 @@ access method extending the HTTP protocol.
 5.  An integrated server provides bulk file access through the HTTP
 protocol.
 6.  An integrated server provides data access through the
-http://www.opengeospatial.org/standards/wcs[OpenGIS Consortium (OGC) Web
+https://www.ogc.org/standards/wcs[OpenGIS Consortium (OGC) Web
 Coverage Service (WCS]) protocol, for any ``gridded'' dataset whose
 coordinate system information is complete.
 7.  An integrated server provides data access through the
@@ -74,7 +74,7 @@ only.
 Much of the realtime data available over the Unidata
 https://www.unidata.ucar.edu/software/idd/index.html[Internet Data
 Distribution] (IDD) is available through a THREDDS Data Server hosted at
-Unidata on http://thredds.ucar.edu/thredds/[thredds.ucar.edu]. You are
+Unidata on https://thredds.ucar.edu/thredds/[thredds.ucar.edu]. You are
 welcome to browse and access these meteorological datasets. If you need
 regular access to large amounts of data, please contact
 support-idd@unidata.ucar.edu.

--- a/docs/src/private/website/tds/TDS.adoc
+++ b/docs/src/private/website/tds/TDS.adoc
@@ -30,7 +30,7 @@ access to any CDM dataset. OPeNDAP is a widely used, subsetting data
 access method extending the HTTP protocol.
 .  An integrated server provides bulk file access through the HTTP protocol.
 .  An integrated server provides data access through the
-http://www.opengeospatial.org/standards/wcs[OpenGIS Consortium (OGC) Web
+https://www.ogc.org/standards/wcs[OpenGIS Consortium (OGC) Web
 Coverage Service (WCS]) protocol, for any _gridded_ dataset whose
 coordinate system information is complete.
 .  An optional server provides data access through the
@@ -65,7 +65,7 @@ library https://www.unidata.ucar.edu/software/netcdf/copyright.html[license].
 Much of the realtime data available over the Unidata
 https://www.unidata.ucar.edu/software/idd/index.html[Internet Data
 Distribution] (IDD) is available through a THREDDS Data Server hosted at
-Unidata on http://thredds.ucar.edu/thredds/[thredds.ucar.edu]. You are
+Unidata on https://thredds.ucar.edu/thredds/[thredds.ucar.edu]. You are
 welcome to browse and access these meteorological datasets. If you need
 regular access to large amounts of data, please contact
 support-idd@unidata.ucar.edu.

--- a/docs/src/private/website/tds/reference/services/StandardServices.adoc
+++ b/docs/src/private/website/tds/reference/services/StandardServices.adoc
@@ -381,7 +381,7 @@ Service Base URL
 OGC WCS supports access to geospatial data as ``coverages''.
 
 * More details about the OGC WCS are available
-http://www.opengeospatial.org/standards/wcs[here].
+https://www.ogc.org/standards/wcs[here].
 * Enable OGC WCS and set other configuration options with the TDS
 Configuration File
 (<<ThreddsConfigXMLFile.adoc#wcs,threddsConfig.xml>>). More setup,

--- a/docs/src/private/website/tds/reference/services/WCS.adoc
+++ b/docs/src/private/website/tds/reference/services/WCS.adoc
@@ -6,7 +6,7 @@
 
 The THREDDS WCS Server implements the
 http://www.opengeospatial.org/[OGC] Web Coverage Service
-(http://www.opengeospatial.org/standards/wcs[WCS]) 1.0.0
+(https://www.ogc.org/standards/wcs[WCS]) 1.0.0
 http://www.opengeospatial.org/docs/03-065r6.pdf[specification]. It
 serves gridded data in http://trac.osgeo.org/geotiff/[GeoTIFF] or NetCDF
 format allowing WCS clients to specify a subset of a gridded dataset and

--- a/docs/src/public/userguide/_config.yml
+++ b/docs/src/public/userguide/_config.yml
@@ -14,6 +14,9 @@ site_topic: THREDDS Data Server
 company_name: Unidata
 # this appears in the footer
 
+netcdf-java_docset_version: 5.4
+# this will appear in the sidebar and doc pages
+
 github_editme_path: 
 
 #github_editme_path: tomjohnson1492/documentation-theme-jekyll/blob/gh-pages/pages/

--- a/docs/src/public/userguide/_includes/footer.html
+++ b/docs/src/public/userguide/_includes/footer.html
@@ -3,7 +3,7 @@
     <div class="col-sm-3">
       <div class="triptych-left">
         <div class="footer-logos">
-          <a class="noicon" href="https://unidata.ucar.edu/software/tds/"> <img alt="TDS" src="images/thredds_tds-32x32.png"/></a>
+          <a class="noicon" href="https://www.unidata.ucar.edu/software/tds/"> <img alt="TDS" src="images/thredds_tds-32x32.png"/></a>
         </div>
         <p class="triptych-header">{{site.site_topic}}</p>
         <ul>
@@ -25,12 +25,12 @@
           <a class="noicon" href="https://www.nsf.gov/"> <img alt="NSF" src="images/nsf_logo_transparent.png"/></a>
         </div>
         <div class="footer-logos" style="padding-right: 1em;">
-          <a class="noicon" href="https://www.ucp.ucar.edu"> <img alt="UCP" src="images/ucp-logo2_transparent.png"/></a>
+          <a class="noicon" href="https://www.ucar.edu/community-programs"> <img alt="UCP" src="images/ucp-logo2_transparent.png"/></a>
         </div>
         <p class="triptych-header">Unidata</p>
           <p class="triptych-center">
             Unidata is a member of the
-            <a href="https://www.ucp.ucar.edu/">UCAR Community Programs</a>, managed by the
+            <a href="https://www.ucar.edu/community-programs/">UCAR Community Programs</a>, managed by the
             <a href="https://www.ucar.edu">University Corporation for Atmospheric Research</a>, and funded by the
             <a href="https://www.nsf.gov">National Science Foundation</a>.
           </p>
@@ -42,10 +42,10 @@
               <tr>
                 <td style="width:33%;text-align:left;">&copy;{{ site.time | date: "%Y" }} UCAR</td>
                 <td style="width:33%;text-align:center;">
-                  <a href="https://www2.ucar.edu/privacy-policy">Privacy Policy</a>
+                  <a href="https://www.ucar.edu/privacy-notice">Privacy Policy</a>
                 </td>
                 <td style="width:33%;text-align:right;">
-                  <a href="https://www2.ucar.edu/terms-of-use">Terms of Use</a>
+                  <a href="https://www.ucar.edu/terms-of-use">Terms of Use</a>
                 </td>
               </tr>
             </table>
@@ -55,7 +55,7 @@
     <div class="col-sm-3">
       <div class="triptych-right">
         <div class="footer-logos">
-          <a class="noicon" href="https://unidata.ucar.edu/"> <img alt="TDS" src="images/unilogo-32x32.png"/></a>
+          <a class="noicon" href="https://www.unidata.ucar.edu/"> <img alt="TDS" src="images/unilogo-32x32.png"/></a>
         </div>
         <p class="triptych-header">Contact Unidata</p>
         <ul>

--- a/docs/src/public/userguide/_includes/sidebar.html
+++ b/docs/src/public/userguide/_includes/sidebar.html
@@ -1,4 +1,6 @@
 {% include custom/sidebarconfigs.html %}
+{% capture netcdf-java_doc_version %}{{ "/netcdf-java/" | append: site.netcdf-java_docset_version }}{% endcapture %}
+{% capture netcdf-java_doc_replace %}{{ netcdf-java_doc_version | append: "/"}}{% endcapture %}
 
 <ul id="mysidebar" class="nav">
     <li class="sidebarTitle">{{sidebar[0].product}} {{sidebar[0].version}}</li>
@@ -11,7 +13,8 @@
             {% for folderitem in folder.folderitems %}
             {% if folderitem.output contains "web" %}
             {% if folderitem.external_url %}
-            <li><a href="{{folderitem.external_url}}" target="_blank">{{folderitem.title}}</a></li>
+
+            <li><a href="{{folderitem.external_url | replace: "/netcdf-java/current/", netcdf-java_doc_replace  }}" target="_blank">{{folderitem.title}}</a></li>
             {% elsif page.url == folderitem.url %}
             <li class="active"><a href="{{folderitem.url | remove: "/"}}">{{folderitem.title}}</a></li>
             {% else %}
@@ -25,7 +28,7 @@
                     {% for subfolderitem in subfolders.subfolderitems %}
                     {% if subfolderitem.output contains "web" %}
                     {% if subfolderitem.external_url %}
-                    <li><a href="{{subfolderitem.external_url}}" target="_blank">{{subfolderitem.title}}</a></li>
+                    <li><a href="{{subfolderitem.external_url | replace: "/netcdf-java/current/", netcdf-java_doc_replace  }}" target="_blank">{{subfolderitem.title}}</a></li>
                     {% elsif page.url == subfolderitem.url %}
                     <li class="active"><a href="{{subfolderitem.url | remove: "/"}}">{{subfolderitem.title}}</a></li>
                     {% else %}

--- a/docs/src/public/userguide/index.md
+++ b/docs/src/public/userguide/index.md
@@ -25,7 +25,7 @@ Some of the technology in the TDS:
 * An integrated server provides [OPeNDAP](http://www.opendap.org/){:target="_blank"} access to any CDM dataset.
   OPeNDAP is a widely used, subsetting data access method extending the HTTP protocol.
 * An integrated server provides bulk file access through the HTTP protocol.
-* An integrated server provides data access through the [OpenGIS Consortium (OGC) Web Coverage Service (WCS)](http://www.opengeospatial.org/standards/wcs){:target="_blank"} protocol, for any gridded dataset whose coordinate system information is complete.
+* An integrated server provides data access through the [OpenGIS Consortium (OGC) Web Coverage Service (WCS)](https://www.ogc.org/standards/wcs){:target="_blank"} protocol, for any gridded dataset whose coordinate system information is complete.
 * An integrated server provides data access through the [OpenGIS Consortium (OGC) Web Map Service (WMS)](http://www.opengeospatial.org/standards/wms){:target="_blank"} protocol, for any gridded dataset whose coordinate system information is complete.
   This software was developed by Jon Blower (University of Reading (UK) E-Science Center) as part of the [ESSC Web Map Service for environmental data](https://github.com/Reading-eScience-Centre/edal-java){:target="_blank"} (aka Godiva3).
 * The integrated [ncISO server](iso_metadata.html) provides automated metadata analysis and ISO metadata generation.
@@ -40,7 +40,7 @@ Configuration is made as simple and as automatic as possible, and we have made t
 
 \* Writing to netCDF-4 files is supported through the netCDF C library only.
 
-Much of the realtime data available over the Unidata Internet Data Distribution (IDD) is available through a demonstration THREDDS Data Server hosted at Unidata at [http://thredds.ucar.edu/](http://thredds.ucar.edu/thredds/catalog.html){:target="_blank"}.
+Much of the realtime data available over the Unidata Internet Data Distribution (IDD) is available through a demonstration THREDDS Data Server hosted at Unidata at [https://thredds.ucar.edu/](https://thredds.ucar.edu/thredds/catalog.html){:target="_blank"}.
 You are welcome to browse and access these meteorological datasets.
 If you need regular access to large amounts of data, please contact <support-idd@unidata.ucar.edu>.
 

--- a/docs/src/public/userguide/pages/tds_tutorial/client_catalogs/CatalogReferences.md
+++ b/docs/src/public/userguide/pages/tds_tutorial/client_catalogs/CatalogReferences.md
@@ -33,11 +33,11 @@ One way to do this is to build each piece as a separate and logically-complete c
    The `xlink:href` attributes are [relative URLs](https://www.w3.org/TR/WD-html40-970917/htmlweb.html#h-5.1.2){:target="_blank"} and are resolved against the catalog URL. 
    For example, if the URL of the client catalog, as shown above, is:
 
-   <http://thredds.ucar.edu/thredds/catalog.xml>{:target="_blank"}
+   <https://thredds.ucar.edu/thredds/catalog.xml>{:target="_blank"}
 
    then the resolved URL of the first `catalogRef` will be:
 
-   <http://thredds.ucar.edu/thredds/idd/forecastModels.xml>{:target="_blank"}
+   <https://thredds.ucar.edu/thredds/idd/forecastModels.xml>{:target="_blank"}
 
 4. `catalogRefs` needn't point to local catalogs only; this one points to a remote one at Far Away University.
    * The `metadata` elements with `inherited="true"` are NOT not copied across `catalogRefs`.

--- a/docs/src/public/userguide/pages/tds_tutorial/client_catalogs/ToolsUi.md
+++ b/docs/src/public/userguide/pages/tds_tutorial/client_catalogs/ToolsUi.md
@@ -7,7 +7,7 @@ permalink: client_catalog_via_toolsUI.html
 ---
 
 The NetCDF Tools User Interface (a.k.a. ToolsUI) can read and display THREDDS catalogs.
-You can start it [from the command line](https://docs.unidata.ucar.edu/netcdf-java/current/userguide/toolsui_ref.html){:target="_blank"}.
+You can start it [from the command line](https://docs.unidata.ucar.edu/netcdf-java/{{site.netcdf-java_docset_version}}/userguide/toolsui_ref.html){:target="_blank"}.
 
 Use the THREDDS Tab, and click on the ![fileOpen](images/tds/tutorial/client_catalogs/fileIcon.jpg){:height="12px" width="12px"} button to navigate to a local catalog file, or enter in the URL of a remote catalog, as below (_note that this is an XML document, not an HTML page!_).
 The catalog will be displayed in a tree widget on the left, and the selected dataset will be shown on the right:

--- a/docs/src/public/userguide/pages/tds_tutorial/client_catalogs/XmlValidation.md
+++ b/docs/src/public/userguide/pages/tds_tutorial/client_catalogs/XmlValidation.md
@@ -30,7 +30,7 @@ If you also want to check _validity_ in those tools, you will need to declare th
 * The `xsi:schemaLocation` attribute tells your XML validation tool where to find the THREDDS XML schema document.
   Just copy it exactly as you see them here.
 
-Or, you can simply use the [THREDDS Catalog Validation service](http://thredds.ucar.edu/thredds/remoteCatalogValidation.html){:target="_blank"} to check all three components at once.
+Or, you can simply use the [THREDDS Catalog Validation service](https://thredds.ucar.edu/thredds/remoteCatalogValidation.html){:target="_blank"} to check all three components at once.
 This service already knows where the schemas are located, so it's not necessary to add that information to the catalog; you only need it if you want to do your own validation.
 
 {%include note.html content="

--- a/docs/src/public/userguide/pages/tds_tutorial/faq/faq.md
+++ b/docs/src/public/userguide/pages/tds_tutorial/faq/faq.md
@@ -204,7 +204,7 @@ Add the following to `JAVA_OPTS` in the `${tomcat_home}/bin/setenv.sh` file:
 If you are interested in more details of the problem, here are two useful links:
 
 Sun bug [#4751177](http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=4751177){:target="_blank"} ("Preferences storage placed unavailable to non-root users")
-[Disabling Sun's Java 1.4.x Preferences Subsystem](http://allaboutbalance.com/articles/disableprefs/){:target="_blank"}
+[Disabling Sun's Java 1.4.x Preferences Subsystem](https://web.archive.org/web/20170305180118/http://allaboutbalance.com/articles/disableprefs/){:target="_blank"}
 
 We have this TDS issue in our bug tracking system and plan to address it.
 
@@ -398,10 +398,10 @@ Lots of redeploys only happen on our test server.
 
 Resources:
 
-["Classloader leaks"](http://frankkieviet.blogspot.com/2006/10/classloader-leaks-dreaded-permgen-space.html){:target="_blank"} (Frank Kieviet's Engineering Notebook) (2016-02-26)
-["Return of the PermGen"](https://web.archive.org/web/20130522112026/http://my.opera.com/karmazilla/blog/2007/09/29/return-of-the-permgen){:target="_blank"} (2007-09-29)
-["PermGen Strikes Back"](https://web.archive.org/web/20130315110359/http://my.opera.com/karmazilla/blog/2007/03/15/permgen-strikes-back){:target="_blank"} (2007-03-15)
-["Good Riddance PermGen OutOfMemoryError"](https://web.archive.org/web/20130318215355/http://my.opera.com/karmazilla/blog/2007/03/13/good-riddance-permgen-outofmemoryerror){:target="_blank"} (2007-03-13)
+* ["Classloader leaks"](http://frankkieviet.blogspot.com/2006/10/classloader-leaks-dreaded-permgen-space.html){:target="_blank"} (Frank Kieviet's Engineering Notebook) (2016-02-26)
+* ["Return of the PermGen"](https://web.archive.org/web/20130522112026/http://my.opera.com/karmazilla/blog/2007/09/29/return-of-the-permgen){:target="_blank"} (2007-09-29)
+* ["PermGen Strikes Back"](https://web.archive.org/web/20130315110359/http://my.opera.com/karmazilla/blog/2007/03/15/permgen-strikes-back){:target="_blank"} (2007-03-15)
+* ["Good Riddance PermGen OutOfMemoryError"](https://web.archive.org/web/20130318215355/http://my.opera.com/karmazilla/blog/2007/03/13/good-riddance-permgen-outofmemoryerror){:target="_blank"} (2007-03-13)
 
 ### During shutdown I'm getting messages about threads (ThreadLocal) having to be shut down to prevent memory leaks. Whats up?
 

--- a/docs/src/public/userguide/pages/tds_tutorial/faq/faq.md
+++ b/docs/src/public/userguide/pages/tds_tutorial/faq/faq.md
@@ -399,20 +399,19 @@ Lots of redeploys only happen on our test server.
 Resources:
 
 ["Classloader leaks"](http://frankkieviet.blogspot.com/2006/10/classloader-leaks-dreaded-permgen-space.html){:target="_blank"} (Frank Kieviet's Engineering Notebook) (2016-02-26)
-["Return of the PermGen"](http://my.opera.com/karmazilla/blog/2007/09/29/return-of-the-permgen){:target="_blank"} (2007-09-29)
-["PermGen Strikes Back"](http://my.opera.com/karmazilla/blog/2007/03/15/permgen-strikes-back){:target="_blank"} (2007-03-15)
-["Good Riddance PermGen OutOfMemoryError"](http://my.opera.com/karmazilla/blog/2007/03/13/good-riddance-permgen-outofmemoryerror){:target="_blank"} (2007-03-13)
+["Return of the PermGen"](https://web.archive.org/web/20130522112026/http://my.opera.com/karmazilla/blog/2007/09/29/return-of-the-permgen){:target="_blank"} (2007-09-29)
+["PermGen Strikes Back"](https://web.archive.org/web/20130315110359/http://my.opera.com/karmazilla/blog/2007/03/15/permgen-strikes-back){:target="_blank"} (2007-03-15)
+["Good Riddance PermGen OutOfMemoryError"](https://web.archive.org/web/20130318215355/http://my.opera.com/karmazilla/blog/2007/03/13/good-riddance-permgen-outofmemoryerror){:target="_blank"} (2007-03-13)
 
 ### During shutdown I'm getting messages about threads (ThreadLocal) having to be shut down to prevent memory leaks. Whats up?
 
 Tomcat memory leak detection code started logging these messages as of Tomcat 6.0.24.
-From various posts (see Spring Forum: ["ThreadLocal forcefully removed"](http://forum.springsource.org/showpost.php?p=282738&postcount=3){:target="_blank"} comment #3) it appears that these messages are not a problem but instead a matter of Tomcat finding these objects before they get garbage collected.
+It appears that these messages are not a problem but instead a matter of Tomcat finding these objects before they get garbage collected.
 
 Here are a number of related links:
 
-* Spring Forum: ["ThreadLocal forcefully removed"](http://forum.springsource.org/showthread.php?p=282738#post282738){:target="_blank"}. Comment #3 provides an answer to the post.
-* [Tomcat Memory Leak Prevention](http://wiki.apache.org/tomcat/MemoryLeakProtection){:target="_blank"} page (in particular, see the ["Custom ThreadLocal"](http://wiki.apache.org/tomcat/MemoryLeakProtection#customThreadLocal){:target="_blank"} section)
-* A Tomcat 7 issue on ["Improving ThreadLocal memory leak clean-up"](https://issues.apache.org/bugzilla/show_bug.cgi?id=%2049159){:target="_blank"}
+* [Tomcat Memory Leak Prevention](https://cwiki.apache.org/confluence/display/tomcat/MemoryLeakProtection){:target="_blank"} page (in particular, see the ["Custom ThreadLocal"](https://cwiki.apache.org/confluence/display/tomcat/MemoryLeakProtection#customThreadLocal){:target="_blank"} section)
+* A Tomcat 7 issue on ["Improving ThreadLocal memory leak clean-up"](https://bz.apache.org/bugzilla/show_bug.cgi?id=%2049159){:target="_blank"}
 
 NOTE: We will monitor the status of this Tomcat issue.
 For now, we do not consider this a TDS bug and will not be working to fix this issue in TDS.

--- a/docs/src/public/userguide/pages/tds_tutorial/feature_collections/FmrcTutorial.md
+++ b/docs/src/public/userguide/pages/tds_tutorial/feature_collections/FmrcTutorial.md
@@ -6,8 +6,8 @@ toc: false
 permalink: fmrc_tutorial.html
 ---
 
-The `featureCollection` element is a way to tell the TDS to serve collections of [CDM Feature Datasets](https://docs.unidata.ucar.edu/netcdf-java/current/userguide/feature_datasets.html){:target="_blank"}.
-Currently this is used mostly for [gridded data](https://docs.unidata.ucar.edu/netcdf-java/current/userguide/grid_datasets.html){:target="_blank"} whose time and spatial coordinates are recognized by the CDM software stack.
+The `featureCollection` element is a way to tell the TDS to serve collections of [CDM Feature Datasets](https://docs.unidata.ucar.edu/netcdf-java/{{site.netcdf-java_docset_version}}/userguide/feature_datasets.html){:target="_blank"}.
+Currently this is used mostly for [gridded data](https://docs.unidata.ucar.edu/netcdf-java/{{site.netcdf-java_docset_version}}/userguide/grid_datasets.html){:target="_blank"} whose time and spatial coordinates are recognized by the CDM software stack.
 This allows the TDS to automatically create logical datasets composed of collections of files, particularly gridded model data output, called **Forecast Model Run Collections (FMRC)**.
 
 A Forecast Model Run Collection is a collection of forecast model output.

--- a/docs/src/public/userguide/pages/tds_tutorial/feature_collections/GribFeatureCollections.md
+++ b/docs/src/public/userguide/pages/tds_tutorial/feature_collections/GribFeatureCollections.md
@@ -8,8 +8,8 @@ permalink: grib_feature_collections.html
 
 ## GRIB Feature Collection
 
-The featureCollection element is a way to tell the TDS to serve collections of [CDM Feature Datasets](https://docs.unidata.ucar.edu/netcdf-java/current/userguide/feature_datasets.html){:target="_blank"}.
-Currently this is used mostly for [gridded data](https://docs.unidata.ucar.edu/netcdf-java/current/userguide/grid_datasets.html){:target="_blank"} whose time and spatial coordinates are recognized by the CDM software stack.
+The featureCollection element is a way to tell the TDS to serve collections of [CDM Feature Datasets](https://docs.unidata.ucar.edu/netcdf-java/{{site.netcdf-java_docset_version}}/userguide/feature_datasets.html){:target="_blank"}.
+Currently this is used mostly for [gridded data](https://docs.unidata.ucar.edu/netcdf-java/{{site.netcdf-java_docset_version}}/userguide/grid_datasets.html){:target="_blank"} whose time and spatial coordinates are recognized by the CDM software stack.
 In this tutorial, we will work with featureCollection for collections of GRIB files.
 
 ## Creating a GRIB Feature Collection

--- a/docs/src/public/userguide/pages/tds_tutorial/getting_started/InstallJavaTomcat.md
+++ b/docs/src/public/userguide/pages/tds_tutorial/getting_started/InstallJavaTomcat.md
@@ -134,7 +134,7 @@ Adding symbolic links for both the Tomcat and the JDK installations will allow f
 The following example shows creating symbolic links for the Tomcat and JDK installation on a linux system. (This type of installation will work on Mac OS systems as well.) The installation is being performed as the `root` user.
 
 {%include note.html content="
-Windows users can consult the [Microsoft Documentation](https://docs.microsoft.com/en-us/windows/desktop/fileio/symbolic-links){:target='_blank'} for creating symbolic links on Windows systems.
+Windows users can consult the [Microsoft Documentation](https://docs.microsoft.com/en-us/windows/win32/fileio/symbolic-links){:target='_blank'} for creating symbolic links on Windows systems.
 " %}
 
 1. Create symbolic links for the Tomcat and the JDK installations:

--- a/docs/src/public/userguide/pages/tds_tutorial/getting_started/TomcatLogFiles.md
+++ b/docs/src/public/userguide/pages/tds_tutorial/getting_started/TomcatLogFiles.md
@@ -59,7 +59,7 @@ Is it only errors messages being reported to `catalina.out`?
 ## Things To Know About `catalina.out`
 
 {% include note.html content="
-The [Tomcat Users mailing list](http://marc.info/?l=tomcat-user&w=2&r=1&s=catalina.out+rotate&q=b){:target='_blank'} has seen a lot of traffic dedicated to `catalina.out` logging and rotation.
+The [Tomcat Users mailing list](https://marc.info/?l=tomcat-user&m=149200281514600&w=2){:target='_blank'} has seen a lot of traffic dedicated to `catalina.out` logging and rotation.
 " %}
 
 * Tomcat `System.out` and `System.err` gets appended to `catalina.out`. `catalina.out` can **quickly grow large** if the hosted web applications are not specifically catching and logging `System.out` and `System.err` to designated files.

--- a/docs/src/public/userguide/pages/tds_tutorial/production/KeepSoftwareUpToDate.md
+++ b/docs/src/public/userguide/pages/tds_tutorial/production/KeepSoftwareUpToDate.md
@@ -27,7 +27,7 @@ It is important that you upgrade your software before an attacker uses the vulne
 * [Tomcat mailing lists](https://tomcat.apache.org/lists.html){:target="_blank"}
   Various tomcat-related mailing lists, including Tomcat-announce which is a low volume list for release announcements and security vulnerabilities.
 
-* [Java SE Security](https://www.oracle.com/technetwork/java/javase/tech/index-jsp-136007.html){:target="_blank"}
+* [Java SE Security](https://www.oracle.com/java/technologies/javase/javase-tech-security.html){:target="_blank"}
   Oracle’s Java security page which includes a chronology of Java security issues and user forums.
 
 * [thredds mailing list](https://www.unidata.ucar.edu/mailing_lists/archives/thredds/){:target="_blank"}

--- a/docs/src/public/userguide/pages/tds_tutorial/production/PerformanceTips.md
+++ b/docs/src/public/userguide/pages/tds_tutorial/production/PerformanceTips.md
@@ -82,7 +82,7 @@ See the Tomcat HTTP Connector [reference page](https://tomcat.apache.org/tomcat-
 ### Automatic Startup
 
 In a production environment, Tomcat should be automatically restarted when the machine starts.
-How to do this depends on what OS you are running. This [FAQ](https://wiki.apache.org/tomcat/HowTo){:target="_blank"} has a bit of info.
+How to do this depends on what OS you are running. This [FAQ](https://cwiki.apache.org/confluence/display/tomcat/HowTo#HowTo-HowdoIinstallTomcatasaserviceunderUnix?){:target="_blank"} has a bit of info.
 
 ### Miscellaneous
 

--- a/docs/src/public/userguide/pages/tds_tutorial/tds_configuration/AddingOgcIsoServices.md
+++ b/docs/src/public/userguide/pages/tds_tutorial/tds_configuration/AddingOgcIsoServices.md
@@ -228,8 +228,8 @@ ncWMS provides several styling and displaying capabilities that are also availab
 * [IDV](https://www.unidata.ucar.edu/software/idv/){:target="_blank"} (WMS) [free]
 * [ToolsUI](https://www.unidata.ucar.edu/downloads/netcdf-java/){:target="_blank"} (WMS) [free]
 * [OWSlib](http://geopython.github.io/OWSLib/){:target="_blank"} (WMS and WCS) [free]
-* [Map Express](https://www.cadcorp.com/products/free-mapping-software/){:target="_blank"} (`WMS` and `WCS`) [commercial / free]
-* [IDL](http://www.harrisgeospatial.com/ProductsandSolutions/GeospatialProducts/IDL.aspx){:target="_blank"} (WMS) [commercial]
+* [Map Express](https://www.cadcorp.com/products/desktop/cadcorp-sis-desktop-express/){:target="_blank"} (`WMS` and `WCS`) [commercial / free]
+* [IDL](https://www.harrisgeospatial.com/Software-Technology/IDL){:target="_blank"} (WMS) [commercial]
 * [gvSIG](http://www.gvsig.org/web/){:target="_blank"} (WMS and WCS) [free]
 
 #### Godiva2 `WMS` Client

--- a/docs/src/public/userguide/pages/tds_tutorial/tds_configuration/ThreddsDataServerConfiguration.md
+++ b/docs/src/public/userguide/pages/tds_tutorial/tds_configuration/ThreddsDataServerConfiguration.md
@@ -51,15 +51,15 @@ Here is what the default version of the serverInformation element looks like:
 The headers and footers of all TDS generated catalog HTML pages. Examples:
 
 * <http://localhost:8080/thredds/catalog.html>{:target="_blank"}
-* <http://thredds.ucar.edu/thredds/catalog.html>{:target="_blank"}
+* <https://thredds.ucar.edu/thredds/catalog.html>{:target="_blank"}
 
 Server element of the WMS GetCapabilities document:
- * <http://thredds.ucar.edu/thredds/wms/grib/NCEP/GFS/Pacific_40km/best?service=WMS&version=1.3.0&request=GetCapabilities>{:target="_blank"}
+ * <https://thredds.ucar.edu/thredds/wms/grib/NCEP/GFS/Pacific_40km/best?service=WMS&version=1.3.0&request=GetCapabilities>{:target="_blank"}
 
 The three supported server information documents:
- * An HTML document: <http://thredds.ucar.edu/thredds/serverInfo.html>{:target="_blank"}
- * An XML document: <http://thredds.ucar.edu/thredds/serverInfo.xml>{:target="_blank"}
- * A version only text document: <http://thredds.ucar.edu/thredds/serverVersion.txt>{:target="_blank"}
+ * An HTML document: <https://thredds.ucar.edu/thredds/serverInfo.html>{:target="_blank"}
+ * An XML document: <https://thredds.ucar.edu/thredds/serverInfo.xml>{:target="_blank"}
+ * A version only text document: <https://thredds.ucar.edu/thredds/serverVersion.txt>{:target="_blank"}
 
 Other Places the Server Information Will be Included
 

--- a/docs/src/public/userguide/pages/thredds/FeatureCollectionsRef.md
+++ b/docs/src/public/userguide/pages/thredds/FeatureCollectionsRef.md
@@ -8,7 +8,7 @@ permalink: feature_collections_ref.html
 
 ## Overview
 
-The `featureCollection` element is a way to tell the TDS to serve collections of [CDM Feature Datasets](https://docs.unidata.ucar.edu/netcdf-java/current/userguide/feature_datasets.html){:target="_blank"}.
+The `featureCollection` element is a way to tell the TDS to serve collections of [CDM Feature Datasets](https://docs.unidata.ucar.edu/netcdf-java/{{site.netcdf-java_docset_version}}/userguide/feature_datasets.html){:target="_blank"}.
 Currently this is used for gridded and point datasets whose time and spatial coordinates are recognized by the CDM software stack.
 This allows the TDS to automatically create logical datasets composed of collections of files, and to allow subsetting in coordinate space on them, through the WMS, WCS, Netcdf Subset, and CDM Remote Feature services.
 
@@ -39,7 +39,7 @@ Specific topics covered here are:
 For Feature Type specific information, see:
 
 * [FMRC Collections](fmrc_ref.html)
-* [Point Collections](https://docs.unidata.ucar.edu/netcdf-java/current/userguide/pointfeature_ref.html){:target="_blank"}
+* [Point Collections](https://docs.unidata.ucar.edu/netcdf-java/{{site.netcdf-java_docset_version}}/userguide/pointfeature_ref.html){:target="_blank"}
 * [GRIB Collections](grib_feature_collections_ref.html)
 * [GRIB specific configuration](grib_collection_config_ref.html)
 * [GRIB Collection FAQs](grib_collection_config_ref.html)

--- a/docs/src/public/userguide/pages/thredds/GribConfigRef.md
+++ b/docs/src/public/userguide/pages/thredds/GribConfigRef.md
@@ -27,7 +27,7 @@ Changes to these settings may happen at any time, without having to recreate the
 They will take affect the next time the TDS starts.
 
 These instructions are tailored for TDS users.
-To work with Grib Collections in client software using the CDM stack, see [CDM Grib Files](https://docs.unidata.ucar.edu/netcdf-java/current/userguide/grib_files_cdm.html){:target="_blank"}.
+To work with Grib Collections in client software using the CDM stack, see [CDM Grib Files](https://docs.unidata.ucar.edu/netcdf-java/{{site.netcdf-java_docset_version}}/userguide/grib_files_cdm.html){:target="_blank"}.
 
 ## Stage One: GribCollection Creation
 
@@ -224,7 +224,7 @@ Here are examples using NcML:
 
 Note that GRIB-1 uses IDs of `center-subcenter-version-param`, e.g. `7-4-2-132`, while GRIB-2 uses IDs of `discipline-category-number`, e.g. `0-1-8`.
 
-Also see [CDM GRIB](https://docs.unidata.ucar.edu/netcdf-java/current/userguide/grib_files_cdm.html){:target="_blank"} docs.
+Also see [CDM GRIB](https://docs.unidata.ucar.edu/netcdf-java/{{site.netcdf-java_docset_version}}/userguide/grib_files_cdm.html){:target="_blank"} docs.
 
 #### option: set miscellaneous values
 

--- a/docs/src/public/userguide/pages/thredds/GribFeatureCollectionsRef.md
+++ b/docs/src/public/userguide/pages/thredds/GribFeatureCollectionsRef.md
@@ -23,8 +23,8 @@ Also see:
 * [GRIB Collection FAQ](tds_grib_faq.html)
 * [GRIB Feature Collection Tutorial](grib_feature_collections.html)
 * [Partitions](partitions_ref.html)
-* [CDM GRIB Collection Processing](https://docs.unidata.ucar.edu/netcdf-java/current/userguide/grib_files_cdm.html){:target="_blank"}
-* [CDM GRIB Tables](https://docs.unidata.ucar.edu/netcdf-java/current/userguide/grib_tables.html){:target="_blank"}
+* [CDM GRIB Collection Processing](https://docs.unidata.ucar.edu/netcdf-java/{{site.netcdf-java_docset_version}}/userguide/grib_files_cdm.html){:target="_blank"}
+* [CDM GRIB Tables](https://docs.unidata.ucar.edu/netcdf-java/{{site.netcdf-java_docset_version}}/userguide/grib_tables.html){:target="_blank"}
 
 ### Multiple Dataset Collections
 

--- a/docs/src/public/userguide/pages/thredds/PointFeatures.md
+++ b/docs/src/public/userguide/pages/thredds/PointFeatures.md
@@ -8,7 +8,7 @@ permalink: pointfeature_collection_ref.html
 
 ## Overview
 
-A Point Feature Collection is a collection of files which the CDM can recognize as containing [Point Features](https://docs.unidata.ucar.edu/netcdf-java/current/userguide/pointfeature_ref.html){:target="_blank"}.
+A Point Feature Collection is a collection of files which the CDM can recognize as containing [Point Features](https://docs.unidata.ucar.edu/netcdf-java/{{site.netcdf-java_docset_version}}/userguide/pointfeature_ref.html){:target="_blank"}.
 
 ### Constraints on Point Feature Collections
 

--- a/docs/src/public/userguide/pages/thredds/TdsServices.md
+++ b/docs/src/public/userguide/pages/thredds/TdsServices.md
@@ -451,7 +451,7 @@ You can still define your own services, either globally in the root catalog, or 
   <td>OGC WCS supports access to geospatial data as "coverages".
     <ul>
       <li>More details about the OGC WCS are available
-        <a href="http://www.opengeospatial.org/standards/wcs" target="_blank">here</a>.
+        <a href="https://www.ogc.org/standards/wcs" target="_blank">here</a>.
       </li>
       <li>Enable OGC WCS and set other configuration options with the TDS
         Configuration File
@@ -582,7 +582,7 @@ You can still define your own services, either globally in the root catalog, or 
       <ul>
         <li>The SOS standard is applicable to use cases in which sensor data
           needs to be managed in an interoperable way. For more information,
-          see the <a href="http://www.opengeospatial.org/standards/sos" target="_blank">OGC</a>
+          see the <a href="https://www.ogc.org/standards/sos" target="_blank">OGC</a>
           SOS page, or the ncSOS
           <a href="https://github.com/asascience-open/ncSOS/wiki" target="_blank">wiki</a>,
           maintained by the developers of the ncSOS plugin, Applied Science

--- a/docs/src/public/userguide/pages/thredds/TdsServices.md
+++ b/docs/src/public/userguide/pages/thredds/TdsServices.md
@@ -413,7 +413,7 @@ You can still define your own services, either globally in the root catalog, or 
     FeatureCollection is used.
     <ul>
       <li>More details are available
-        <a href="https://docs.unidata.ucar.edu/netcdf-java/current/userguide/cdmremote.html" target="_blank">here</a>.
+        <a href="https://docs.unidata.ucar.edu/netcdf-java/{{site.netcdf-java_docset_version}}/userguide/cdmremote.html" target="_blank">here</a>.
       </li>
     </ul>
   </td>

--- a/docs/src/public/userguide/pages/thredds/ThreddsConfigRef.md
+++ b/docs/src/public/userguide/pages/thredds/ThreddsConfigRef.md
@@ -89,7 +89,7 @@ Default CSS files are provided, and should not be modified. Instead, these can b
 * <3> The CSS used in TDS Dataset catalogs pages
 * <4> The CSS used in the OPeNDAP form.
 * <5> Google Analytics Tracking Code (GATC) enables tracking catalog use.
-      Obtain the GATC from [Google](http://www.google.com/analytics/){:target="_blank"} and enter it here to enable this feature.
+      Obtain the GATC from [Google](https://marketingplatform.google.com/about/analytics/){:target="_blank"} and enter it here to enable this feature.
 * <6> If set to true, schema.org [`Dataset`](https://schema.org/Dataset){:target="_blank"} objects will be encoded using json-ld and embeded into the `<head>` element of the generated dataset HTML pages.
 
 ### Controlling THREDDS catalog output
@@ -453,7 +453,7 @@ We recommend that you use the default settings, by not specifying this option.
 ~~~
 
 * `dir`: location of Feature Collection cache, currently implemented
-with [Berkeley DB](http://www.oracle.com/technetwork/database/berkeleydb/overview/index-093405.html){:target="_blank"}. 
+with [Berkeley DB](https://www.oracle.com/technetwork/database/berkeleydb/overview/index-093405.html){:target="_blank"}. 
   If not otherwise set, the TDS will use the`${tds.content.root.path}/thredds/cache/collection/` directory.
   We recommend that you use this default, by not specifying a `FeatureCollection.dir` element.
 * `maxSize`: maximum amount of memory to be used for this cache.

--- a/docs/src/public/userguide/pages/thredds/ThreddsConfigRef.md
+++ b/docs/src/public/userguide/pages/thredds/ThreddsConfigRef.md
@@ -336,8 +336,8 @@ For TDS users, we recommend setting the library path and name in `threddsConfig.
 </nj22Config>
 ~~~
 
-These elements allow you to specify [runtime parameters](https://docs.unidata.ucar.edu/netcdf-java/current/userguide/runtime_loading.html)  for the NetCDF-Java library from the threddsConfig file.
-See the NetCDF-Java [tutorial](https://docs.unidata.ucar.edu/netcdf-java/current/userguide/) for an overview.
+These elements allow you to specify [runtime parameters](https://docs.unidata.ucar.edu/netcdf-java/{{site.netcdf-java_docset_version}}/userguide/runtime_loading.html)  for the NetCDF-Java library from the threddsConfig file.
+See the NetCDF-Java [tutorial](https://docs.unidata.ucar.edu/netcdf-java/{{site.netcdf-java_docset_version}}/userguide/) for an overview.
 
 ### Aggregation
 

--- a/docs/src/public/userguide/pages/thredds/WcsRef.md
+++ b/docs/src/public/userguide/pages/thredds/WcsRef.md
@@ -170,8 +170,8 @@ Here are example WCS queries (REST API Call appened to the wcs access url of a d
 A few WCS clients we know of (though we haven't tried all of them):
 
 * [OWSlib](http://geopython.github.io/OWSLib/){:target="_blank"} (WMS and WCS) [free]
-* [Map Express](https://www.cadcorp.com/products/free-mapping-software/){:target="_blank"} (WMS and `WCS`) [commercial / free]
-* [IDL](http://www.harrisgeospatial.com/ProductsandSolutions/GeospatialProducts/IDL.aspx){:target="_blank"} (WMS) [commercial]
+* [Map Express](https://www.cadcorp.com/products/desktop/cadcorp-sis-desktop-express/){:target="_blank"} (WMS and `WCS`) [commercial / free]
+* [IDL](https://www.harrisgeospatial.com/Software-Technology/IDL){:target="_blank"} (WMS) [commercial]
 * [gvSIG](http://www.gvsig.org/web/){:target="_blank"} (WMS and WCS) [free]
 
 This one is not a general client.

--- a/docs/src/public/userguide/pages/thredds/WcsRef.md
+++ b/docs/src/public/userguide/pages/thredds/WcsRef.md
@@ -177,4 +177,4 @@ A few WCS clients we know of (though we haven't tried all of them):
 This one is not a general client.
 It is a server site with a web interface for accessing their served data:
 
- * [DATAFed](http://www.datafed.net/){:target="_blank"}
+ * [DATAFed](http://datafed.org/){:target="_blank"}

--- a/docs/src/public/userguide/pages/workshops/2018UnidataTrainingWorkshop.md
+++ b/docs/src/public/userguide/pages/workshops/2018UnidataTrainingWorkshop.md
@@ -93,10 +93,10 @@ permalink:  workshop2018.html
 ### 10:00 (15 minutes) Break
 
 ### 10:15 (15 minutes) NcML modifications (Sean)
-* [Basic NcML tutorial](https://docs.unidata.ucar.edu/netcdf-java/current/userguide/basic_ncml_tutorial.html){:target="_blank"}
+* [Basic NcML tutorial](https://docs.unidata.ucar.edu/netcdf-java/{{site.netcdf-java_docset_version}}/userguide/basic_ncml_tutorial.html){:target="_blank"}
 
 ### 10:30 (30 minutes) NcML aggregation (Sean)
-* [NcML Aggregation](https://docs.unidata.ucar.edu/netcdf-java/current/userguide/ncml_aggregation.html){:target="_blank"}
+* [NcML Aggregation](https://docs.unidata.ucar.edu/netcdf-java/{{site.netcdf-java_docset_version}}/userguide/ncml_aggregation.html){:target="_blank"}
 * [NcML Aggregation Example Problems](ncml_aggregation_examples.html)
 * NcML Aggregations vs Feature Collections ([pdf](https://www.unidata.ucar.edu/software/thredds/current/tds/tutorial/files/NcMLvsFeatureCollections.pdf){:target="_blank"})
 

--- a/gradle/any/dependencies.gradle
+++ b/gradle/any/dependencies.gradle
@@ -74,6 +74,8 @@ libraries["spotless"] = "com.diffplug.spotless:spotless-plugin-gradle:3.22.0"
 
 /////////////////////////////////////// netCDF-Java ////////////////////////////////////////
 
+// NOTE: If updating to a new major or minor version of netcdf-java, be sure to update
+// the netcdf-java_docset_version variable in docs/src/public/userguide/_config.yml."
 versions["ncj"] = "5.4.0-SNAPSHOT"
 
 libraries["bufr"] = "edu.ucar:bufr:${versions["ncj"]}"


### PR DESCRIPTION
- Updated links to address 301s.
- Links to Wayback Machine for some referenced materials.
- Removed defunct & inaccessible link references to old Spring forum threads (not accessible via WayBack Machine).
- Added liquid variable substitution for external links to netcdf-java documentation.
