### PR TITLE
Bump log4j2 deps and fix log4J listener loading

### DIFF
--- a/gradle/any/dependencies.gradle
+++ b/gradle/any/dependencies.gradle
@@ -135,13 +135,13 @@ libraries["52n-xml-sampling-v20"] = "org.n52.sensorweb:52n-xml-sampling-v20:${ve
 
 ////////////////////////////////////////// Logging //////////////////////////////////////////
 
-versions["slf4j"] = "1.7.28"
+versions["slf4j"] = "1.7.30"
 
 libraries["slf4j-api"] = "org.slf4j:slf4j-api:${versions["slf4j"]}"
 
 libraries["jcl-over-slf4j"] = "org.slf4j:jcl-over-slf4j:${versions["slf4j"]}"
 
-versions["log4j"] = "2.11.0"
+versions["log4j"] = "2.13.3"
 
 libraries["log4j-web"] = "org.apache.logging.log4j:log4j-web:${versions["log4j"]}"
 
@@ -364,8 +364,14 @@ configurations.all {
             \--- org.springframework:spring-core:4.3.8.RELEASE
                  ...
          */
+        // Also, make sure we are using a consistent (version-wise) set of slf4j deps
+        // See http://www.slf4j.org/manual.html#compatibility
         eachDependency { DependencyResolveDetails dep ->
             if (dep.requested.name == 'commons-logging') {
+                dep.useTarget libraries["jcl-over-slf4j"]
+            } else if (dep.requested.name == 'slf4j-api') {
+                dep.useTarget libraries["slf4j-api"]
+            } else if (dep.requested.name == 'jcl-over-slf4j') {
                 dep.useTarget libraries["jcl-over-slf4j"]
             }
         }
@@ -393,5 +399,4 @@ configurations.all {
              ...
      */
     exclude group: 'org.slf4j', module: 'slf4j-log4j12'
-
 }

--- a/tds/src/main/webapp/WEB-INF/web.xml
+++ b/tds/src/main/webapp/WEB-INF/web.xml
@@ -18,7 +18,31 @@
      Spring listener to bootstrap Spring WebApplicationContext. Used to
      handle Spring bean configuration outside of SpringMVC configuration.
      Paths, by default, are relative to the application root.
+
+     But first...because we are going to be using ContextLoaderListener,
+     we need to make sure the Log4jServletContextListener is called first
+     or else we will get thread leaks on shutdown. See
+     https://issues.apache.org/jira/browse/LOG4J2-1259?focusedCommentId=15895026&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-15895026
   -->
+  <listener>
+    <listener-class>org.apache.logging.log4j.web.Log4jServletContextListener</listener-class>
+  </listener>
+
+  <filter>
+    <filter-name>log4jServletFilter</filter-name>
+    <filter-class>org.apache.logging.log4j.web.Log4jServletFilter</filter-class>
+  </filter>
+  <filter-mapping>
+    <filter-name>log4jServletFilter</filter-name>
+    <url-pattern>/*</url-pattern>
+    <dispatcher>REQUEST</dispatcher>
+    <dispatcher>FORWARD</dispatcher>
+    <dispatcher>INCLUDE</dispatcher>
+    <dispatcher>ERROR</dispatcher>
+    <dispatcher>ASYNC</dispatcher>
+  </filter-mapping>
+
+  <!-- Now, bootstrap the Spring WebApplicationContext -->
   <context-param>
     <param-name>contextConfigLocation</param-name>
     <param-value>/WEB-INF/applicationContext.xml</param-value>


### PR DESCRIPTION
Because we are using `ContextLoaderListener` to bootstrap spring, we need to make sure the `Log4jServletContextListener` is called first or else we will get thread leaks on shutdown. See [this comment on LOG4J2-1259](https://issues.apache.org/jira/browse/LOG4J2-1259?focusedCommentId=15895026&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-15895026).