### PR TITLE
Allow TDS to use both old and new netCDF-Java API

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,26 @@
+on:
+  pull_request:
+    paths:
+      - 'docs/src/public/**'
+      - 'docs/build.gradle'
+      - 'gradle/**'
+
+jobs:
+  check-doc-build:
+    name: TDS Documentation Build Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Zulu JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+          architecture: x64
+      - name: Cache Gradle packages
+        uses: actions/cache@v1
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: ${{ runner.os }}-gradle
+      - name: Build docs using Gradle
+        run: ./gradlew buildUserGuide

--- a/.github/workflows/tds.yml
+++ b/.github/workflows/tds.yml
@@ -1,0 +1,110 @@
+on: [pull_request]
+
+jobs:
+  check-assemble-adpotopenjdk-hs-8:
+    name: Check fresh assemble of THREDDS Data Server Project (AdoptOpenJDK-HS 8)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Fetch latest AdoptOpenJDK 8 (hotspot) built for linux"
+        run: curl -L "https://api.adoptopenjdk.net/v2/binary/releases/openjdk8?openjdk_impl=hotspot&arch=x64&release=latest&type=jdk&os=linux" -o aojdk8-hs.tar.gz
+      - name: Setup Latest AdoptOpenJDK (hotspot) 8
+        uses: actions/setup-java@master
+        with:
+          java-version: 8
+          architecture: x64
+          jdkFile: ./aojdk8-hs.tar.gz
+      - name: Print java version
+        run: java -version
+      - name: Build and test with Gradle
+        run: ./gradlew assemble --refresh-dependencies
+
+  tests-adpotopenjdk-hs-8:
+    name: THREDDS Data Server Tests (AdoptOpenJDK-HS 8)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Fetch latest AdoptOpenJDK 8 (hotspot) built for linux"
+        run: curl -L "https://api.adoptopenjdk.net/v2/binary/releases/openjdk8?openjdk_impl=hotspot&arch=x64&release=latest&type=jdk&os=linux" -o aojdk8-hs.tar.gz
+      - name: Setup Latest AdoptOpenJDK (hotspot) 8
+        uses: actions/setup-java@master
+        with:
+          java-version: 8
+          architecture: x64
+          jdkFile: ./aojdk8-hs.tar.gz
+      - name: Print java version
+        run: java -version
+      - name: Install netCDF-C
+        run: sudo apt-get install libnetcdf-dev
+      - name: Cache Gradle packages
+        uses: actions/cache@v1
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: ${{ runner.os }}-gradle
+      - name: Build and test with Gradle
+        run: ./gradlew -Dtds.content.root.path=$CONTENT_DIR  -Dtds.download.dir=$DOWNLOAD_DIR -Dtds.upload.dir=$UPLOAD_DIR --info --stacktrace testAll
+        env:
+          TRAVIS: 'true'
+          CONTENT_DIR: ${{ github.workspace }}/tds/src/test/content
+          DOWNLOAD_DIR: '/tmp/download'
+          UPLOAD_DIR: '/tmp/upload'
+      - uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: tds_JUnit_Results_${{ github.sha }}_AdoptOpenJDK-HS-8
+          path: build/reports/allTests
+
+  tests-adpotopenjdk-hs-8-builders:
+    name: THREDDS Data Server Tests (AdoptOpenJDK-HS 8)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Fetch latest AdoptOpenJDK 8 (hotspot) built for linux"
+        run: curl -L "https://api.adoptopenjdk.net/v2/binary/releases/openjdk8?openjdk_impl=hotspot&arch=x64&release=latest&type=jdk&os=linux" -o aojdk8-hs.tar.gz
+      - name: Setup Latest AdoptOpenJDK (hotspot) 8
+        uses: actions/setup-java@master
+        with:
+          java-version: 8
+          architecture: x64
+          jdkFile: ./aojdk8-hs.tar.gz
+      - name: Print java version
+        run: java -version
+      - name: Install netCDF-C
+        run: sudo apt-get install libnetcdf-dev
+      - name: Cache Gradle packages
+        uses: actions/cache@v1
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: ${{ runner.os }}-gradle
+      - name: Build and test with Gradle
+        run: ./gradlew -Dtds.content.root.path=$CONTENT_DIR  -Dtds.download.dir=$DOWNLOAD_DIR -Dtds.upload.dir=$UPLOAD_DIR -Dthredds.test.experimental.useNetcdfJavaBuilders=true --info --stacktrace testAll
+        env:
+          TRAVIS: 'true'
+          CONTENT_DIR: ${{ github.workspace }}/tds/src/test/content
+          DOWNLOAD_DIR: '/tmp/download'
+          UPLOAD_DIR: '/tmp/upload'
+      - uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: tds_JUnit_Results_${{ github.sha }}_AdoptOpenJDK-HS-8
+          path: build/reports/allTests
+
+  spotless:
+    name: Code Style Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Cache Gradle packages
+        uses: actions/cache@v1
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: ${{ runner.os }}-gradle
+      - name: Code Style Check with Gradle and Spotless
+        run: ./gradlew clean spotlessCheck

