### PR TITLE
Enable multiple notebooks in notebook service; update notebook docs

### DIFF
--- a/docs/src/public/userguide/pages/tds_tutorial/tds_configuration/CustomizingTdsLookAndFeel.md
+++ b/docs/src/public/userguide/pages/tds_tutorial/tds_configuration/CustomizingTdsLookAndFeel.md
@@ -1,5 +1,5 @@
 ---
-title: Customizing The TDS Look And Feel
+title: Customizing the TDS Look and Feel
 last_updated: 2020-08-24
 sidebar: tdsTutorial_sidebar
 toc: false
@@ -7,19 +7,21 @@ permalink: customizing_tds_look_and_feel.html
 ---
 
 TDS provides a extensible and customizable user interface using [Thymeleaf](https://www.thymeleaf.org/){:target="_blank"} Java template engine.
-The pages which currently support customization are:
+The HTML pages which currently support customization are:
  * Catalog
  * Dataset access
 
-UI customization can be implemented through the contribution of both CSS stylesheets and Thymeleaf HTML templates.
-Additionally, TDS administrators may register Jupyter Notebooks as dataset viewers using the Jupyter Notebook service.
+UI customization can be implemented through the contribution of [CSS stylesheets](customizing_tds_look_and_feel.html#css-stylesheets) 
+and [Thymeleaf HTML templates](customizing_tds_look_and_feel.html#thymeleaf-templates).
+To promote the accessibility and usability of dataset, TDS administrators may register Jupyter Notebooks as dataset viewers 
+using the [Jupyter Notebook service](customizing_tds_look_and_feel.html#jupyter-notebooks).
 
 ## CSS Stylesheets
 
-To customize TDS using CSS, custom CSS documents should be placed inside the `${tds.content.root.path}/thredds/public` directory.
+To customize the TDS using CSS, contributed CSS documents should be placed inside the `${tds.content.root.path}/thredds/public` directory.
 
-TDS is configured to use the CSS documents supplied in the `public` directory in `threddsConfig.xml`.
-There are three properties within the `htmlSetup` element used to define stylesheets:
+By default, the TDS is configured to use several CSS documents supplied in the `public` directory in `threddsConfig.xml`.
+There are four properties within the `htmlSetup` element used to define stylesheets:
 
 ~~~xml
 <htmlSetup>
@@ -30,28 +32,31 @@ There are three properties within the `htmlSetup` element used to define stylesh
 </htmlSetup>
 ~~~
 
-CSS documents given for `catalogCssUrl` and `datasetCssUrl` elements will be applied on the Catalog and Dataset
-access HTML pages, respectively.
-A CSS document supplied to `standardCssUrl` will be used in all generated HTML pages.
-The OPeNDAP HTML form is treated special -- the only CSS document applied to this page is defined by the `openDapCssUrl` element.
+To override HTML style default the TDS, replace any or all of the standard stylsheets with your own.
+Each property is responsible for style on a set of HTML pages:
+* `standardCssUrl`: styles are applied on all generated HTML pages (except the OPeNDAP HTML form)
+* `catalogCssUrl`: styles are applied only on Catalog HTML pages
+* `datasetCssUrl`: styles are applied only on Dataset access HTML pages
+* `openDapCssUrl`: styles are applied only on the OPeNDAP HTML form; unlike other pages, this is the only CSS document applied on the page
 
 ## Thymeleaf Templates
 
-When TDS is deployed, a `templates` directory is created within the main `content` directory (`tds.content.root.path`).
-The Thymeleaf template resolver used by TDS will search this directory for user-supplied template fragments each time
-a customizable HTML page is requested.
+When the TDS is deployed, a `templates` directory is created within the main `content` directory (`tds.content.root.path`).
+Each time a customizable HTML page is requested (Catalog or Dataset), the Thymeleaf template resolver will search this directory
+for user-supplied template fragments.
 
 Pages are customizable at plug-in points defined by the tag `ext:`, which instructs the template resolver to look for
-externally supplied template fragments. 
-Some of the plug-in points provide defaults when no user-supplied template is available (such as the main TDS header and footer, whereas other plug-in allow for additional content. 
+externally supplied template fragments.  
+Some of the plug-in points provide defaults when no user-supplied template is available (such as the main TDS header and footer, 
+whereas other plug-in allow for additional content. 
 See the [Thymeleaf documentation](https://www.thymeleaf.org/doc/articles/layouts.html){:target="_blank"} for an overview of natural templating using Thymeleaf and fragments. 
-A full list of current plug-in points for user-supplied fragments can be found in the following sections.
+A full list of currently supported plug-in points for user-supplied fragments can be found in the following sections.
 
-### Overwriting A Default
+### Overwriting a default
 
 To contribute a template fragment, place the `fragment` element in `templates/tdsTemplateFragments.html`.
 
-#### Example: Overwriting The Default Header
+#### Example: overwriting the default header
 
 Add the following to the 'template/tdsTemplateFragments.html' file:
 
@@ -60,20 +65,18 @@ Add the following to the 'template/tdsTemplateFragments.html' file:
 ~~~
 
 The templating system will automatically attach default TDS CSS properties to custom headers and footers.
-To avoid this behavior, users must provide their own overrides through custom stylesheets.
+To avoid this behavior, users must provide their own overrides through [custom stylesheets](customizing_tds_look_and_feel.html#css-stylesheets).
 
-Current default fragments which may be overridden are:
+Current default fragments which allow overrides are:
   * `header`
   * `footer`
 
-### Contributing Additional Content Sections
+### Contributing additional content sections
 
-Additional content sections may be contributed the same way as overridable defaults, but will only render as HTML element
-if a user-contributed template fragment is found.
+Users may contribute additional content sections the same way as overridable defaults; unlike sections with default content, i.e. headers and footers), 
+additional content sections are optional and will only render as HTML elements if a user-contributed template fragment exists.
 
-#### Example: Adding Content To The Bottom Of The Catalog
-
-
+#### Example: adding content to the bottom of the Catalog
 
 Add the following to the 'template/tdsTemplateFragments.html' file:
 
@@ -83,9 +86,9 @@ Add the following to the 'template/tdsTemplateFragments.html' file:
 </div>
 ~~~
 
-#### Example: Contributing Multiple Fragments
+#### Example: contributing multiple fragments
 
-Add the following to the 'template/tdsTemplateFragments.html' file:
+To add multiple fragments to a customizable section, add the following to the 'template/tdsTemplateFragments.html' file:
 
 ~~~html
 <div th:fragment="datasetCustomContentBottom">
@@ -101,19 +104,20 @@ And, in the `templates/additionalFragments/myFragments.html` file:
     <div th:fragment="mySectionContent" class="section-content">Your contributed content here.</div>
 ~~~
 
-We have defined our own fragments in a separate file, `myFragments.html`. 
-Fragments which correspond to a plug-in point, such as `catalogCustomContentTop` must be within the file `tdsTemplateFragments`, however the main fragments may reference paths to other template files by using the `ext:` tag.
+In the example above, we have defined our own fragments in a separate file, `myFragments.html`. 
+Fragments which correspond to a plug-in point, such as `catalogCustomContentTop` must be within the file `tdsTemplateFragments`, 
+however main fragments may reference paths to unlimited other template files by using the `ext:` tag.
 
-Note: The classes `section-header` and `section-content` apply the default TDS style for content panes.
+*Note:* The classes `section-header` and `section-content` apply the default TDS style for content panes.
 
-Current contributable sections are:
+Currently supported contributable sections are:
 
   * `catalogCustomContentTop` - additional content placed at the top of catalog pages.
   * `catalogCustomContentBottom` - additional content placed at the bottom of catalog pages.
   * `datasetCustomContentBottom` - additional content placed at the bottom of dataset access pages.
 
-### Contributing Additional Content Tabs
-Contributing tabbed content requires two fragments, one for the tab button and another for the content.
+### Contributing additional content tabs
+Contributing tabbed content requires two fragments, one for the *tab button* and another for the *content*.
 Each tab button must implement the click event handler `switchTab(buttonElement, contentElementId, groupId)`.
 
 #### Example
@@ -136,17 +140,16 @@ In the above example, the `tab-button` and `tab-content` classes apply the same 
 default tabs. 
 The `info` class groups the contributed tabs with the other tabs in the information tab pane.
 To group a contributed tab with the access tab pane, use the `access` class.
-Note: Multiple custom tabs may be contributed by grouping them within the fragment tags.
+*Note:* Multiple custom tabs may be contributed by grouping them within the fragment tags.
 
 Current contributable tabs are:
 
   * `customAccessTabButtons/customAccessTabContent` - adds tabs to the tab pane holding the "Access" and "Preview" views.
   * `customInfoTabButtons/customInfoTabContent` - adds tabs to the tab pane holding view with information about the dataset.
 
-### Using TDS Properties In Contributed Templates
+### Accessing TDS properties in custom templates
 Information from the server is passed to the templated pages through a data model. 
-The properties made available to
-the template parser are:
+The properties made available to the template parser are:
 
 ~~~java
 {
@@ -167,7 +170,8 @@ the template parser are:
 }
 ~~~
 
-Additionally, the catalog page is passed the properties `boolean rootCatalog`, which is set to `true` only on the top-level catalog page, and `List<CatalogItemContext> items`, a set of items in the Catalogdefined as `CatalogItemContext` data contracts:
+Additionally, the catalog page is passed the properties `boolean rootCatalog`, which is set to `true` only on the top-level catalog page, 
+and `List<CatalogItemContext> items`, a set of items in the Catalog defined as `CatalogItemContext` data contracts:
 
 ~~~java
 class CatalogItemContext {
@@ -215,7 +219,7 @@ class DatasetContext {
 
   List<Map<String, String>> getVariables();
 
-  String getVaraiableMapLink();
+  String getVariableMapLink();
 
   Map<String, Object> getGeospatialCoverage();
 
@@ -233,7 +237,7 @@ class DatasetContext {
 }
 ~~~
 
-#### Example: Dataset View
+#### Example: Dataset view
 
 Add a section to a dataset view which links to the host institution site and displays a table of all properties returned by `getAllContext()`.
 
@@ -253,28 +257,27 @@ Add the following to the 'template/tdsTemplateFragments.html' file:
 </div>
 ~~~
 
-### Adding TDS Properties To Templates
+### Contributing to the TDS: adding accessible properties
 
 Don't see what you're looking for?
 If the properties exposed to the template parser do not meet your needs, you are encouraged to update the above data models by submitting a pull request to
-[https://github.com/Unidata/thredds](https://github.com/Unidata/thredds){:target="_blank"}. 
+the [Unidata TDS GitHub repository](https://github.com/Unidata/tds){:target="_blank"}. 
 The data models are defined and populated in
-[`CatalogViewContextParser.java`](https://github.com/Unidata/thredds/blob/5.0.0/tds/src/main/java/thredds/server/catalogservice/CatalogViewContextParser.java){:target="_blank"}.
+[`CatalogViewContextParser.java`](https://github.com/Unidata/tds/blob/master/tds/src/main/java/thredds/server/catalogservice/CatalogViewContextParser.java){:target="_blank"}.
 
 ## Jupyter Notebooks
 
 ### About
-The goal of the Jupyter Notebook service is to provide an method of interacting with and visualizing TDS datasets without
+The goal of the *Jupyter Notebook service* is to provide a method of interacting with and visualizing TDS datasets without
 large data transfers. 
-When the Notebook service is enabled, requests to the service will return a Notebook (`ipynb` file) which demos accessing the requested dataset via [Siphon](https://unidata.github.io/siphon/latest/api/){:target="_blank"}. 
-Notebook files may be viewed in Jupyter Notebook or JupyterLab and edited by the end user to explore capabilities of the dataset and Siphon.
+When the Notebook service is enabled, the service provides a list of available Notebooks the demo access to requested dataset via [Siphon](https://unidata.github.io/siphon/latest/api/){:target="_blank"}. 
+The service returns requested Notebooks as `ipynb` files, which may be viewed in Jupyter Notebook or JupyterLab and edited by the end user to 
+explore capabilities of the dataset and Siphon.
+
+Read more about Jupyter Notebooks [here](https://jupyter-notebook.readthedocs.io/en/stable/).
 
 ### Enable/Disable Notebook Service
-By default, the Jupyter Notebook service is enabled. 
-If no contributed Notebook viewers are found, the TDS will supply a default viewer for accessing all datasets in the system. 
-This default can be found in `notebooks/jupyter_viewer.ipynb` in the content directory.
-
-To disable the Notebook service, add the following property to `threddsConfig.xml`:
+By default, the Jupyter Notebook service is enabled. To disable the Notebook service, add the following property to `threddsConfig.xml`:
 
 ~~~xml
   <JupyterNotebookService>
@@ -292,46 +295,98 @@ To configure the Notebook service, add the following properties to `threddsConfi
   </JupyterNotebookService>
 ~~~
 
-Where `<maxAge>` defines how long a mapping between a dataset and a Notebook should be stored after the last access, and `<maxFile>` defines the maximum number of mapping which can be stored at one time.
+Where `<maxAge>` defines how long a mapping between a dataset and a Notebook should be stored after the last access, and `<maxFiles>` defines the maximum number of mappings which can be stored at one time.
+The TDS provides some default Notebook viewers, which can be 
 
-### Contribute Notebooks
-  * To add a Notebook viewers to the TDS Notebook service, place `ipynb` files in the `notebooks` folder within the
-  content directory. 
-  (Note: To register new Notebook viewers, the server must be restarted with the new files in the
- notebook directory, TDS will not process new Notebooks while active.)
-  * To map a Notebook viewer to a subset of datasets, include the following in the Notebook's metadata:
+### Using the Notebooks Service
 
-~~~
-  "metadata": {
-  ...
-    "viewer_info": {
-      "accept_datasetIDs": [],
-      "accept_catalogs": [],
-      "accept_dataset_types": [],
-      "accept_all" : false,
-      "order": 1
-    }
-  }
-~~~
+#### Accessing Notebooks through a browser
 
-All `viewer_info` properties are optional. 
-Multiple properties may be used to register a single Notebook.
+All Notebooks viewers that are valid for a given dataset can be accessed though the Dataset HTML page under the "Preview" tab.
 
-* `accept_datasetIDs` - Accepts a list of dataset IDs for which the Notebook is valid.
-* `accept_catalogs` - Accepts a list of catalog names or URLs which contain datasets for which the Notebook is valid.
-* `accept_dataset_types`: Accepts a list of  feature types for which the Notebook is valid (e.g. Grid, Point).
-* `accept_all` - If true, indicates the Notebook is valid for all datasets.
-* `order` - In the case that more than one Notebook is valid for a given dataset, `order` will be used to determine
-which Notebook is returned.
+#### Accessing Notebooks via code
 
-If no `viewer_info` is included in the Notebook metadata, the following default will be supplied:
+Two public endpoints are available in the Notebook service:
+* Get all valid viewers for a dataset: {hostURL}/thredds/notebook/{datasetID}?catalog={catalogURL}
+    * e.g. https://mysite.edu/thredds/notebook/mydataset?catalog=catalog.xml
+* Download a selected viewer: {hostURL}/thredds/notebook/{datasetID}?catalog={catalogURL}&filename={filename}
+    * e.g. https://mysite.edu/thredds/notebook/mydataset?catalog=catalog.xml&filename=jupyter_viewer.ipynb
+
+### Custom Notebooks
+To add a Notebook viewers to the TDS Notebook service, place `ipynb` files in the `notebooks` folder within the content directory. 
+(*Note*: To register new Notebook viewers, the server must be restarted with the new files in the notebook directory, 
+TDS will not process new Notebooks while active.)
+
+Notebook viewer properties are set by adding a `viewer_info` property to the Notebooks metadata block:
 
 ~~~
   "metadata": {
   ...
     "viewer_info": {
-      "accept_all" : true,
-      "order": INT_MAX
+    ...
     }
   }
 ~~~
+
+The Notebook services checks for two viewer properties: `description` and `accepts`. The `description` property defines a plain-text
+description of the viewer, and defaults to an empty string if not present. The `accepts` property defines the set of datasets for which
+the viewer is valid and may include any or all of the following sub-properties:
+
+* `accept_datasetIDs`: Accepts a list of dataset IDs for which the Notebook is valid.
+* `accept_catalogs`: Accepts a list of catalog names or URLs which contain datasets for which the Notebook is valid.
+* `accept_dataset_types`: Accepts a list of  feature types for which the Notebook is valid (e.g. Grid, Point, Station).
+* `accept_all`: If true, indicates the Notebook is valid for all datasets.
+
+If no `accepts` properties are included in the Notebook metadata, the Notebook will default to `"accept_all": true`.
+
+#### Examples
+
+A Notebook configured for all datasets in the catalog `testCatalog`:
+~~~
+  "metadata": {
+  ...
+    "viewer_info": {
+        "description": "This Notebook displays all datasets in the test catalog.",
+        "accepts": {
+          "accept_catalogs": ["testCatalog"],
+        }
+    }
+  }
+~~~
+
+A Notebook configured for all gridded datasets and a dataset called `almostGridded`
+~~~
+  "metadata": {
+  ...
+    "viewer_info": {
+        "description": "This Notebook displays gridded data.",
+        "accepts": {
+          "accept_datasetIDs": ["almostGridded],
+          "accept_dataset_types": ["Grid"]
+        }
+    }
+  }
+~~~
+
+#### Suppressing default Notebooks
+
+To suppress default Notebooks, you can override them with a custom Notebook or a dummy Notebook, configured to not accept any datasets.
+
+For example, to suppress `default_viewer.ipynb`, place a file of the same name in the content directory with the following `viewer_info`:
+~~~
+  "metadata": {
+  ...
+    "viewer_info": {
+        "accepts": {
+          "accept_all": false
+        }
+    }
+  }
+~~~
+
+### Contributing default Notebooks
+
+You can contribute default Notebooks viewers to the TDS repository to highlight various types of datasets by submitting a pull request to
+the [Unidata TDS GitHub repository](https://github.com/Unidata/tds){:target="_blank"}.
+The default Notebooks live in the [`jupyter_notebooks`](https://github.com/Unidata/tds/tree/master/tds/src/main/webapp/WEB-INF/altContent/startup/jupyter_notebooks) directory.
+*NOTE:* Be sure to map your contributed Notebooks to the appropriate datasets by editing the Notebook's metadata, as described above.

--- a/tds/src/main/java/thredds/server/TdsErrorHandling.java
+++ b/tds/src/main/java/thredds/server/TdsErrorHandling.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.servlet.HandlerExceptionResolver;
 import org.springframework.web.servlet.ModelAndView;
+import thredds.server.exception.MethodNotImplementedException;
 import thredds.server.exception.RequestTooLargeException;
 import thredds.server.exception.ServiceNotAllowed;
 import thredds.server.ncss.exception.NcssException;
@@ -66,6 +67,16 @@ public class TdsErrorHandling implements HandlerExceptionResolver {
     responseHeaders.setContentType(MediaType.TEXT_PLAIN);
     return new ResponseEntity<>("Request Too Large: " + htmlEscape(ex.getMessage()), responseHeaders,
         HttpStatus.FORBIDDEN);
+  }
+
+  @ExceptionHandler(MethodNotImplementedException.class)
+  public ResponseEntity<String> handle(MethodNotImplementedException ex) {
+    logger.warn("TDS Error", ex);
+
+    HttpHeaders responseHeaders = new HttpHeaders();
+    responseHeaders.setContentType(MediaType.TEXT_PLAIN);
+    return new ResponseEntity<>("Method not implemented: " + htmlEscape(ex.getMessage()), responseHeaders,
+        HttpStatus.NOT_IMPLEMENTED);
   }
 
   @ExceptionHandler(FileNotFoundException.class)

--- a/tds/src/main/java/thredds/server/catalogservice/CatalogViewContextParser.java
+++ b/tds/src/main/java/thredds/server/catalogservice/CatalogViewContextParser.java
@@ -520,7 +520,11 @@ class DatasetContext {
       String datasetId = null;
 
       ServiceType stype = s.getType();
+      // Viewer services are listed as viewers
       if (stype != null) {
+        if (stype.getAccessType().equals(ServiceType.AccessType.DataViewer)) {
+          continue;
+        }
         switch (stype) {
           case OPENDAP:
           case DODS:
@@ -553,20 +557,6 @@ class DatasetContext {
                 catalogUrl = catalogUrl.substring(0, catalogUrl.lastIndexOf('#'));
               queryString = "catalog=" + catalogUrl + "&dataset=" + datasetId;
             }
-            break;
-
-          case JupyterNotebook:
-            datasetId = ds.getId();
-            catalogUrl = ds.getCatalogUrl();
-            if (catalogUrl.indexOf('#') > 0)
-              catalogUrl = catalogUrl.substring(0, catalogUrl.lastIndexOf('#'));
-            if (catalogUrl.indexOf(contentDir) > -1) {
-              catalogUrl = catalogUrl.substring(catalogUrl.indexOf(contentDir) + contentDir.length());
-            }
-            catalogUrl =
-                catalogUrl.substring(catalogUrl.indexOf("/catalog/") + ("/catalog/").length()).replace("html", "xml");
-            queryString = "catalog=" + catalogUrl;
-            urlString = urlString.substring(0, urlString.indexOf(s.getBase()) + s.getBase().length()) + datasetId;
             break;
 
           case NetcdfSubset:
@@ -892,10 +882,11 @@ class DatasetContext {
       Map<String, String> viewerMap = new HashMap<>();
       viewerMap.put("title", viewer.getTitle());
       viewerMap.put("href", viewer.getUrl());
+      viewerMap.put("description", viewer.getDescription());
+      viewerMap.put("type", viewer.getType());
       this.viewerLinks.add(viewerMap);
     }
   }
-
 }
 
 

--- a/tds/src/main/java/thredds/server/exception/MethodNotImplementedException.java
+++ b/tds/src/main/java/thredds/server/exception/MethodNotImplementedException.java
@@ -1,0 +1,9 @@
+package thredds.server.exception;
+
+public class MethodNotImplementedException extends RuntimeException {
+
+  public MethodNotImplementedException(String message) {
+    super(message);
+  }
+
+}

--- a/tds/src/main/java/thredds/server/notebook/JupyterNotebookServiceCache.java
+++ b/tds/src/main/java/thredds/server/notebook/JupyterNotebookServiceCache.java
@@ -8,12 +8,14 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import thredds.client.catalog.Dataset;
+import thredds.core.StandardService;
 import thredds.server.config.TdsContext;
+import thredds.server.viewer.ViewerService;
+
 import java.io.*;
 import java.time.Duration;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
+import java.util.stream.Collectors;
 
 @Component
 public class JupyterNotebookServiceCache {
@@ -23,23 +25,28 @@ public class JupyterNotebookServiceCache {
   @Autowired
   TdsContext tdsContext;
 
-  private List<NotebookMetadata> allNotebooks;
+  @Autowired
+  ViewerService viewerService;
 
-  private Cache<String, NotebookMetadata> notebookMappingCache;
+  private Set<NotebookMetadata> allNotebooks;
+
+  private Cache<String, Set<NotebookMetadata>> notebookMappingCache;
 
   public void init(int maxAge, int maxSize) {
-    this.allNotebooks = new ArrayList<>();
+    this.allNotebooks = new HashSet<>();
     this.notebookMappingCache =
         CacheBuilder.newBuilder().expireAfterAccess(Duration.ofSeconds(maxAge)).maximumSize(maxSize).build();
     buildNotebookList();
+    viewerService
+        .registerViewers(new JupyterNotebookViewerService(this, tdsContext.getContentRootPathProperty()).getViewers());
   }
 
-  public String getNotebookFilename(Dataset ds) {
+  public Set<NotebookMetadata> getMappedNotebooks(Dataset ds) {
     try {
-      NotebookMetadata nbmd = this.notebookMappingCache.get(ds.getID(), () -> {
+      Set<NotebookMetadata> nbmd = this.notebookMappingCache.get(ds.getID(), () -> {
         return getNotebookMapping(ds);
       });
-      return nbmd.filename;
+      return nbmd;
     } catch (Exception e) {
       logger.warn(e.getMessage());
       return null;
@@ -51,19 +58,13 @@ public class JupyterNotebookServiceCache {
     File notebooksDir = new File(tdsContext.getThreddsDirectory(), "notebooks");
     if (notebooksDir.exists() && notebooksDir.isDirectory()) {
 
-      File[] files = notebooksDir.listFiles(new FileFilter() {
-        @Override
-        public boolean accept(File pathname) {
-          return pathname.getName().endsWith(".ipynb");
-        }
-      });
+      File[] files = notebooksDir.listFiles(pathname -> pathname.getName().endsWith(".ipynb"));
 
       for (File notebookFile : files) {
-        NotebookMetadata nbMeta;
         try {
           NotebookMetadata nb = new NotebookMetadata(notebookFile);
           this.allNotebooks.add(nb);
-        } catch (InvalidJupyterNotebookException e) {
+        } catch (NotebookMetadata.InvalidJupyterNotebookException e) {
           logger.warn(e.getMessage());
           continue;
         } catch (FileNotFoundException e) {
@@ -74,214 +75,21 @@ public class JupyterNotebookServiceCache {
     }
   }
 
-  private NotebookMetadata getNotebookMapping(Dataset ds) {
-    NotebookMetadata bestMatch = null;
+  private Set<NotebookMetadata> getNotebookMapping(Dataset ds) {
+    Set<NotebookMetadata> matches = new HashSet<>();
     for (NotebookMetadata nbmd : this.allNotebooks) {
       if (nbmd.isValidForDataset(ds)) {
-        if (nbmd.compareNotebookForDataset(ds, bestMatch) > 0) {
-          bestMatch = nbmd;
-        }
+        matches.add(nbmd);
       }
     }
-    return bestMatch;
+    return matches;
   }
 
-  public List<NotebookMetadata> getAllNotebooks() {
+  public Set<NotebookMetadata> getAllNotebooks() {
     return this.allNotebooks;
   }
 
-  public Map<String, NotebookMetadata> getNotebookMapping() {
-    return this.notebookMappingCache.asMap();
-  }
-
-  private class NotebookMetadata {
-
-    public String filename;
-
-    public boolean accept_all;
-
-    public List<String> accept_datasetIDs;
-
-    public List<String> accept_catalogs;
-
-    public List<String> accept_dataset_types;
-
-    public int order;
-
-    public NotebookMetadata(File notebookFile) throws InvalidJupyterNotebookException, FileNotFoundException {
-      if (!notebookFile.exists()) {
-        throw new FileNotFoundException(notebookFile.getName());
-      }
-
-      JSONObject jobj = parseFile(notebookFile);
-      if (jobj == null) {
-        throw new InvalidJupyterNotebookException(
-            String.format("Notebook %s could not be parsed", notebookFile.getName()));
-      }
-
-      this.filename = notebookFile.getName();
-      this.accept_all = tryGetBoolJSON(NotebookMetadataKeys.acceptAll.key, jobj);
-      this.accept_datasetIDs = tryGetListFromJSON(NotebookMetadataKeys.acceptDatasetIDs.key, jobj);
-      this.accept_catalogs = tryGetListFromJSON(NotebookMetadataKeys.acceptCatalogs.key, jobj);
-      this.accept_dataset_types = tryGetListFromJSON(NotebookMetadataKeys.acceptDatasetTypes.key, jobj);
-      this.order = tryGetIntFromJSON(NotebookMetadataKeys.order.key, jobj);
-    }
-
-    public boolean isValidForDataset(Dataset ds) {
-
-      if (this.accept_all) {
-        return true;
-      }
-      if (this.accept_datasetIDs.contains(ds.getID())) {
-        return true;
-      }
-      if (this.accept_catalogs.contains(ds.getParentCatalog().getUriString())
-          || this.accept_catalogs.contains(ds.getParentCatalog().getName())) {
-        return true;
-      }
-      if (this.accept_dataset_types.contains(ds.getFeatureTypeName())) {
-        return true;
-      }
-
-      return false;
-    }
-
-    public int compareNotebookForDataset(Dataset ds, NotebookMetadata md) {
-      if (md == null) {
-        return 1;
-      }
-
-      // order
-      int tiebreaker = md.order - this.order;
-
-      // dataset id
-      String id = ds.getID();
-      if (this.accept_datasetIDs.contains(id) && md.accept_datasetIDs.contains(id)) {
-        return tiebreaker;
-      }
-      if (this.accept_datasetIDs.contains(id)) {
-        return 1;
-      }
-      if (md.accept_datasetIDs.contains(id)) {
-        return -1;
-      }
-
-      // catalogs
-      String catUrl = ds.getParentCatalog().getUriString();
-      String catName = ds.getParentCatalog().getName();
-      if ((this.accept_catalogs.contains(catUrl) || this.accept_catalogs.contains(catName))
-          && (md.accept_catalogs.contains(catUrl) || md.accept_catalogs.contains(catName))) {
-        return tiebreaker;
-      }
-      if (this.accept_catalogs.contains(catUrl) || this.accept_catalogs.contains(catName)) {
-        return 1;
-      }
-      if (md.accept_catalogs.contains(catUrl) || md.accept_catalogs.contains(catName)) {
-        return -1;
-      }
-
-      // data type
-      String dataType = ds.getFeatureTypeName();
-      if (this.accept_dataset_types.contains(dataType) && md.accept_dataset_types.contains(dataType)) {
-        return tiebreaker;
-      }
-      if (this.accept_dataset_types.contains(dataType)) {
-        return 1;
-      }
-      if (md.accept_dataset_types.contains(dataType)) {
-        return -1;
-      }
-
-      // accept all
-      if (this.accept_all && md.accept_all) {
-        return tiebreaker;
-      }
-      if (this.accept_all) {
-        return 1;
-      }
-      if (md.accept_all) {
-        return -1;
-      }
-
-      return 0;
-    }
-
-    private JSONObject parseFile(File notebookFile) {
-      InputStream is;
-      try {
-        is = new FileInputStream(notebookFile);
-      } catch (FileNotFoundException e) {
-        return null;
-      }
-
-      JSONTokener tokener = new JSONTokener(is);
-      JSONObject jobj;
-      try {
-        jobj = new JSONObject(tokener);
-        JSONObject metadata = jobj.getJSONObject("metadata");
-
-        try {
-          JSONObject viewerInfo = metadata.getJSONObject("viewer_info");
-          return viewerInfo;
-        } catch (JSONException e) {
-          return getDefaultViewerInfo();
-        }
-      } catch (JSONException e) {
-        return null;
-      }
-    }
-
-    private JSONObject getDefaultViewerInfo() {
-      JSONObject defaultInfo = new JSONObject();
-      defaultInfo.put(NotebookMetadataKeys.acceptAll.key, true);
-      return defaultInfo;
-    }
-
-    private boolean tryGetBoolJSON(String key, JSONObject jobj) {
-      try {
-        return jobj.getBoolean(key);
-      } catch (JSONException e) {
-        return false;
-      }
-    }
-
-    private List<String> tryGetListFromJSON(String key, JSONObject jobj) {
-      List<String> list = new ArrayList<>();
-      try {
-        JSONArray jArray = jobj.getJSONArray(key);
-        if (jArray != null)
-          for (int i = 0; i < jArray.length(); i++) {
-            list.add(jArray.getString(i));
-          }
-        return list;
-      } catch (JSONException e) {
-        return list;
-      }
-    }
-
-    private int tryGetIntFromJSON(String key, JSONObject jobj) {
-      try {
-        return jobj.getInt(key);
-      } catch (JSONException e) {
-        return Integer.MAX_VALUE;
-      }
-    }
-  }
-
-  private enum NotebookMetadataKeys {
-    acceptAll("accept_all"), acceptDatasetIDs("accept_datasetIDs"), acceptCatalogs(
-        "accept_catalogs"), acceptDatasetTypes("accept_dataset_types"), order("order");
-
-    final String key;
-
-    NotebookMetadataKeys(String key) {
-      this.key = key;
-    }
-  }
-
-  private class InvalidJupyterNotebookException extends Exception {
-    public InvalidJupyterNotebookException(String message) {
-      super(message);
-    }
-  }
+  // public Map<String, Set<NotebookMetadata>> getNotebookMapping() {
+  // return this.notebookMappingCache.asMap();
+  // }
 }

--- a/tds/src/main/java/thredds/server/notebook/JupyterNotebookViewerService.java
+++ b/tds/src/main/java/thredds/server/notebook/JupyterNotebookViewerService.java
@@ -1,9 +1,8 @@
 package thredds.server.notebook;
 
-import gov.noaa.pmel.sgt.MethodNotImplementedError;
+import thredds.server.exception.MethodNotImplementedException;
 import thredds.client.catalog.Dataset;
 import thredds.core.StandardService;
-import thredds.server.config.TdsContext;
 import thredds.server.viewer.Viewer;
 import thredds.server.viewer.ViewerLinkProvider;
 import thredds.server.viewer.ViewerService;
@@ -39,7 +38,7 @@ public class JupyterNotebookViewerService implements ViewerService {
 
   @Override
   public String getViewerTemplate(String template) {
-    throw new MethodNotImplementedError();
+    throw new MethodNotImplementedException("JupyterNotebookViewerService.getViewerTemplate is not implemented");
   }
 
   @Override
@@ -54,7 +53,7 @@ public class JupyterNotebookViewerService implements ViewerService {
 
   @Override
   public void showViewers(Formatter sbuff, Dataset dataset, HttpServletRequest req) {
-    throw new MethodNotImplementedError();
+    throw new MethodNotImplementedException("JupyterNotebookViewerService.showViewers is not implemented");
   }
 
   @Override

--- a/tds/src/main/java/thredds/server/notebook/JupyterNotebookViewerService.java
+++ b/tds/src/main/java/thredds/server/notebook/JupyterNotebookViewerService.java
@@ -101,8 +101,8 @@ public class JupyterNotebookViewerService implements ViewerService {
       catUrl =
           catUrl.substring(catUrl.indexOf(catalogServiceBase) + catalogServiceBase.length()).replace("html", "xml");
 
-      String url = req.getContextPath() + StandardService.jupyterNotebook.getBase()
-              + ds.getID() + "?catalog=" + catUrl + "&filename=" + notebook.getFilename();
+      String url = req.getContextPath() + StandardService.jupyterNotebook.getBase() + ds.getID() + "?catalog=" + catUrl
+          + "&filename=" + notebook.getFilename();
       return new ViewerLinkProvider.ViewerLink(notebook.getFilename(), url, notebook.getDescription(), type);
     }
   }

--- a/tds/src/main/java/thredds/server/notebook/JupyterNotebookViewerService.java
+++ b/tds/src/main/java/thredds/server/notebook/JupyterNotebookViewerService.java
@@ -1,0 +1,109 @@
+package thredds.server.notebook;
+
+import gov.noaa.pmel.sgt.MethodNotImplementedError;
+import thredds.client.catalog.Dataset;
+import thredds.core.StandardService;
+import thredds.server.config.TdsContext;
+import thredds.server.viewer.Viewer;
+import thredds.server.viewer.ViewerLinkProvider;
+import thredds.server.viewer.ViewerService;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.ArrayList;
+import java.util.Formatter;
+import java.util.List;
+
+public class JupyterNotebookViewerService implements ViewerService {
+
+  private JupyterNotebookServiceCache jupyterNotebooks;
+
+  private String contentDir;
+
+  private List<Viewer> viewers = new ArrayList<>();
+
+  public JupyterNotebookViewerService(JupyterNotebookServiceCache jupyterNotebooks, String contentDir) {
+    this.jupyterNotebooks = jupyterNotebooks;
+    this.contentDir = contentDir;
+    this.buildViewerList();
+  }
+
+  @Override
+  public List<Viewer> getViewers() {
+    return viewers;
+  }
+
+  @Override
+  public Viewer getViewer(String viewer) {
+    return null;
+  }
+
+  @Override
+  public String getViewerTemplate(String template) {
+    throw new MethodNotImplementedError();
+  }
+
+  @Override
+  public boolean registerViewer(Viewer v) {
+    return viewers.add(v);
+  }
+
+  @Override
+  public boolean registerViewers(List<Viewer> v) {
+    return viewers.addAll(v);
+  }
+
+  @Override
+  public void showViewers(Formatter sbuff, Dataset dataset, HttpServletRequest req) {
+    throw new MethodNotImplementedError();
+  }
+
+  @Override
+  public List<ViewerLinkProvider.ViewerLink> getViewerLinks(Dataset dataset, HttpServletRequest req) {
+    return null;
+  }
+
+  private void buildViewerList() {
+    jupyterNotebooks.getAllNotebooks()
+        .forEach(notebook -> registerViewer(new JupyterNotebookViewer(notebook, contentDir)));
+  }
+
+  public static class JupyterNotebookViewer implements Viewer {
+
+    private static final ViewerLinkProvider.ViewerLink.ViewerType type =
+        ViewerLinkProvider.ViewerLink.ViewerType.JupyterNotebook;
+
+    private String contentDir;
+
+    private NotebookMetadata notebook;
+
+    public JupyterNotebookViewer(NotebookMetadata notebook, String contentDir) {
+      this.notebook = notebook;
+      this.contentDir = contentDir;
+    }
+
+    public boolean isViewable(Dataset ds) {
+      return notebook.isValidForDataset(ds);
+    }
+
+    public String getViewerLinkHtml(Dataset ds, HttpServletRequest req) {
+      ViewerLinkProvider.ViewerLink viewerLink = this.getViewerLink(ds, req);
+      return "<a href='" + viewerLink.getUrl() + "'>" + viewerLink.getTitle() + "</a>";
+    }
+
+    public ViewerLinkProvider.ViewerLink getViewerLink(Dataset ds, HttpServletRequest req) {
+      String catUrl = ds.getCatalogUrl();
+      if (catUrl.indexOf('#') > 0)
+        catUrl = catUrl.substring(0, catUrl.lastIndexOf('#'));
+      if (catUrl.indexOf(contentDir) > -1) {
+        catUrl = catUrl.substring(catUrl.indexOf(contentDir) + contentDir.length());
+      }
+      String catalogServiceBase = StandardService.catalogRemote.getBase();
+      catUrl =
+          catUrl.substring(catUrl.indexOf(catalogServiceBase) + catalogServiceBase.length()).replace("html", "xml");
+
+      String url = req.getContextPath() + StandardService.jupyterNotebook.getBase()
+              + ds.getID() + "?catalog=" + catUrl + "&filename=" + notebook.getFilename();
+      return new ViewerLinkProvider.ViewerLink(notebook.getFilename(), url, notebook.getDescription(), type);
+    }
+  }
+}

--- a/tds/src/main/java/thredds/server/notebook/NotebookMetadata.java
+++ b/tds/src/main/java/thredds/server/notebook/NotebookMetadata.java
@@ -65,8 +65,7 @@ public class NotebookMetadata {
     JSONObject jobj;
     try {
       jobj = new JSONObject(tokener);
-      return jobj.getJSONObject(NotebookMetadataKeys.metadata.key)
-              .getJSONObject(NotebookMetadataKeys.viewerInfo.key);
+      return jobj.getJSONObject(NotebookMetadataKeys.metadata.key).getJSONObject(NotebookMetadataKeys.viewerInfo.key);
 
     } catch (JSONException e) {
       return null;

--- a/tds/src/main/java/thredds/server/notebook/NotebookMetadata.java
+++ b/tds/src/main/java/thredds/server/notebook/NotebookMetadata.java
@@ -1,0 +1,168 @@
+package thredds.server.notebook;
+
+import org.json.*;
+import thredds.client.catalog.Dataset;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+import java.util.HashSet;
+import java.util.Set;
+
+public class NotebookMetadata {
+
+  private String filename;
+
+  private AcceptedDatasetTypes acceptedDatasetTypes;
+
+  private String description;
+
+  private JSONObject params;
+
+  public NotebookMetadata(File notebookFile) throws InvalidJupyterNotebookException, FileNotFoundException {
+    if (!notebookFile.exists()) {
+      throw new FileNotFoundException(notebookFile.getName());
+    }
+
+    JSONObject jobj = parseFile(notebookFile);
+    if (jobj == null) {
+      throw new InvalidJupyterNotebookException(
+          String.format("Notebook %s could not be parsed", notebookFile.getName()));
+    }
+
+    this.filename = notebookFile.getName();
+    this.description = tryGetStringFromJSON(NotebookMetadataKeys.description.key, jobj);
+    this.acceptedDatasetTypes = new AcceptedDatasetTypes(jobj);
+    this.params = new JSONObject().put("filename", filename).put("description", description);
+  }
+
+  public boolean isValidForDataset(Dataset ds) {
+    return acceptedDatasetTypes.acceptsDataset(ds);
+  }
+
+  public JSONObject getParams() {
+    return params;
+  }
+
+  public String getFilename() {
+    return filename;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  private static JSONObject parseFile(File notebookFile) {
+    InputStream is;
+    try {
+      is = new FileInputStream(notebookFile);
+    } catch (FileNotFoundException e) {
+      return null;
+    }
+
+    JSONTokener tokener = new JSONTokener(is);
+    JSONObject jobj;
+    try {
+      jobj = new JSONObject(tokener);
+      return jobj.getJSONObject(NotebookMetadataKeys.metadata.key)
+              .getJSONObject(NotebookMetadataKeys.viewerInfo.key);
+
+    } catch (JSONException e) {
+      return null;
+    }
+  }
+
+  private static boolean tryGetBoolFromJSON(String key, JSONObject jobj) {
+    try {
+      return jobj.getBoolean(key);
+    } catch (JSONException e) {
+      return false;
+    }
+  }
+
+  private static String tryGetStringFromJSON(String key, JSONObject jobj) {
+    try {
+      return jobj.getString(key);
+    } catch (JSONException e) {
+      return "";
+    }
+  }
+
+  private static JSONObject tryGetJSONObjectFromJSON(String key, JSONObject jobj) {
+    try {
+      return jobj.getJSONObject(key);
+    } catch (JSONException e) {
+      return new JSONObject();
+    }
+  }
+
+  private static Set<String> tryGetSetFromJSON(String key, JSONObject jobj) {
+    Set<String> set = new HashSet<>();
+    try {
+      JSONArray jArray = jobj.getJSONArray(key);
+      if (jArray != null)
+        for (int i = 0; i < jArray.length(); i++) {
+          set.add(jArray.getString(i));
+        }
+      return set;
+    } catch (JSONException e) {
+      return set;
+    }
+  }
+
+  private class AcceptedDatasetTypes {
+
+    private boolean accept_all;
+
+    private Set<String> accept_datasetIDs;
+
+    private Set<String> accept_catalogs;
+
+    private Set<String> accept_dataset_types;
+
+    public AcceptedDatasetTypes(JSONObject nb) {
+      JSONObject jobj = tryGetJSONObjectFromJSON(NotebookMetadataKeys.acceptObject.key, nb);
+
+      this.accept_all = jobj.isEmpty() ? true : tryGetBoolFromJSON(NotebookMetadataKeys.acceptAll.key, jobj);
+      this.accept_datasetIDs = tryGetSetFromJSON(NotebookMetadataKeys.acceptDatasetIDs.key, jobj);
+      this.accept_catalogs = tryGetSetFromJSON(NotebookMetadataKeys.acceptCatalogs.key, jobj);
+      this.accept_dataset_types = tryGetSetFromJSON(NotebookMetadataKeys.acceptDatasetTypes.key, jobj);
+    }
+
+    public boolean acceptsDataset(Dataset ds) {
+      if (this.accept_all) {
+        return true;
+      }
+      if (this.accept_datasetIDs.contains(ds.getID())) {
+        return true;
+      }
+      if (this.accept_catalogs.contains(ds.getParentCatalog().getUriString())
+          || this.accept_catalogs.contains(ds.getParentCatalog().getName())) {
+        return true;
+      }
+      if (this.accept_dataset_types.contains(ds.getFeatureTypeName())) {
+        return true;
+      }
+      return false;
+    }
+  }
+
+  private enum NotebookMetadataKeys {
+    metadata("metadata"), viewerInfo("viewer_info"), description("description"), acceptObject("accepts"), acceptAll(
+        "accept_all"), acceptDatasetIDs(
+            "accept_datasetIDs"), acceptCatalogs("accept_catalogs"), acceptDatasetTypes("accept_dataset_types");
+
+    final String key;
+
+    NotebookMetadataKeys(String key) {
+      this.key = key;
+    }
+  }
+
+  class InvalidJupyterNotebookException extends Exception {
+    public InvalidJupyterNotebookException(String message) {
+      super(message);
+    }
+  }
+}

--- a/tds/src/main/java/thredds/server/viewer/ViewerLinkProvider.java
+++ b/tds/src/main/java/thredds/server/viewer/ViewerLinkProvider.java
@@ -32,10 +32,22 @@ public interface ViewerLinkProvider extends Viewer {
   class ViewerLink {
     private String title;
     private String url;
+    private String description;
+    private ViewerType type;
 
     public ViewerLink(String title, String url) {
+      this(title, url, "", ViewerType.Unknown);
+    }
+
+    public ViewerLink(String title, String url, String description) {
+      this(title, url, description, ViewerType.Unknown);
+    }
+
+    public ViewerLink(String title, String url, String description, ViewerType type) {
       this.title = title;
       this.url = url;
+      this.description = description;
+      this.type = type;
     }
 
     public String getTitle() {
@@ -44,6 +56,28 @@ public interface ViewerLinkProvider extends Viewer {
 
     public String getUrl() {
       return url;
+    }
+
+    public String getDescription() {
+      return description;
+    }
+
+    public String getType() {
+      return type.getName();
+    }
+
+    public static enum ViewerType {
+      Application("Application"), Browser("Browser"), JupyterNotebook("Jupyter Notebook"), Unknown("Unknown");
+
+      protected final String name;
+
+      private ViewerType(String name) {
+        this.name = name;
+      }
+
+      public String getName() {
+        return this.name;
+      }
     }
   }
 }

--- a/tds/src/main/java/thredds/server/viewer/ViewerService.java
+++ b/tds/src/main/java/thredds/server/viewer/ViewerService.java
@@ -20,6 +20,8 @@ public interface ViewerService {
 
   boolean registerViewer(Viewer v);
 
+  boolean registerViewers(List<Viewer> v);
+
   void showViewers(Formatter sbuff, Dataset dataset, HttpServletRequest req);
 
   List<ViewerLinkProvider.ViewerLink> getViewerLinks(Dataset dataset, HttpServletRequest req);

--- a/tds/src/main/java/thredds/server/viewer/ViewerServiceImpl.java
+++ b/tds/src/main/java/thredds/server/viewer/ViewerServiceImpl.java
@@ -5,11 +5,8 @@
 
 package thredds.server.viewer;
 
-import java.io.File;
-import java.io.FileFilter;
 import java.io.IOException;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Formatter;
@@ -19,14 +16,8 @@ import javax.servlet.http.HttpServletRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.InitializingBean;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import thredds.client.catalog.*;
-import thredds.core.AllowedServices;
-import thredds.core.StandardService;
-import thredds.server.config.TdsContext;
-import thredds.server.notebook.JupyterNotebookServiceCache;
-import ucar.nc2.constants.FeatureType;
 import ucar.nc2.util.IO;
 import ucar.unidata.util.StringUtil2;
 import thredds.server.wms.Godiva3Viewer;
@@ -41,15 +32,6 @@ public class ViewerServiceImpl implements ViewerService, InitializingBean {
 
   private List<Viewer> viewers = new ArrayList<>();
   private HashMap<String, String> templates = new HashMap<>();
-
-  @Autowired
-  private TdsContext tdsContext;
-
-  @Autowired
-  private JupyterNotebookServiceCache jupyterNotebooks;
-
-  @Autowired
-  private AllowedServices allowedServices;
 
   @Override
   public List<Viewer> getViewers() {
@@ -66,6 +48,11 @@ public class ViewerServiceImpl implements ViewerService, InitializingBean {
     return viewers.add(v);
   }
 
+  public boolean registerViewers(List<Viewer> v) {
+    return viewers.addAll(v);
+  }
+
+  @Deprecated
   @Override
   public String getViewerTemplate(String path) {
 
@@ -138,53 +125,9 @@ public class ViewerServiceImpl implements ViewerService, InitializingBean {
   public void afterPropertiesSet() {
     registerViewer(new Godiva3Viewer());
     registerViewer(new StaticView());
-    registerViewer(
-        new JupyterNotebookViewer(jupyterNotebooks, allowedServices, tdsContext.getContentRootPathProperty()));
   }
 
   // Viewers...
-
-  private static class JupyterNotebookViewer implements Viewer {
-    private static final String title = "Jupyter Notebook viewer";
-
-    private JupyterNotebookServiceCache jupyterNotebooks;
-
-    private AllowedServices allowedServices;
-
-    private String contentDir;
-
-    public JupyterNotebookViewer(JupyterNotebookServiceCache jupyterNotebooks, AllowedServices allowedServices,
-        String contentDir) {
-      this.jupyterNotebooks = jupyterNotebooks;
-      this.allowedServices = allowedServices;
-      this.contentDir = contentDir;
-    }
-
-    public boolean isViewable(Dataset ds) {
-      return this.allowedServices.isAllowed(StandardService.jupyterNotebook)
-          && jupyterNotebooks.getNotebookFilename(ds) != null;
-    }
-
-    public String getViewerLinkHtml(Dataset ds, HttpServletRequest req) {
-      ViewerLinkProvider.ViewerLink viewerLink = this.getViewerLink(ds, req);
-      return "<a href='" + viewerLink.getUrl() + "'>" + viewerLink.getTitle() + "</a>";
-    }
-
-    public ViewerLinkProvider.ViewerLink getViewerLink(Dataset ds, HttpServletRequest req) {
-      String catUrl = ds.getCatalogUrl();
-      if (catUrl.indexOf('#') > 0)
-        catUrl = catUrl.substring(0, catUrl.lastIndexOf('#'));
-      if (catUrl.indexOf(contentDir) > -1) {
-        catUrl = catUrl.substring(catUrl.indexOf(contentDir) + contentDir.length());
-      }
-      String catalogServiceBase = StandardService.catalogRemote.getBase();
-      catUrl =
-          catUrl.substring(catUrl.indexOf(catalogServiceBase) + catalogServiceBase.length()).replace("html", "xml");
-
-      String url = req.getContextPath() + StandardService.jupyterNotebook.getBase() + ds.getID() + "?catalog=" + catUrl;
-      return new ViewerLinkProvider.ViewerLink(JupyterNotebookViewer.title, url);
-    }
-  }
 
   // LOOK whats this for ??
   private static final String propertyNamePrefix = "viewer";

--- a/tds/src/main/java/thredds/server/wms/Godiva3Viewer.java
+++ b/tds/src/main/java/thredds/server/wms/Godiva3Viewer.java
@@ -52,7 +52,7 @@ import thredds.server.viewer.ViewerLinkProvider;
 public class Godiva3Viewer implements Viewer {
   static private final Logger logger = LoggerFactory.getLogger(Godiva3Viewer.class);
 
-  static private final String title = "Godiva3 (browser-based)";
+  static private final String title = "Godiva3";
 
   /**
    * Returns true if this is a gridded dataset that is accessible via WMS.
@@ -90,6 +90,7 @@ public class Godiva3Viewer implements Viewer {
       return null;
     }
     String url = req.getContextPath() + "/Godiva.html?server=" + dataURI.toString();
-    return new ViewerLinkProvider.ViewerLink(Godiva3Viewer.title, url);
+    return new ViewerLinkProvider.ViewerLink(Godiva3Viewer.title, url, "",
+        ViewerLinkProvider.ViewerLink.ViewerType.Browser);
   }
 }

--- a/tds/src/main/webapp/WEB-INF/altContent/startup/jupyter_notebooks/default_viewer.ipynb
+++ b/tds/src/main/webapp/WEB-INF/altContent/startup/jupyter_notebooks/default_viewer.ipynb
@@ -2,7 +2,10 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+      "description": "The TDS default viewer attempts to plot any Variable contained in the Dataset.",
+      "accepts": {}
+   },
    "source": [
     "<img src=\"https://unidata.ucar.edu/images/logos/badges/badge_unidata_100.jpg\" alt=\"Unidata Logo\" style=\"float: right; height: 98px;\">\n",
     "\n",

--- a/tds/src/main/webapp/WEB-INF/templates/datasetFragments.html
+++ b/tds/src/main/webapp/WEB-INF/templates/datasetFragments.html
@@ -168,11 +168,15 @@
 
     <div th:fragment="viewers" class="tab-content access" id="viewers">
         <h3>Viewers:</h3>
-        <ul>
-            <li th:each="link : ${dataset.getViewerLinks()}">
-                <a th:href="${link.get('href')}" th:text="${link.get('title')}"></a>
-            </li>
-        </ul>
+        <table class="property-table">
+            <tr><th>Viewer</th><th>Type</th><th>Description</th></tr>
+            <tr th:each="viewer : ${dataset.getViewerLinks()}">
+                <td><a th:href="${viewer.get('href')}">
+                    <b th:text="${viewer.get('title')}"></b></a></td>
+                <td th:if="${viewer.get('type') != null}" th:text="${viewer.get('type')}"/>
+                <td th:text="${viewer.get('description') == null ? '' : viewer.get('description')}"/>
+            </tr>
+        </table>
     </div>
 
 </body>


### PR DESCRIPTION
- Update notebook service to have 2 endpoint: get a list all notebooks for a given dataset, and get a specific notebook
- Update dataset HTML page to show all available notebooks
- Change JupyterNotebook access type to new "DataViewer" access and remove from Access tab (only in Viewers tab)
- Change JupyterNotebookViewer logic:
     - Each notebook has its own JupyterNotebookViewer
     - New JupyterNotebookViewerService registers a list of all JupyterNotebookViewers
- added a, optional description and a type to Viewer objects
TODO:
- include screenshots in docs
- add tests for notebook service

Depends on [netcdf-java#507](https://github.com/Unidata/netcdf-java/pull/507)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidata/tds/116)
<!-- Reviewable:end -->
