### PR TITLE
Fix HttpHeadFilter for large requests

### DIFF
--- a/tds/src/main/java/thredds/servlet/filter/HttpHeadFilter.java
+++ b/tds/src/main/java/thredds/servlet/filter/HttpHeadFilter.java
@@ -125,7 +125,7 @@ public class HttpHeadFilter implements Filter {
      * Sets the content length, based on what has been written to the outputstream so far.
      */
     void setContentLength() {
-      super.setContentLength(noBodyOutputStream.getContentLength());
+      super.setContentLengthLong(noBodyOutputStream.getContentLength());
     }
   }
 
@@ -136,12 +136,12 @@ public class HttpHeadFilter implements Filter {
     /**
      * The number of bytes written to this stream so far.
      */
-    private int contentLength = 0;
+    private long contentLength = 0;
 
     /**
      * @return The number of bytes written to this stream so far.
      */
-    int getContentLength() {
+    long getContentLength() {
       return contentLength;
     }
 

--- a/tds/src/main/webapp/WEB-INF/applicationContext.xml
+++ b/tds/src/main/webapp/WEB-INF/applicationContext.xml
@@ -42,6 +42,10 @@
            requestQueryFilterAllowAngleBrackets,
            requestCORSFilter,
            requestBracketingLogMessageFilter"/>
+                <security:filter-chain pattern="/fileServer/**" filters="
+           requestQueryFilter,
+           requestCORSFilter,
+           requestBracketingLogMessageFilter"/>
                 <security:filter-chain pattern="/**" filters="
            httpHeadFilter,
            requestQueryFilter,


### PR DESCRIPTION
Requests for large files (larger than 2GB) via the fileServer service
were getting an invalid content length assigned due to the
HttpHeadFilter using int instead of long. The fileServer controller sets
the correct content-length value, which gets overwritten by the filter.
This PR does two things:

1) Configure fileServer to bypass HttpHeadFilter (which fixes Unidata/tds#52)
2) Fix HttpHeadFilter to track response size using long instead of int.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidata/tds/112)
<!-- Reviewable:end -->
