### PR TITLE
Readme

### DIFF
--- a/tds/src/freshInstallTest/groovy/thredds/tds/FreshTdsInstallSpec.groovy
+++ b/tds/src/freshInstallTest/groovy/thredds/tds/FreshTdsInstallSpec.groovy
@@ -38,6 +38,8 @@ class FreshTdsInstallSpec extends Specification {
         
         and: "it copied over the default startup files"
         // See TdsContext.afterPropertiesSet(), in the "Copy default startup files, if necessary" section.
+        new File(contentRootPath, "README.txt").exists()
+        new File(threddsDirectory, "README.txt").exists()
         new File(threddsDirectory, "catalog.xml").exists()
         new File(threddsDirectory, "enhancedCatalog.xml").exists()
         new File(new File(threddsDirectory, "public"), "testdata").exists()

--- a/tds/src/main/java/thredds/server/config/TdsContext.java
+++ b/tds/src/main/java/thredds/server/config/TdsContext.java
@@ -267,16 +267,14 @@ public final class TdsContext implements ServletContextAware, InitializingBean, 
       File rootDirReadMe = new File(contentRootDir, "README.txt");
       if (!rootDirReadMe.exists()) {
         File defaultRootDirReadMeFile = new File(startupContentDirectory, "root_README.txt");
-        logServerStartup.info("TdsContext.init(): Copying root README file from {}.",
-            defaultRootDirReadMeFile);
+        logServerStartup.info("TdsContext.init(): Copying root README file from {}.", defaultRootDirReadMeFile);
         IO.copyFile(defaultRootDirReadMeFile, rootDirReadMe);
       }
 
       File threddsDirReadMe = new File(threddsDirectory, "README.txt");
       if (!threddsDirReadMe.exists()) {
         File defaultThreddsDirReadMeFile = new File(startupContentDirectory, "thredds_README.txt");
-        logServerStartup.info("TdsContext.init(): Copying thredds README file from {}.",
-            defaultThreddsDirReadMeFile);
+        logServerStartup.info("TdsContext.init(): Copying thredds README file from {}.", defaultThreddsDirReadMeFile);
         IO.copyFile(defaultThreddsDirReadMeFile, threddsDirReadMe);
       }
 

--- a/tds/src/main/java/thredds/server/config/TdsContext.java
+++ b/tds/src/main/java/thredds/server/config/TdsContext.java
@@ -264,6 +264,22 @@ public final class TdsContext implements ServletContextAware, InitializingBean, 
     ////////////////////////////////
 
     try {
+      File rootDirReadMe = new File(contentRootDir, "README.txt");
+      if (!rootDirReadMe.exists()) {
+        File defaultRootDirReadMeFile = new File(startupContentDirectory, "root_README.txt");
+        logServerStartup.info("TdsContext.init(): Copying root README file from {}.",
+            defaultRootDirReadMeFile);
+        IO.copyFile(defaultRootDirReadMeFile, rootDirReadMe);
+      }
+
+      File threddsDirReadMe = new File(threddsDirectory, "README.txt");
+      if (!threddsDirReadMe.exists()) {
+        File defaultThreddsDirReadMeFile = new File(startupContentDirectory, "thredds_README.txt");
+        logServerStartup.info("TdsContext.init(): Copying thredds README file from {}.",
+            defaultThreddsDirReadMeFile);
+        IO.copyFile(defaultThreddsDirReadMeFile, threddsDirReadMe);
+      }
+
       File catalogFile = new File(threddsDirectory, "catalog.xml");
       if (!catalogFile.exists()) {
         File defaultCatalogFile = new File(startupContentDirectory, "catalog.xml");
@@ -320,6 +336,7 @@ public final class TdsContext implements ServletContextAware, InitializingBean, 
       logServerStartup.error("TdsContext.init(): " + message);
       throw new IllegalStateException(message, e);
     }
+
 
     //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     // logging

--- a/tds/src/main/webapp/WEB-INF/altContent/startup/root_README.txt
+++ b/tds/src/main/webapp/WEB-INF/altContent/startup/root_README.txt
@@ -1,0 +1,22 @@
+NAME:
+${tds.content.root.path}   (a.k.a., the TDS content directory)
+
+PURPOSE:
+All THREDDS Data Server configuration information is stored here.
+
+Due to the importance of this directory, it is a good idea to locate it somewhere separate from ${tomcat_home} on your
+file system. It needs to be persisted between Tomcat upgrades or TDS re-deployments.
+
+CONTENTS:
+This directory will contain the following subdirectories:
+
+  - thredds/    Contains THREDDS catalogs and TDS configuration files.
+  - tdm/        Will be present if the THREDDS Data Manager (TDM) is installed/used with the TDS.
+
+MORE INFORMATION:
+https://docs.unidata.ucar.edu/tds/current/userguide/tds_content_directory.html
+
+
+
+
+

--- a/tds/src/main/webapp/WEB-INF/altContent/startup/thredds_README.txt
+++ b/tds/src/main/webapp/WEB-INF/altContent/startup/thredds_README.txt
@@ -1,0 +1,28 @@
+NAME:
+${tds.content.root.path}/thredds/
+
+PURPOSE:
+Contains THREDDS catalogs and TDS configuration files. All TDS configuration, modifications, and additions should be
+made to the pertinent files in this directory.
+
+CONTENTS:
+This directory will contain the following subdirectories and files:
+
+  - cache/                Contains cashed TDS configuration information.
+  - catalog.xml           Main TDS client configuration file (a.k.a, the root catalog) used to serve data.
+  - enhancedCatalog.xml   Example client catalog file that comes with the TDS (referenced from catalog.xml).
+  - logs/                 TDS-generated log files are located within this directory.
+  - notebooks/            Contains public endpoint .ipynb files for the TDS Jupyter Notebook service.
+  - public/               Certain files in this directory are automatically mapped and served from the TDS context root.
+  - state/                Contains state information about the TDS configuration catalogs.
+  - templates/            User-supplied Thymeleaf HTML templates to customize the look and feel of your TDS server.
+  - threddsConfig.xml     Main TDS configuration file for allowing non-default services, configuring caching, etc.
+  - wmsConfig.xml         A configuration file for the THREDDS Web Mapping Service (WMS).
+
+MORE INFORMATION:
+https://docs.unidata.ucar.edu/tds/current/userguide/tds_content_directory.html
+
+
+
+
+

--- a/tds/src/main/webapp/WEB-INF/altContent/startup/thredds_README.txt
+++ b/tds/src/main/webapp/WEB-INF/altContent/startup/thredds_README.txt
@@ -8,9 +8,9 @@ made to the pertinent files in this directory.
 CONTENTS:
 This directory will contain the following subdirectories and files:
 
-  - cache/                Contains cashed TDS configuration information.
+  - cache/                Contains directories for temporary files and on-disk caches.
   - catalog.xml           Main TDS client configuration file (a.k.a, the root catalog) used to serve data.
-  - enhancedCatalog.xml   Example client catalog file that comes with the TDS (referenced from catalog.xml).
+  - enhancedCatalog.xml   Example configuration catalog, demonstrating advanced features (referenced from catalog.xml).
   - logs/                 TDS-generated log files are located within this directory.
   - notebooks/            Contains public endpoint .ipynb files for the TDS Jupyter Notebook service.
   - public/               Certain files in this directory are automatically mapped and served from the TDS context root.


### PR DESCRIPTION
Added simple (for now) README.txt files to these directories upon startup:

- ${tds.content.root.path}
- ${tds.content.root.path}/thredds/

We can flesh this out in more detail when we start to fine tune the docs.

Used provided code notation for file copies from startupContentDirectory to contentRootDir and threddsDirectory in TdsContext.java.  (E.g., no try with resources used.)

I thought that if we add more README files in the future, we could store the text for these files off in a single resource file somewhere (JSON, XML, or whatever) and write the contents to the README.txt files instead of copy/replace mechanism we are doing now.  That way, we have one place where can go if we want to modify the text of a README and we don't have to hunt all over the directory structure to find them.

@lesserwhirls, please have a look and let me know what changes in text and/or file locations (startupContentDirectory) you'd like.  Thanks!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidata/tds/119)
<!-- Reviewable:end -->