--- a/it/src/test/java/thredds/server/cdmr/TestCdmRemoteCompareHeadersP.java
+++ b/it/src/test/java/thredds/server/cdmr/TestCdmRemoteCompareHeadersP.java
@@ -110,7 +110,30 @@ public class TestCdmRemoteCompareHeadersP {
   }
 
   static int compareDatasets(String local, String remote, boolean readData) throws IOException {
+    if (TestDir.cdmUseBuilders) {
+      return compareDatasetsNew(local, remote, readData);
+    } else {
+      return compareDatasetsOld(local, remote, readData);
+    }
+  }
+
+  private static int compareDatasetsNew(String local, String remote, boolean readData) throws IOException {
     try (NetcdfFile ncfile = NetcdfDatasets.openFile(local, null); NetcdfFile ncremote = new CdmRemote(remote)) {
+
+      Formatter f = new Formatter();
+      CompareNetcdf2 mind = new CompareNetcdf2(f, false, false, false);
+      boolean ok = mind.compare(ncfile, ncremote, new NcstreamObjFilter(), false, false, readData);
+      if (!ok) {
+        System.out.printf("--Compare %s to %s%n", local, remote);
+        System.out.printf("  %s%n", f);
+      }
+      Assert.assertTrue(local + " != " + remote, ok);
+    }
+    return 1;
+  }
+
+  private static int compareDatasetsOld(String local, String remote, boolean readData) throws IOException {
+    try (NetcdfFile ncfile = NetcdfDataset.openFile(local, null); NetcdfFile ncremote = new CdmRemote(remote)) {
 
       Formatter f = new Formatter();
       CompareNetcdf2 mind = new CompareNetcdf2(f, false, false, false);

--- a/it/src/test/java/thredds/server/ncss/NcssGridIntegrationTest.java
+++ b/it/src/test/java/thredds/server/ncss/NcssGridIntegrationTest.java
@@ -1,5 +1,6 @@
 package thredds.server.ncss;
 
+import java.io.IOException;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.slf4j.Logger;
@@ -7,8 +8,11 @@ import org.slf4j.LoggerFactory;
 import thredds.TestOnLocalServer;
 import thredds.util.ContentType;
 import ucar.nc2.NetcdfFile;
+import ucar.nc2.NetcdfFiles;
 import ucar.nc2.dataset.NetcdfDataset;
+import ucar.nc2.dataset.NetcdfDatasets;
 import ucar.nc2.dt.grid.GridDataset;
+import ucar.unidata.util.test.TestDir;
 import ucar.unidata.util.test.category.NeedsCdmUnitTest;
 import java.lang.invoke.MethodHandles;
 import static org.junit.Assert.assertNotNull;
@@ -16,6 +20,22 @@ import static org.junit.Assert.assertNotNull;
 @Category(NeedsCdmUnitTest.class)
 public class NcssGridIntegrationTest {
   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+  private void openBinaryNew(byte[] content, String gridName) throws IOException {
+    try (NetcdfFile nf = NetcdfFiles.openInMemory("test_data.nc", content)) {
+      GridDataset gdsDataset = new GridDataset(NetcdfDatasets.enhance(nf, NetcdfDataset.getDefaultEnhanceMode(), null));
+      assertNotNull(gdsDataset.findGridByName(gridName));
+      logger.debug("{}", nf);
+    }
+  }
+
+  private void openBinaryOld(byte[] content, String gridName) throws IOException {
+    try (NetcdfFile nf = NetcdfFile.openInMemory("test_data.nc", content)) {
+      GridDataset gdsDataset = new GridDataset(new NetcdfDataset(nf));
+      assertNotNull(gdsDataset.findGridByName(gridName));
+      logger.debug("{}", nf);
+    }
+  }
 
   /*
    * @HttpTest(method = Method.GET, path =
@@ -41,11 +61,10 @@ public class NcssGridIntegrationTest {
         "/ncss/grid/gribCollection/GFS_CONUS_80km/GFS_CONUS_80km_20120227_0000.grib1?var=Temperature_isobaric");
 
     byte[] content = TestOnLocalServer.getContent(endpoint, 200, ContentType.netcdf);
-    // Open the binary response in memory
-    try (NetcdfFile nf = NetcdfFile.openInMemory("test_data.nc", content)) {
-      GridDataset gdsDataset = new GridDataset(new NetcdfDataset(nf));
-      assertNotNull(gdsDataset.findGridByName("Temperature_isobaric"));
-      logger.debug("{}", nf);
+    if (TestDir.cdmUseBuilders) {
+      openBinaryNew(content, "Temperature_isobaric");
+    } else {
+      openBinaryOld(content, "Temperature_isobaric");
     }
   }
 
@@ -63,10 +82,10 @@ public class NcssGridIntegrationTest {
     byte[] content = TestOnLocalServer.getContent(endpoint, 200, ContentType.netcdf);
 
     // Open the binary response in memory
-    try (NetcdfFile nf = NetcdfFile.openInMemory("test_data.nc", content)) {
-      GridDataset gdsDataset = new GridDataset(new NetcdfDataset(nf));
-      assertNotNull(gdsDataset.findGridByName("Relative_humidity_height_above_ground"));
-      logger.debug("{}", nf);
+    if (TestDir.cdmUseBuilders) {
+      openBinaryNew(content, "Relative_humidity_height_above_ground");
+    } else {
+      openBinaryOld(content, "Relative_humidity_height_above_ground");
     }
   }
 
@@ -82,10 +101,10 @@ public class NcssGridIntegrationTest {
     byte[] content = TestOnLocalServer.getContent(endpoint, 200, ContentType.netcdf);
 
     // Open the binary response in memory
-    try (NetcdfFile nf = NetcdfFile.openInMemory("test_data.nc", content)) {
-      GridDataset gdsDataset = new GridDataset(new NetcdfDataset(nf));
-      assertNotNull(gdsDataset.findGridByName("eastward_ekman_current_velocity"));
-      logger.debug("{}", nf);
+    if (TestDir.cdmUseBuilders) {
+      openBinaryNew(content, "eastward_ekman_current_velocity");
+    } else {
+      openBinaryOld(content, "eastward_ekman_current_velocity");
     }
   }
 }

--- a/it/src/test/java/thredds/server/services/ConsistentDatesTest.java
+++ b/it/src/test/java/thredds/server/services/ConsistentDatesTest.java
@@ -24,15 +24,18 @@ import thredds.TestOnLocalServer;
 import thredds.util.ContentType;
 import ucar.nc2.Attribute;
 import ucar.nc2.NetcdfFile;
+import ucar.nc2.NetcdfFiles;
 import ucar.nc2.constants.CDM;
 import ucar.nc2.constants.CF;
 import ucar.nc2.dataset.CoordinateAxis1D;
 import ucar.nc2.dataset.CoordinateAxis1DTime;
 import ucar.nc2.dataset.NetcdfDataset;
+import ucar.nc2.dataset.NetcdfDatasets;
 import ucar.nc2.time.Calendar;
 import ucar.nc2.time.CalendarDate;
 import ucar.nc2.time.CalendarDateUnit;
 import ucar.nc2.util.IO;
+import ucar.unidata.util.test.TestDir;
 import ucar.unidata.util.test.category.NeedsCdmUnitTest;
 import java.io.*;
 import java.lang.invoke.MethodHandles;
@@ -150,8 +153,16 @@ public class ConsistentDatesTest {
     String endpoint = TestOnLocalServer.withHttpPath(
         "/ncss/grid/cdmUnitTest/ncss/climatology/PF5_SST_Climatology_Monthly_1985_2001.nc?var=sst&latitude=45&longitude=-20&temporal=all&accept=netcdf");
     byte[] result = TestOnLocalServer.getContent(endpoint, 200, ContentType.netcdf);
-    NetcdfFile nf = NetcdfFile.openInMemory("test_data.ncs", result);
-    NetcdfDataset ds = new NetcdfDataset(nf);
+    NetcdfFile nf;
+    NetcdfDataset ds;
+
+    if (TestDir.cdmUseBuilders) {
+      nf = NetcdfFiles.openInMemory("test_data.ncs", result);
+      ds = NetcdfDatasets.enhance(nf, NetcdfDataset.getDefaultEnhanceMode(), null);
+    } else {
+      nf = NetcdfFile.openInMemory("test_data.ncs", result);
+      ds = new NetcdfDataset(nf);
+    }
 
     CoordinateAxis1D tAxis = (CoordinateAxis1D) ds.findCoordinateAxis("time");
     Attribute calendarAtt = tAxis.findAttribute(CF.CALENDAR);
@@ -214,8 +225,15 @@ public class ConsistentDatesTest {
     System.out.printf("Write file to %s%n", tmpFile.getAbsolutePath());
     IO.appendToFile(is, tmpFile.getAbsolutePath());
 
-    NetcdfFile nf = NetcdfFile.openInMemory("test_data.ncs", result);
-    NetcdfDataset ds = new NetcdfDataset(nf);
+    NetcdfFile nf;
+    NetcdfDataset ds;
+    if (TestDir.cdmUseBuilders) {
+      nf = NetcdfFiles.openInMemory("test_data.ncs", result);
+      ds = NetcdfDatasets.enhance(nf, NetcdfDataset.getDefaultEnhanceMode(), null);
+    } else {
+      nf = NetcdfFile.openInMemory("test_data.ncs", result);
+      ds = new NetcdfDataset(nf);
+    }
 
     CoordinateAxis1DTime tAxis = CoordinateAxis1DTime.factory(ds, ds.findCoordinateAxis("time"), null);
     List<CalendarDate> dates = tAxis.getCalendarDates();

--- a/it/src/test/java/thredds/server/wcs/TestWcsServer.java
+++ b/it/src/test/java/thredds/server/wcs/TestWcsServer.java
@@ -32,6 +32,7 @@ import thredds.util.ContentType;
 import ucar.nc2.NetcdfFile;
 import ucar.nc2.constants.AxisType;
 import ucar.nc2.dataset.NetcdfDataset;
+import ucar.nc2.dataset.NetcdfDatasets;
 import ucar.nc2.ft2.coverage.Coverage;
 import ucar.nc2.ft2.coverage.CoverageCollection;
 import ucar.nc2.ft2.coverage.CoverageCoordAxis1D;
@@ -44,6 +45,7 @@ import ucar.nc2.time.Calendar;
 import ucar.nc2.time.CalendarDate;
 import ucar.nc2.util.IO;
 import ucar.unidata.util.test.Assert2;
+import ucar.unidata.util.test.TestDir;
 import ucar.unidata.util.test.category.NeedsCdmUnitTest;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -132,6 +134,16 @@ public class TestWcsServer {
     byte[] result = TestOnLocalServer.getContent(endpoint, 200, null);
   }
 
+  private DtCoverageDataset getDtCoverageDataset(NetcdfFile ncf) throws IOException {
+    DtCoverageDataset dtc;
+    if (TestDir.cdmUseBuilders) {
+      dtc = new DtCoverageDataset(NetcdfDatasets.enhance(ncf, NetcdfDataset.getDefaultEnhanceMode(), null));
+    } else {
+      dtc = new DtCoverageDataset(new NetcdfDataset(ncf), null);
+    }
+    return dtc;
+  }
+
   @Test
   public void testGetCoverageNetcdf() throws IOException {
     String endpoint = TestOnLocalServer.withHttpPath(
@@ -140,7 +152,7 @@ public class TestWcsServer {
 
     // Open the binary response in memory
     try (NetcdfFile nf = NetcdfFile.openInMemory("test_data.nc", content)) {
-      DtCoverageDataset dt = new DtCoverageDataset(new NetcdfDataset(nf), null);
+      DtCoverageDataset dt = getDtCoverageDataset(nf);
       Formatter errlog = new Formatter();
       FeatureDatasetCoverage cdc = DtCoverageAdapter.factory(dt, errlog);
       Assert.assertNotNull(errlog.toString(), cdc);
@@ -224,7 +236,7 @@ public class TestWcsServer {
 
     // Open the binary response in memory
     try (NetcdfFile nf = NetcdfFile.openInMemory("test_data.nc", content)) {
-      DtCoverageDataset dt = new DtCoverageDataset(new NetcdfDataset(nf), null);
+      DtCoverageDataset dt = getDtCoverageDataset(nf);
       Formatter errlog = new Formatter();
       FeatureDatasetCoverage cdc = DtCoverageAdapter.factory(dt, errlog);
       Assert.assertNotNull(errlog.toString(), cdc);

--- a/tdcommon/src/main/java/thredds/server/catalog/DataRoot.java
+++ b/tdcommon/src/main/java/thredds/server/catalog/DataRoot.java
@@ -188,9 +188,13 @@ public class DataRoot {
     if (locationReletive.startsWith("/"))
       locationReletive = locationReletive.substring(1);
 
-    if (!rootLocation.endsWith("/"))
-      rootLocation = rootLocation + "/";
-
+    if (!rootLocation.endsWith("/")) {
+      if (rootLocation.startsWith("cdms3") || rootLocation.startsWith("s3")) {
+        rootLocation = rootLocation + "?";
+      } else {
+        rootLocation = rootLocation + "/";
+      }
+    }
     // put it together
     return (locationReletive.length() > 1) ? rootLocation + locationReletive : rootLocation;
   }

--- a/tds/src/main/java/thredds/server/admin/DebugCommands.java
+++ b/tds/src/main/java/thredds/server/admin/DebugCommands.java
@@ -121,9 +121,17 @@ public class DebugCommands {
           fc.showCache(f);
         }
 
-        fc = NetcdfDatasets.getNetcdfFileCache();
+        fc = NetcdfDataset.getNetcdfFileCache();
         if (fc == null)
           f.format("NetcdfDatasetFileCache : turned off%n");
+        else {
+          f.format("%n%n");
+          fc.showCache(f);
+        }
+
+        fc = NetcdfDatasets.getNetcdfFileCache();
+        if (fc == null)
+          f.format("NetcdfDatasetsFileCache : turned off%n");
         else {
           f.format("%n%n");
           fc.showCache(f);
@@ -144,6 +152,7 @@ public class DebugCommands {
 
     act = new Action("clearCaches", "Clear All File Object Caches") {
       public void doAction(Event e) {
+        NetcdfDataset.getNetcdfFileCache().clearCache(false);
         NetcdfDatasets.getNetcdfFileCache().clearCache(false);
         RandomAccessFile.getGlobalFileCache().clearCache(false);
         FileCacheIF fc = GribCdmIndex.gribCollectionCache;
@@ -174,6 +183,7 @@ public class DebugCommands {
     act = new Action("disableNetcdfCache", "Disable NetcdfDatasetFile Cache") {
       public void doAction(Event e) {
         NetcdfDatasets.disableNetcdfFileCache();
+        NetcdfDataset.disableNetcdfFileCache();
         e.pw.println("  Disable NetcdfFile Cache ok");
       }
     };
@@ -182,6 +192,7 @@ public class DebugCommands {
     act = new Action("forceNCCache", "Force clear NetcdfDatasetFile Cache") {
       public void doAction(Event e) {
         NetcdfDatasets.getNetcdfFileCache().clearCache(true);
+        NetcdfDataset.getNetcdfFileCache().clearCache(true);
         e.pw.println("  NetcdfFileCache force clearCache done");
       }
     };

--- a/tds/src/main/java/thredds/server/config/TdsInit.java
+++ b/tds/src/main/java/thredds/server/config/TdsInit.java
@@ -218,6 +218,13 @@ public class TdsInit implements ApplicationListener<ContextRefreshedEvent>, Disp
 
     // use new builders in netCDF-Java
     useBuilders = ThreddsConfig.getBoolean("Experimental.useNetcdfJavaBuilders", false);
+
+    // if useBuilders is false, look at the Java system properties to see if there is a special flag set, used
+    // for testing only.
+    if (!useBuilders) {
+      useBuilders = Boolean.getBoolean("thredds.test.experimental.useNetcdfJavaBuilders");
+    }
+
     datasetManager.setUseNetcdfJavaBuilders(useBuilders);
 
     // prefer cdmRemote when available

--- a/tds/src/main/java/thredds/server/config/TdsInit.java
+++ b/tds/src/main/java/thredds/server/config/TdsInit.java
@@ -104,8 +104,16 @@ public class TdsInit implements ApplicationListener<ContextRefreshedEvent>, Disp
   private XMLStore store;
   private PreferencesExt mainPrefs;
 
+  private boolean useBuilders;
+
   @Override
   public void onApplicationEvent(ContextRefreshedEvent event) {
+    String awsRegion = System.getProperty("aws.region");
+    // if aws.region system property already set, use it.
+    // otherwise, default to us-east-1
+    if (awsRegion == null) {
+      System.setProperty("aws.region", "us-east-1");
+    }
     if (event != null) { // startup
       synchronized (this) {
         if (!wasInitialized) {
@@ -208,6 +216,10 @@ public class TdsInit implements ApplicationListener<ContextRefreshedEvent>, Disp
     // initialize the tds configuration beans
     tdsConfigMapper.init(tdsContext);
 
+    // use new builders in netCDF-Java
+    useBuilders = ThreddsConfig.getBoolean("Experimental.useNetcdfJavaBuilders", false);
+    datasetManager.setUseNetcdfJavaBuilders(useBuilders);
+
     // prefer cdmRemote when available
     DataFactory.setPreferCdm(true);
     // netcdf-3 files can only grow, not have metadata changes
@@ -246,6 +258,7 @@ public class TdsInit implements ApplicationListener<ContextRefreshedEvent>, Disp
 
     allowedServices.finish(); // finish when we know everything is wired
     InvDatasetFeatureCollection.setAllowedServices(allowedServices);
+    InvDatasetFeatureCollection.setUseNetcdfJavaBuilders(useBuilders);
     DatasetScan.setSpecialServices(allowedServices.getStandardService(StandardService.resolver),
         allowedServices.getStandardService(StandardService.httpServer));
     DatasetScan.setAllowedServices(allowedServices);
@@ -390,6 +403,8 @@ public class TdsInit implements ApplicationListener<ContextRefreshedEvent>, Disp
     if (max > 0) {
       NetcdfDatasets.initNetcdfFileCache(min, max, secs);
       startupLog.info("TdsInit: NetcdfDatasets.initNetcdfFileCache= [" + min + "," + max + "] scour = " + secs);
+      NetcdfDataset.initNetcdfFileCache(min, max, secs);
+      startupLog.info("TdsInit: NetcdfDataset.initNetcdfFileCache= [" + min + "," + max + "] scour = " + secs);
     }
 
     // GribCollection partitions: default is allow 100 - 150 objects, cleanup every 13 minutes
@@ -479,6 +494,7 @@ public class TdsInit implements ApplicationListener<ContextRefreshedEvent>, Disp
 
     // open file caches
     RandomAccessFile.shutdown();
+    NetcdfDataset.shutdown();
     NetcdfDatasets.shutdown();
 
     // memory caches

--- a/tds/src/main/java/thredds/server/reify/DownloadController.java
+++ b/tds/src/main/java/thredds/server/reify/DownloadController.java
@@ -327,7 +327,7 @@ public class DownloadController extends LoadCommon {
       NetcdfFile ncfile = null;
       try {
         CancelTaskImpl cancel = new CancelTaskImpl();
-        ncfile = NetcdfDatasets.openFile(trueurl, cancel);
+        ncfile = NetcdfDataset.openFile(trueurl, cancel);
         switch (this.params.format) {
           case NETCDF3:
             makeNetcdf3(ncfile, fulltarget);

--- a/tds/src/main/java/thredds/server/wfs/WFSController.java
+++ b/tds/src/main/java/thredds/server/wfs/WFSController.java
@@ -2,6 +2,7 @@ package thredds.server.wfs;
 
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
+import thredds.core.DatasetManager;
 import thredds.core.TdsRequestedDataset;
 import thredds.servlet.ServletUtil;
 import ucar.nc2.dataset.CoordinateSystem;
@@ -173,7 +174,7 @@ public class WFSController extends HttpServlet {
    * @param request parameter value
    * @param version parameter value
    * @param service parameter value
-   * @param actualFTName parameter value
+   * @param typeName parameter value
    * @return an ExceptionWriter if any errors occurred or null if none occurred
    */
   private WFSExceptionWriter checkParametersForError(String request, String version, String service, String typeName) {
@@ -316,7 +317,12 @@ public class WFSController extends HttpServlet {
       actualPath = TdsRequestedDataset.getLocationFromRequestPath(datasetReqPath);
 
       if (actualPath != null)
-        dataset = NetcdfDatasets.openDataset(actualPath);
+        if (TdsRequestedDataset.getDatasetManager().useNetcdfJavaBuilders()
+            || DatasetManager.isLocationObjectStore(actualPath)) {
+          dataset = NetcdfDatasets.openDataset(actualPath);
+        } else {
+          dataset = NetcdfDataset.openDataset(actualPath);
+        }
       else
         return;
 

--- a/tds/src/main/java/thredds/server/wms/ThreddsWmsServlet.java
+++ b/tds/src/main/java/thredds/server/wms/ThreddsWmsServlet.java
@@ -28,6 +28,7 @@
 
 package thredds.server.wms;
 
+import ucar.nc2.dataset.NetcdfDatasets;
 import uk.ac.rdg.resc.edal.graphics.exceptions.EdalLayerNotFoundException;
 import uk.ac.rdg.resc.edal.wms.RequestParams;
 import uk.ac.rdg.resc.edal.wms.WmsCatalogue;
@@ -77,8 +78,12 @@ public class ThreddsWmsServlet extends WmsServlet {
       catalogue = catalogueCache.get(tdsDataset.getPath());
     } else {
       NetcdfFile ncf = tdsDataset.getNetcdfFile(httpServletRequest, httpServletResponse, tdsDataset.getPath());
-
-      NetcdfDataset ncd = new NetcdfDataset(ncf, true);
+      NetcdfDataset ncd;
+      if (tdsDataset.useNetcdfJavaBuilders()) {
+        ncd = NetcdfDatasets.enhance(ncf, NetcdfDataset.getDefaultEnhanceMode(), null);
+      } else {
+        ncd = NetcdfDataset.wrap(ncf, NetcdfDataset.getDefaultEnhanceMode());
+      }
 
       String netcdfFilePath = ncf.getLocation();
 

--- a/tds/src/test/content/thredds/catalog.xml
+++ b/tds/src/test/content/thredds/catalog.xml
@@ -22,6 +22,18 @@
     <service name="uddc" serviceType="UDDC" base="/thredds/uddc/"/>
   </service>
 
+  <service name="obstoreGrid" base="" serviceType="compound">
+    <service name="odap" serviceType="OpenDAP" base="/thredds/dodsC/"/>
+    <service name="wcs" serviceType="WCS" base="/thredds/wcs/"/>
+    <service name="wms" serviceType="WMS" base="/thredds/wms/"/>
+    <service name="ncssGrid" serviceType="NetcdfSubset" base="/thredds/ncss/grid/"/>
+    <service name="cdmremote" serviceType="CdmRemote" base="/thredds/cdmremote/"/>
+    <service name="cdmrFeature" serviceType="CdmrFeature" base="/thredds/cdmrfeature/grid/"/>
+    <service name="iso" serviceType="ISO" base="/thredds/iso/"/>
+    <service name="ncml" serviceType="NCML" base="/thredds/ncml/"/>
+    <service name="uddc" serviceType="UDDC" base="/thredds/uddc/"/>
+  </service>
+
   <datasetRoot path="localContent" location="content/testdata/"/>
   <datasetRoot path="protected" location="content/protected/"/>
   <datasetRoot path="testRestrictedDataset" location="content/testdata/"/>

--- a/tds/src/test/content/thredds/tds-s3.xml
+++ b/tds/src/test/content/thredds/tds-s3.xml
@@ -2,10 +2,11 @@
 <catalog name="S3 Test Catalog"
   xmlns="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0">
 
-  <datasetRoot path="s3-test" location="s3://noaa-goes16" />
+  <datasetRoot path="s3-test" location="cdms3:noaa-goes16" />
 
   <dataset name="Test GOES-16 S3" ID="testS3Grid"
     urlPath="s3-test/ABI-L1b-RadC/2019/363/21/OR_ABI-L1b-RadC-M6C16_G16_s20193632101189_e20193632103574_c20193632104070.nc"
-    dataType="Grid"/>
+    dataType="Grid"
+    serviceName="obstoreGrid"/>
 
 </catalog>

--- a/tds/src/test/java/thredds/server/ncss/controller/grid/AllVariablesSubsettingTest.java
+++ b/tds/src/test/java/thredds/server/ncss/controller/grid/AllVariablesSubsettingTest.java
@@ -51,10 +51,15 @@ import org.springframework.test.web.servlet.RequestBuilder;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
+import thredds.core.TdsRequestedDataset;
 import thredds.mock.params.GridPathParams;
 import thredds.mock.web.MockTdsContextLoader;
 import ucar.nc2.NetcdfFile;
+import ucar.nc2.NetcdfFiles;
 import ucar.nc2.dataset.NetcdfDataset;
+import ucar.nc2.dataset.NetcdfDatasets;
+import ucar.nc2.dt.grid.GridDataset;
+import ucar.unidata.util.test.TestDir;
 import ucar.unidata.util.test.category.NeedsCdmUnitTest;
 
 /**
@@ -89,9 +94,17 @@ public class AllVariablesSubsettingTest {
 
     // Open the binary response in memory
     // NetcdfFile nf = NetcdfFile.openInMemory("test_data.ncs", response.getContentAsByteArray() );
-    NetcdfFile nf = NetcdfFile.openInMemory("test_data.ncs", mvc.getResponse().getContentAsByteArray());
+    NetcdfFile nf;
+    GridDataset gdsDataset;
+    if (TestDir.cdmUseBuilders) {
+      nf = NetcdfFiles.openInMemory("test_data.ncs", mvc.getResponse().getContentAsByteArray());
+      gdsDataset =
+          new ucar.nc2.dt.grid.GridDataset(NetcdfDatasets.enhance(nf, NetcdfDataset.getDefaultEnhanceMode(), null));
+    } else {
+      nf = NetcdfFile.openInMemory("test_data.ncs", mvc.getResponse().getContentAsByteArray());
+      gdsDataset = new ucar.nc2.dt.grid.GridDataset(new NetcdfDataset(nf));
+    }
 
-    ucar.nc2.dt.grid.GridDataset gdsDataset = new ucar.nc2.dt.grid.GridDataset(new NetcdfDataset(nf));
     assertTrue(gdsDataset.getCalendarDateRange().isPoint());
     assertEquals(7, gdsDataset.getDataVariables().size());
 

--- a/tds/src/test/java/thredds/server/ncss/controller/grid/SpatialSubsettingTest.java
+++ b/tds/src/test/java/thredds/server/ncss/controller/grid/SpatialSubsettingTest.java
@@ -62,10 +62,13 @@ import thredds.server.ncss.dataservice.DatasetHandlerAdapter;
 import thredds.junit4.SpringJUnit4ParameterizedClassRunner;
 import thredds.junit4.SpringJUnit4ParameterizedClassRunner.Parameters;
 import ucar.nc2.NetcdfFile;
+import ucar.nc2.NetcdfFiles;
 import ucar.nc2.dataset.NetcdfDataset;
+import ucar.nc2.dataset.NetcdfDatasets;
 import ucar.nc2.dt.GridDataset;
 import ucar.unidata.geoloc.LatLonPointImpl;
 import ucar.unidata.geoloc.LatLonRect;
+import ucar.unidata.util.test.TestDir;
 import ucar.unidata.util.test.category.NeedsCdmUnitTest;
 
 /**
@@ -152,10 +155,17 @@ public class SpatialSubsettingTest {
     this.mockMvc.perform(requestBuilder).andExpect(MockMvcResultMatchers.status().isOk())
         .andExpect(new ResultMatcher() {
           public void match(MvcResult result) throws Exception {
-
-            // Open the binary response in memory
             NetcdfFile nf = NetcdfFile.openInMemory("test_data.ncs", result.getResponse().getContentAsByteArray());
             ucar.nc2.dt.grid.GridDataset gdsDataset = new ucar.nc2.dt.grid.GridDataset(new NetcdfDataset(nf));
+            // Open the binary response in memory
+            if (TestDir.cdmUseBuilders) {
+              nf = NetcdfFiles.openInMemory("test_data.ncs", result.getResponse().getContentAsByteArray());
+              gdsDataset = new ucar.nc2.dt.grid.GridDataset(
+                  NetcdfDatasets.enhance(nf, NetcdfDataset.getDefaultEnhanceMode(), null));
+            } else {
+              nf = NetcdfFile.openInMemory("test_data.ncs", result.getResponse().getContentAsByteArray());
+              gdsDataset = new ucar.nc2.dt.grid.GridDataset(new NetcdfDataset(nf));
+            }
             LatLonRect responseBBox = gdsDataset.getBoundingBox();
 
             assertTrue(

--- a/tds/src/test/java/thredds/server/ncss/controller/grid/TemporalSpaceSubsettingTest.java
+++ b/tds/src/test/java/thredds/server/ncss/controller/grid/TemporalSpaceSubsettingTest.java
@@ -54,7 +54,10 @@ import thredds.mock.web.MockTdsContextLoader;
 import thredds.server.ncss.format.SupportedFormat;
 import ucar.nc2.Dimension;
 import ucar.nc2.NetcdfFile;
+import ucar.nc2.NetcdfFiles;
 import ucar.nc2.dataset.NetcdfDataset;
+import ucar.nc2.dataset.NetcdfDatasets;
+import ucar.unidata.util.test.TestDir;
 import ucar.unidata.util.test.category.NeedsCdmUnitTest;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
@@ -158,8 +161,15 @@ public class TemporalSpaceSubsettingTest {
     // IO.writeToFile(is, "C:/temp/shouldGetTimeRange.nc");
 
     // Open the binary response in memory
-    NetcdfFile nf = NetcdfFile.openInMemory("test_data.ncs", mvc.getResponse().getContentAsByteArray());
-    NetcdfDataset ds = new NetcdfDataset(nf);
+    NetcdfFile nf;
+    NetcdfDataset ds;
+    if (TestDir.cdmUseBuilders) {
+      nf = NetcdfFiles.openInMemory("test_data.ncs", mvc.getResponse().getContentAsByteArray());
+      ds = NetcdfDatasets.enhance(nf, NetcdfDataset.getDefaultEnhanceMode(), null);
+    } else {
+      nf = NetcdfFile.openInMemory("test_data.ncs", mvc.getResponse().getContentAsByteArray());
+      ds = new NetcdfDataset(nf);
+    }
     Dimension time = ds.findDimension("time");
 
     assertEquals(lengthTimeDim, time.getLength());

--- a/tds/src/test/java/thredds/server/ncss/controller/grid/VariableSpaceSubsettingTest.java
+++ b/tds/src/test/java/thredds/server/ncss/controller/grid/VariableSpaceSubsettingTest.java
@@ -64,8 +64,11 @@ import thredds.server.ncss.format.SupportedFormat;
 import thredds.junit4.SpringJUnit4ParameterizedClassRunner;
 import thredds.junit4.SpringJUnit4ParameterizedClassRunner.Parameters;
 import ucar.nc2.NetcdfFile;
+import ucar.nc2.NetcdfFiles;
 import ucar.nc2.dataset.NetcdfDataset;
+import ucar.nc2.dataset.NetcdfDatasets;
 import ucar.nc2.dt.grid.GeoGrid;
+import ucar.unidata.util.test.TestDir;
 import ucar.unidata.util.test.category.NeedsCdmUnitTest;
 
 /**
@@ -149,8 +152,17 @@ public class VariableSpaceSubsettingTest {
     mockMvc.perform(requestBuilder).andExpect(MockMvcResultMatchers.status().isOk()).andExpect(new ResultMatcher() {
       public void match(MvcResult result) throws Exception {
         // Open the binary response in memory
-        NetcdfFile nf = NetcdfFile.openInMemory("test_data.ncs", result.getResponse().getContentAsByteArray());
-        ucar.nc2.dt.grid.GridDataset gdsDataset = new ucar.nc2.dt.grid.GridDataset(new NetcdfDataset(nf));
+        NetcdfFile nf;
+        ucar.nc2.dt.grid.GridDataset gdsDataset;
+        if (TestDir.cdmUseBuilders) {
+          nf = NetcdfFiles.openInMemory("test_data.ncs", result.getResponse().getContentAsByteArray());
+          gdsDataset =
+              new ucar.nc2.dt.grid.GridDataset(NetcdfDatasets.enhance(nf, NetcdfDataset.getDefaultEnhanceMode(), null));
+        } else {
+          nf = NetcdfFile.openInMemory("test_data.ncs", result.getResponse().getContentAsByteArray());
+          gdsDataset = new ucar.nc2.dt.grid.GridDataset(new NetcdfDataset(nf));
+        }
+
         assertTrue(gdsDataset.getCalendarDateRange().isPoint());
 
         int[][] shapes = new int[vars.size()][];

--- a/tds/src/test/java/thredds/server/ncss/controller/grid/VerticalStrideSubsettingTest.java
+++ b/tds/src/test/java/thredds/server/ncss/controller/grid/VerticalStrideSubsettingTest.java
@@ -64,8 +64,11 @@ import thredds.server.ncss.format.SupportedFormat;
 import thredds.junit4.SpringJUnit4ParameterizedClassRunner;
 import thredds.junit4.SpringJUnit4ParameterizedClassRunner.Parameters;
 import ucar.nc2.NetcdfFile;
+import ucar.nc2.NetcdfFiles;
 import ucar.nc2.VariableSimpleIF;
 import ucar.nc2.dataset.NetcdfDataset;
+import ucar.nc2.dataset.NetcdfDatasets;
+import ucar.unidata.util.test.TestDir;
 import ucar.unidata.util.test.category.NeedsCdmUnitTest;
 
 
@@ -163,8 +166,17 @@ public class VerticalStrideSubsettingTest {
     mockMvc.perform(requestBuilder).andExpect(MockMvcResultMatchers.status().isOk()).andExpect(new ResultMatcher() {
       public void match(MvcResult result) throws Exception {
         // Open the binary response in memory
-        NetcdfFile nf = NetcdfFile.openInMemory("test_data.ncs", result.getResponse().getContentAsByteArray());
-        ucar.nc2.dt.grid.GridDataset gdsDataset = new ucar.nc2.dt.grid.GridDataset(new NetcdfDataset(nf));
+        NetcdfFile nf;
+        ucar.nc2.dt.grid.GridDataset gdsDataset;
+        if (TestDir.cdmUseBuilders) {
+          nf = NetcdfFiles.openInMemory("test_data.ncs", result.getResponse().getContentAsByteArray());
+          gdsDataset =
+              new ucar.nc2.dt.grid.GridDataset(NetcdfDatasets.enhance(nf, NetcdfDataset.getDefaultEnhanceMode(), null));
+        } else {
+          nf = NetcdfFile.openInMemory("test_data.ncs", result.getResponse().getContentAsByteArray());
+          gdsDataset = new ucar.nc2.dt.grid.GridDataset(new NetcdfDataset(nf));
+        }
+
         assertTrue(gdsDataset.getCalendarDateRange().isPoint());
         List<VariableSimpleIF> vars = gdsDataset.getDataVariables();
         int[][] shapes = new int[vars.size()][];

--- a/tds/src/test/java/thredds/server/ncss/view/dsg/DsgSubsetWriterTest.java
+++ b/tds/src/test/java/thredds/server/ncss/view/dsg/DsgSubsetWriterTest.java
@@ -37,6 +37,7 @@ import java.net.URISyntaxException;
 import java.util.Arrays;
 import java.util.Formatter;
 import java.util.List;
+import ucar.unidata.util.test.TestDir;
 
 /**
  * Created by cwardgar on 2014/05/27.
@@ -211,6 +212,29 @@ public class DsgSubsetWriterTest {
   }
 
   public static boolean compareNetCDF(File expectedResultFile, File actualResultFile) throws IOException {
+    if (TestDir.cdmUseBuilders) {
+      return compareNetCDFNew(expectedResultFile, actualResultFile);
+    } else {
+      return compareNetCDFOld(expectedResultFile, actualResultFile);
+    }
+  }
+
+  private static boolean compareNetCDFOld(File expectedResultFile, File actualResultFile) throws IOException {
+    try (NetcdfFile expectedNcFile = NetcdfDataset.openDataset(expectedResultFile.getAbsolutePath());
+        NetcdfFile actualNcFile = NetcdfDataset.openDataset(actualResultFile.getAbsolutePath())) {
+      Formatter formatter = new Formatter();
+      boolean contentsAreEqual = new CompareNetcdf2(formatter).compare(expectedNcFile, actualNcFile,
+          new NcssNetcdfObjFilter(), false, false, true);
+
+      if (!contentsAreEqual) {
+        System.err.println(formatter.toString());
+      }
+
+      return contentsAreEqual;
+    }
+  }
+
+  private static boolean compareNetCDFNew(File expectedResultFile, File actualResultFile) throws IOException {
     try (NetcdfFile expectedNcFile = NetcdfDatasets.openDataset(expectedResultFile.getAbsolutePath());
         NetcdfFile actualNcFile = NetcdfDatasets.openDataset(actualResultFile.getAbsolutePath())) {
       Formatter formatter = new Formatter();

--- a/tds/src/test/java/thredds/server/opendap/TestCEEvaluator.java
+++ b/tds/src/test/java/thredds/server/opendap/TestCEEvaluator.java
@@ -13,6 +13,7 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import ucar.nc2.dataset.NetcdfDatasets;
+import ucar.unidata.util.test.TestDir;
 import ucar.unidata.util.test.UnitTestCommon;
 import ucar.unidata.util.test.Diff;
 import ucar.nc2.NetcdfFile;
@@ -111,7 +112,11 @@ public class TestCEEvaluator extends UnitTestCommon {
 
         try {
           file = new File(path);
-          ncfile = NetcdfDatasets.openFile(file.getPath(), null);
+          if (TestDir.cdmUseBuilders) {
+            ncfile = NetcdfDatasets.openFile(file.getPath(), null);
+          } else {
+            ncfile = NetcdfDataset.openFile(file.getPath(), null);
+          }
           if (ncfile == null)
             throw new FileNotFoundException(path);
           if (DEBUG)
@@ -210,7 +215,11 @@ public class TestCEEvaluator extends UnitTestCommon {
 
       // generate the complete unconstrained data set
       file = new File(path);
-      ncfile = NetcdfDatasets.openFile(file.getPath(), null);
+      if (TestDir.cdmUseBuilders) {
+        ncfile = NetcdfDatasets.openFile(file.getPath(), null);
+      } else {
+        ncfile = NetcdfDataset.openFile(file.getPath(), null);
+      }
       if (ncfile == null)
         throw new FileNotFoundException(path);
       ds = new GuardedDatasetCacheAndClone(path, ncfile, false);

--- a/testUtil/src/main/java/ucar/unidata/util/test/UnitTestCommon.java
+++ b/testUtil/src/main/java/ucar/unidata/util/test/UnitTestCommon.java
@@ -1,11 +1,11 @@
 /*
+ * /*
  * Copyright 2012, UCAR/Unidata.
  * See the LICENSE file for more information.
  */
 
 package ucar.unidata.util.test;
 
-import org.junit.rules.TemporaryFolder;
 import ucar.httpservices.HTTPFactory;
 import ucar.httpservices.HTTPMethod;
 import ucar.nc2.NetcdfFile;
@@ -21,7 +21,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import ucar.nc2.dataset.NetcdfDatasets;
+
 
 abstract public class UnitTestCommon {
   //////////////////////////////////////////////////


### PR DESCRIPTION
This PR enables the TDS and its tests to configure whether or not the
new netCDF-Java API is used when reading data (that is, whether or not
it will use the new NetcdfFiles and NetcdfDatasets methods). If the
dataset being served by the TDS is on an object store, it will be
accessed via the new API, as that is the only choice.