### PR TITLE
Use special edal build

### DIFF
--- a/gradle/any/dependencies.gradle
+++ b/gradle/any/dependencies.gradle
@@ -42,9 +42,9 @@ repositories {
     }
 
     // edal-java SNAPSHOTS
-    maven {
-        url "https://oss.sonatype.org/content/repositories/snapshots"
-    }
+    //maven {
+    //    url "https://oss.sonatype.org/content/repositories/snapshots"
+    //}
 }
 
 //================================================ Dependencies ================================================//
@@ -274,7 +274,7 @@ libraries["oro"] = "oro:oro:2.0.8"
 
 libraries["thymeleaf-spring4"] = "org.thymeleaf:thymeleaf-spring4:3.0.11.RELEASE"
 
-versions["edal"] = "1.4.2"
+versions["edal"] = "1.4.2.1-SNAPSHOT"
 
 // needed for edal-common but this pulls in a newer version.
 libraries["ehcache"] = "net.sf.ehcache:ehcache:2.10.6"
@@ -287,7 +287,7 @@ libraries["edal-common"] = dependencies.create("uk.ac.rdg.resc:edal-common:${ver
 libraries["edal-cdm"] = dependencies.create("uk.ac.rdg.resc:edal-cdm:${versions["edal"]}") {
     // These are dependencies that are included in edal-cdm, but are provided by
     // us already, so we will exclude these from the edal-cdm artifact.
-    exclude group: 'edu.ucar', module: 'cdm'
+    exclude group: 'edu.ucar', module: 'cdm-core'
     exclude group: 'edu.ucar', module: 'udunits'
     exclude group: 'edu.ucar', module: 'netcdf4'
     exclude group: 'edu.ucar', module: 'grib'


### PR DESCRIPTION
Use a special set of edal-java artifacts which were recompiled against
5.4.0-SNAPSHOT and published on our nexus server. See

https://github.com/lesserwhirls/edal-java/tree/edal-1.4.2.1-unidata

Fixes Unidata/netcdf-java#313