### PR TITLE
Correct time_coverage_start attr for point test

### DIFF
--- a/tds/src/test/resources/thredds/server/ncss/view/dsg/point/netcdf3/outputAll.ncml
+++ b/tds/src/test/resources/thredds/server/ncss/view/dsg/point/netcdf3/outputAll.ncml
@@ -47,7 +47,7 @@
   <attribute name="Conventions" value="CF-1.6" />
   <attribute name="history" value="Written by CFPointWriter" />
   <attribute name="title" value="Extracted data from TDS Feature Collection file:C:\Users\cwardgar\dev\projects\thredds\tds\src\test\resources\thredds\server\ncss\view\dsg\point.ncml" />
-  <attribute name="time_coverage_start" value="1970-01-01T00:20:00Z" />
+  <attribute name="time_coverage_start" value="1970-01-01T00:00:00Z" />
   <attribute name="time_coverage_end" value="1970-01-01T04:40:00Z" />
   <attribute name="geospatial_lat_min" type="double" value="40.0" />
   <attribute name="geospatial_lat_max" type="double" value="68.0" />

--- a/tds/src/test/resources/thredds/server/ncss/view/dsg/point/netcdf3/outputSubset.ncml
+++ b/tds/src/test/resources/thredds/server/ncss/view/dsg/point/netcdf3/outputSubset.ncml
@@ -39,7 +39,7 @@
   <attribute name="Conventions" value="CF-1.6" />
   <attribute name="history" value="Written by CFPointWriter" />
   <attribute name="title" value="Extracted data from TDS Feature Collection file:C:\Users\cwardgar\dev\projects\thredds\tds\src\test\resources\thredds\server\ncss\view\dsg\point.ncml" />
-  <attribute name="time_coverage_start" value="1970-01-01T01:20:00Z" />
+  <attribute name="time_coverage_start" value="1970-01-01T01:00:00Z" />
   <attribute name="time_coverage_end" value="1970-01-01T02:00:00Z" />
   <attribute name="geospatial_lat_min" type="double" value="46.0" />
   <attribute name="geospatial_lat_max" type="double" value="52.0" />

--- a/tds/src/test/resources/thredds/server/ncss/view/dsg/point/netcdf4/outputAll.ncml
+++ b/tds/src/test/resources/thredds/server/ncss/view/dsg/point/netcdf4/outputAll.ncml
@@ -53,7 +53,7 @@
   <attribute name="Conventions" value="CF-1.6" />
   <attribute name="history" value="Written by CFPointWriter" />
   <attribute name="title" value="Extracted data from TDS Feature Collection file:C:\Users\cwardgar\dev\projects\thredds\tds\src\test\resources\thredds\server\ncss\view\dsg\point.ncml" />
-  <attribute name="time_coverage_start" value="1970-01-01T00:20:00Z" />
+  <attribute name="time_coverage_start" value="1970-01-01T00:00:00Z" />
   <attribute name="time_coverage_end" value="1970-01-01T04:40:00Z" />
   <attribute name="geospatial_lat_min" type="double" value="40.0" />
   <attribute name="geospatial_lat_max" type="double" value="68.0" />

--- a/tds/src/test/resources/thredds/server/ncss/view/dsg/point/netcdf4/outputSubset.ncml
+++ b/tds/src/test/resources/thredds/server/ncss/view/dsg/point/netcdf4/outputSubset.ncml
@@ -44,7 +44,7 @@
   <attribute name="Conventions" value="CF-1.6" />
   <attribute name="history" value="Written by CFPointWriter" />
   <attribute name="title" value="Extracted data from TDS Feature Collection file:C:\Users\cwardgar\dev\projects\thredds\tds\src\test\resources\thredds\server\ncss\view\dsg\point.ncml" />
-  <attribute name="time_coverage_start" value="1970-01-01T01:20:00Z" />
+  <attribute name="time_coverage_start" value="1970-01-01T01:00:00Z" />
   <attribute name="time_coverage_end" value="1970-01-01T02:00:00Z" />
   <attribute name="geospatial_lat_min" type="double" value="46.0" />
   <attribute name="geospatial_lat_max" type="double" value="52.0" />


### PR DESCRIPTION
The `time_coverage_start` global attribute in NcML files used by the DsgSubsetWriterTest do not have the correct value based on the data defined in the file. The new point writer in netCDF-Java will update the time_coverage_start/stop attrs based on what is actually written, and so these values must be correct in the first place or the tests will fail once Unidata/netcdf-java#319 is merged.