### PR TITLE
Dependency and Gradle Upgrades

### DIFF
--- a/.github/workflows/tds.yml
+++ b/.github/workflows/tds.yml
@@ -24,8 +24,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # test against latest Adoptium LTS releases, and latest non-LTS version supported by gradle
-        java: [ 8, 11, 14 ]
+        # test against latest Adoptium LTS release, and latest non-LTS version supported by gradle
+        java: [ 11, 14 ]
         # test against both old and new netCDF-Java api
         ncjnewapi: ['false', 'true']
         # test against tomcat 8.5.x and tomcat 9.x

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
   // The buildscript {} block is odd: even though we applied dependencies.gradle above, the repositories therein
   // do not get included here. Instead, we must explicitly define the repos again. Yay for duplication.
   repositories {
-    jcenter()
+    gradlePluginPortal()
   }
 
   dependencies {
@@ -20,7 +20,6 @@ buildscript {
     classpath buildPlugins.sonarqube
     classpath buildPlugins.shadow
     classpath buildPlugins.spotless
-    classpath buildPlugins.grgit
     classpath buildPlugins.protobuf
     classpath buildPlugins.jruby
     classpath buildPlugins.depcheck
@@ -79,6 +78,11 @@ ext {
   // Will hold the list of projects that apply the java plugin
   // Used by :docs (javadoc tasks) and sonarqube
   javaProjects = []
+}
+
+tasks.named('wrapper') {
+  distributionType = Wrapper.DistributionType.ALL
+  gradleVersion = '6.8.3'
 }
 
 gradle.projectsEvaluated {

--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -6,8 +6,8 @@ plugins {
 }
 
 repositories {
-  jcenter()
-  mavenCentral()  // JCenter isn't quite a superset of Maven Central.
+  gradlePluginPortal()
+  mavenCentral()
 }
 
 dependencies {

--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -8,7 +8,7 @@ plugins {
 import com.github.jrubygradle.JRubyExec
 
 repositories {
-  jcenter()
+  mavenCentral()
   ruby.gems()
 }
 

--- a/gradle/any/dependencies.gradle
+++ b/gradle/any/dependencies.gradle
@@ -11,10 +11,7 @@ apply from: "$rootDir/gradle/any/shared-mvn-coords.gradle"
 //================================================ Repositories ================================================//
 
 repositories {
-  // Prefer JCenter to Maven Central. See
-  // https://blog.bintray.com/2015/02/09/android-studio-migration-from-maven-central-to-jcenter/
-  jcenter()
-  mavenCentral()  // JCenter isn't quite a superset of Maven Central.
+  mavenCentral()
 
   // chronicle-bom needs access to chronicle snapshots
   maven {

--- a/gradle/any/gretty.gradle
+++ b/gradle/any/gretty.gradle
@@ -5,7 +5,9 @@ buildscript {
   apply from: "$rootDir/gradle/any/shared-mvn-coords.gradle"
 
   repositories {
-    jcenter()
+    maven {
+      url 'https://plugins.gradle.org/m2/'
+    }
   }
   dependencies {
     classpath buildPlugins.gretty  // We want to import FarmBeforeIntegrationTestTask, etc.
@@ -15,6 +17,20 @@ buildscript {
 apply from: "$rootDir/gradle/any/properties.gradle"
 apply plugin: 'org.gretty'
 apply plugin: 'jacoco'
+
+// when applying the gretty buildScript to a project, make sure that project has access to the gradlePluginPortal
+// which is where the gretty tomcat runners live
+repositories {
+  exclusiveContent {
+    forRepository {
+      gradlePluginPortal()
+    }
+    // only look for unidata gretty related artifacts from the gradlePluginPortal
+    filter {
+      includeGroup 'org.gretty'
+    }
+  }
+}
 
 // allow servlet container to be configured by setting a system property
 // default to tomcat 8.5.x

--- a/gradle/any/java-internal.gradle
+++ b/gradle/any/java-internal.gradle
@@ -2,8 +2,8 @@ apply plugin: 'java'
 apply from: "$rootDir/gradle/any/spotless.gradle"
 
 java {
-  sourceCompatibility = JavaVersion.VERSION_1_8
-  targetCompatibility = JavaVersion.VERSION_1_8
+  sourceCompatibility = JavaVersion.VERSION_11
+  targetCompatibility = JavaVersion.VERSION_11
 }
 
 // Will apply to "compileJava", "compileTestJava", "compileSourceSetJava", etc.

--- a/gradle/any/shared-mvn-coords.gradle
+++ b/gradle/any/shared-mvn-coords.gradle
@@ -24,6 +24,7 @@ ext {
   depVersion.gwt = '2.8.2'
   depVersion.log4jWeb = '2.13.3'
   depVersion.jaxen = '1.1.6'
+  depVersion.netcdfJava = '5.4.2-SNAPSHOT'
   // gradle seems to have issues with the compileOnly configuration, so we need to provide the full maven
   // coordinates for javax.servlet-api if the gradle plugin in applied. If we don't, we see errors like this:
   depVersion.javaxServletApi = '3.1.0'

--- a/gradle/any/shared-mvn-coords.gradle
+++ b/gradle/any/shared-mvn-coords.gradle
@@ -9,7 +9,6 @@ ext {
   buildPlugins.shadow = 'com.github.jengelman.gradle.plugins:shadow:5.2.0'
   buildPlugins.sonarqube = 'org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:3.0'
   buildPlugins.spotless = 'com.diffplug.spotless:spotless-plugin-gradle:4.5.1'
-  buildPlugins.grgit = 'org.ajoberstar.grgit:grgit-core:4.0.2'
   buildPlugins.protobuf = 'com.google.protobuf:protobuf-gradle-plugin:0.8.12'
   buildPlugins.jruby = 'com.github.jruby-gradle:jruby-gradle-plugin:2.0.0'
   buildPlugins.depcheck = 'org.owasp:dependency-check-gradle:6.0.2'

--- a/gradle/root/coverage.gradle
+++ b/gradle/root/coverage.gradle
@@ -6,7 +6,7 @@ if (!name.equals(rootProject.name)) {
 // Execution failed for task ':jacocoMerge'.
 // > Could not resolve all files for configuration ':jacocoAnt'.
 repositories {
-  jcenter()
+  mavenCentral()
 }
 
 apply plugin: 'jacoco'

--- a/gradle/root/sonarqube.gradle
+++ b/gradle/root/sonarqube.gradle
@@ -1,24 +1,8 @@
-buildscript {
-  // Add the "buildPlugins" ExtraProperty. It should be usable from the rest of this script as well.
-  // See http://goo.gl/9bixNV
-  apply from: "$rootDir/gradle/any/shared-mvn-coords.gradle"
-
-  // The buildscript {} block is odd: even though we applied dependencies.gradle above, the repositories therein
-  // do not get included here. Instead, we must explicitly define the repos again. Yay for duplication.
-  repositories {
-    jcenter()
-  }
-
-  dependencies {
-    classpath buildPlugins.grgit
-  }
-}
+import java.nio.file.Paths
 
 if (!name.equals(rootProject.name)) {
   throw new GradleException("This script plugin should only be applied to the root project, not '$name'.")
 }
-
-import org.ajoberstar.grgit.Grgit
 
 // Effectively adds "sonarqube" extension to all projects.
 // Adds "sonarqube" task to only the root project. However, the task analyzes the root and all subprojects.
@@ -28,11 +12,10 @@ apply from: "$rootDir/gradle/any/properties.gradle"  // For SonarQube user token
 
 def branchName = 'unknown_branch'
 // If this is a git repo, grab the branch name to tag the sonarcloud analysis
-def folder = new File( "$rootDir/.git" )
-if( folder.exists() ) {
-  def grgit = Grgit.open(currentDir: project.rootDir)
-  branchName = grgit.branch.current.name
-  grgit.close()
+def headFile = Paths.get( "$rootDir", ".git", "HEAD" ).toFile()
+if(headFile.exists()) {
+  String head = headFile.getText('UTF-8')
+  branchName = head.split('refs/heads/').last()
 }
 
 gradle.projectsEvaluated {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.3-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/project-files/owasp-dependency-check/dependency-check-suppression.xml
+++ b/project-files/owasp-dependency-check/dependency-check-suppression.xml
@@ -16,14 +16,8 @@
     <packageUrl regex="true">^pkg:maven/net\.openhft/chronicle\-wire@.*$</packageUrl>
     <cve>CVE-2018-8909</cve>
     <cve>CVE-2020-15258</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-      file name: tds-5.0.0-SNAPSHOT.war: chronicle-wire-2.20.80.jar
-      reason: not a chronicle-wire vulnerability (Wire - Audio, Video, and Signaling (AVS) App).
-      ]]></notes>
-    <packageUrl regex="true">^pkg:maven/net\.openhft/chronicle\-wire@.*$</packageUrl>
     <cve>CVE-2020-27853</cve>
+    <cve>CVE-2021-21301</cve>
   </suppress>
   <suppress>
     <notes><![CDATA[
@@ -41,7 +35,7 @@
     <packageUrl regex="true">^pkg:maven/org\.codehaus\.jettison/jettison@.*$</packageUrl>
     <cve>CVE-2020-7712</cve>
   </suppress>
-  <suppress>
+  <!--suppress>
     <notes><![CDATA[
        file name: junit-4.13.1.jar
        reason: Fixed in junit-4.13.1 for applications running JDK 1.7 and later. We require Java 1.8
@@ -50,5 +44,17 @@
       ]]></notes>
     <packageUrl regex="true">^pkg:maven/junit/junit@.*$</packageUrl>
     <vulnerabilityName>CVE-2020-15250</vulnerabilityName>
+  </suppress-->
+  <suppress>
+    <notes><![CDATA[
+      file name example: taglibs-standard-impl-1.2.5.jar
+      reason: These CVEs are for a GO based project called tag (MP3/MP4/OGG/FLAC metadata parsing library).
+              False positive. See https://github.com/dhowden/tag/issues/77 (from first CVE listed)
+    ]]></notes>
+    <packageUrl regex="true">^pkg:maven/org\.apache\.taglibs/taglibs\-standard\-impl@.*$</packageUrl>
+    <cve>CVE-2020-29242</cve>
+    <cve>CVE-2020-29243</cve>
+    <cve>CVE-2020-29244</cve>
+    <cve>CVE-2020-29245</cve>
   </suppress>
 </suppressions>

--- a/tds-platform/build.gradle
+++ b/tds-platform/build.gradle
@@ -13,10 +13,10 @@ dependencies {
   // when resolving dependencies (even transitively)
   // If there is a conflict (previously hidden by optimistic resolution), we should get an error when we build, and
   // at that point we can take things on a case-by-case basis.
-  api enforcedPlatform('edu.ucar:netcdf-java-bom:5.4.0-SNAPSHOT')
-  api enforcedPlatform('org.springframework:spring-framework-bom:5.3.1')
-  api enforcedPlatform('org.springframework.security:spring-security-bom:5.4.1')
-  api platform('net.openhft:chronicle-bom:2.20.93')
+  api enforcedPlatform("edu.ucar:netcdf-java-bom:${depVersion.netcdfJava}")
+  api enforcedPlatform('org.springframework:spring-framework-bom:5.3.4')
+  api enforcedPlatform('org.springframework.security:spring-security-bom:5.4.5')
+  api platform('net.openhft:chronicle-bom:2.21ea74')
 
   constraints {
     // dependencies without explicit versions are getting their version set by one of the platforms above
@@ -79,7 +79,7 @@ dependencies {
     runtime "org.apache.logging.log4j:log4j-web:${depVersion.log4jWeb}"
 
     // reify
-    api 'org.apache.httpcomponents:httpcore:4.4.13'
+    api 'org.apache.httpcomponents:httpcore'
 
     // tds
     api 'org.json:json:20180813'
@@ -97,11 +97,12 @@ dependencies {
     api 'org.n52.sensorweb:52n-xml-om-v20'
 
     // edal-java (ncwms)
-    api 'uk.ac.rdg.resc:edal-common:1.4.2.1-SNAPSHOT'
-    api 'uk.ac.rdg.resc:edal-cdm:1.4.2.1-SNAPSHOT'
-    api 'uk.ac.rdg.resc:edal-wms:1.4.2.1-SNAPSHOT'
-    api 'uk.ac.rdg.resc:edal-graphics:1.4.2.1-SNAPSHOT'
-    api 'uk.ac.rdg.resc:edal-godiva:1.4.2.1-SNAPSHOT'
+    def edalVersion = '1.5.0'
+    api "uk.ac.rdg.resc:edal-common:${edalVersion}"
+    api "uk.ac.rdg.resc:edal-cdm:${edalVersion}"
+    api "uk.ac.rdg.resc:edal-wms:${edalVersion}"
+    api "uk.ac.rdg.resc:edal-graphics:${edalVersion}"
+    api "uk.ac.rdg.resc:edal-godiva:${edalVersion}"
 
     // gwt version defined in gradle/any/shared-mvn-coords.gradle, accessible via gradle/any/dependencies.gradle
     api "com.google.gwt:gwt-dev:${depVersion.gwt}"

--- a/tds-testing-platform/build.gradle
+++ b/tds-testing-platform/build.gradle
@@ -9,11 +9,16 @@ javaPlatform {
 }
 
 dependencies {
+  api enforcedPlatform("edu.ucar:netcdf-java-testing-platform:${depVersion.netcdfJava}")
   api enforcedPlatform(project(':tds-platform'))
+
   constraints {
 
     // Spring
-    api 'org.springframework:spring-test'
+    // Spring-test v5.3.4 introduced a hard dependency on servlet api v4.
+    // That will be rolled back in v5.4.5, so for now, we specifically ask for
+    // spring-test 5.3.3.
+    api 'org.springframework:spring-test:5.3.3'
 
     // opendap
     api 'org.apache.taglibs:taglibs-standard-spec'

--- a/tds/build.gradle
+++ b/tds/build.gradle
@@ -12,7 +12,7 @@ apply plugin: 'groovy'  // For FreshInstall Spock tests.
 
 dependencies {
   implementation enforcedPlatform (project(':tds-platform'))
-  compile enforcedPlatform (project(':tds-testing-platform'))
+  testCompile enforcedPlatform (project(':tds-testing-platform'))
 
   compile 'edu.ucar:bufr'
   compile 'edu.ucar:cdm-core'

--- a/testUtil/build.gradle
+++ b/testUtil/build.gradle
@@ -5,6 +5,7 @@ apply from: "$rootDir/gradle/any/dependencies.gradle"
 apply from: "$rootDir/gradle/any/java-internal.gradle"
 
 dependencies {
+    implementation enforcedPlatform(project(':tds-testing-platform'))
     implementation enforcedPlatform(project(':tds-platform'))
 
     implementation 'edu.ucar:cdm-core'


### PR DESCRIPTION
* Bump the following Bill of Materials versions:
  * netndf-java-bom (5.4.0-SNAPSHOT to 5.2.0-SNAPSHOT)
  * spring-framework-bom (5.3.1 to 5.3.4)
  * spring-security-bom (5.4.1 to 5.4.5)
  * chronicle-bom (2.20.93 to 2.21ea74)
* Utilize the netcdf-java-testing-platform for testing dependency
  management
* Suppress OWAPS dependency check false positives
* Move to edal-java 1.5.0
  * this forces the minimum required version of Java from 8 to 11.
* Upgrade to Gradle 6.8.3
* Migrate away from `jcenter`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidata/tds/123)
<!-- Reviewable:end -->
