### PR TITLE
Various Fixes

### DIFF
--- a/tdcommon/src/main/java/thredds/server/catalog/tracker/DatasetExtBytesMarshaller.java
+++ b/tdcommon/src/main/java/thredds/server/catalog/tracker/DatasetExtBytesMarshaller.java
@@ -1,0 +1,47 @@
+package thredds.server.catalog.tracker;
+
+import com.google.protobuf.InvalidProtocolBufferException;
+import net.openhft.chronicle.bytes.Bytes;
+import net.openhft.chronicle.core.util.ReadResolvable;
+import net.openhft.chronicle.hash.serialization.BytesReader;
+import net.openhft.chronicle.hash.serialization.BytesWriter;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class DatasetExtBytesMarshaller
+    implements BytesWriter<DatasetExt>, BytesReader<DatasetExt>, ReadResolvable<DatasetExtBytesMarshaller> {
+
+  static final DatasetExtBytesMarshaller INSTANCE = new DatasetExtBytesMarshaller();
+
+  private DatasetExtBytesMarshaller() {}
+
+  @Override
+  public @NotNull DatasetExtBytesMarshaller readResolve() {
+    return INSTANCE;
+  }
+
+  @NotNull
+  @Override
+  public DatasetExt read(Bytes in, @Nullable DatasetExt datasetExt) throws RuntimeException {
+    if (datasetExt == null) {
+      datasetExt = new DatasetExt();
+    }
+    int len = in.readInt();
+    byte[] b = new byte[len];
+    in.read(b);
+    try {
+      datasetExt.fromProtoBytes(b);
+    } catch (InvalidProtocolBufferException e) {
+      throw new RuntimeException("Cannot restore dataset from protobuf serialization", e);
+    }
+    return datasetExt;
+  }
+
+  @Override
+  public void write(Bytes out, @NotNull DatasetExt datasetExt) {
+    // to parts to write - size of protoBytes, then actual protoByte array
+    byte[] protoBytes = datasetExt.toProtoBytes();
+    out.writeInt(protoBytes.length);
+    out.write(protoBytes);
+  }
+}

--- a/tdcommon/src/main/java/thredds/server/catalog/tracker/DatasetTrackerChronicle.java
+++ b/tdcommon/src/main/java/thredds/server/catalog/tracker/DatasetTrackerChronicle.java
@@ -105,8 +105,9 @@ public class DatasetTrackerChronicle implements DatasetTracker {
   }
 
   private void open() throws IOException {
-    ChronicleMapBuilder<String, DatasetExt> builder = ChronicleMapBuilder.of(String.class, DatasetExt.class)
-        .averageValueSize(200).entries(maxDatasets).averageKeySize(averagePathLength).skipCloseOnExitHook(true);
+    ChronicleMapBuilder<String, DatasetExt> builder =
+        ChronicleMapBuilder.of(String.class, DatasetExt.class).averageValueSize(200).entries(maxDatasets)
+            .averageKeySize(averagePathLength).valueMarshaller(DatasetExtBytesMarshaller.INSTANCE);
     datasetMap = builder.createPersistedTo(dbFile);
     changed = false;
   }

--- a/tds-platform/build.gradle
+++ b/tds-platform/build.gradle
@@ -97,7 +97,7 @@ dependencies {
     api 'org.n52.sensorweb:52n-xml-om-v20'
 
     // edal-java (ncwms)
-    def edalVersion = '1.5.0'
+    def edalVersion = '1.5.0.1-SNAPSHOT'
     api "uk.ac.rdg.resc:edal-common:${edalVersion}"
     api "uk.ac.rdg.resc:edal-cdm:${edalVersion}"
     api "uk.ac.rdg.resc:edal-wms:${edalVersion}"

--- a/tds/build.gradle
+++ b/tds/build.gradle
@@ -165,7 +165,6 @@ war {
   }
 }
 
-
 import org.akhikhl.gretty.AppBeforeIntegrationTestTask
 import org.akhikhl.gretty.AppAfterIntegrationTestTask
 
@@ -345,4 +344,5 @@ configurations.all {
    */
   exclude group: 'stax', module: 'stax-api'
   exclude group: 'org.slf4j', module: 'slf4j-log4j12'
+  exclude group: 'net.openhft', module: 'chronicle-analytics'
 }

--- a/tds/build.gradle
+++ b/tds/build.gradle
@@ -70,21 +70,11 @@ dependencies {
   testCompile 'jaxen:jaxen'
 
   // edal ncwms related libs
-  compile('uk.ac.rdg.resc:edal-common') {
-    exclude group: 'org.slf4j', module: 'slf4j-log4j12'
-  }
-  compile ('uk.ac.rdg.resc:edal-cdm') {
-    exclude group: 'org.slf4j', module: 'slf4j-log4j12'
-  }
-  compile ('uk.ac.rdg.resc:edal-graphics') {
-    exclude group: 'org.slf4j', module: 'slf4j-log4j12'
-  }
-  compile ('uk.ac.rdg.resc:edal-wms') {
-    exclude group: 'org.slf4j', module: 'slf4j-log4j12'
-  }
-  compile('uk.ac.rdg.resc:edal-godiva') {
-    exclude group: 'org.slf4j', module: 'slf4j-log4j12'
-  }
+  compile('uk.ac.rdg.resc:edal-common')
+  compile ('uk.ac.rdg.resc:edal-cdm')
+  compile ('uk.ac.rdg.resc:edal-graphics')
+  compile ('uk.ac.rdg.resc:edal-wms')
+  compile('uk.ac.rdg.resc:edal-godiva')
 
   // threddsIso related libs
   runtime 'EDS:tds-plugin'
@@ -193,6 +183,7 @@ AppWarAfterIntegrationTest.mustRunAfter AppWarBeforeIntegrationTest
 gretty {
   httpPort = 8081
   contextPath = '/thredds'
+  jvmArgs = ['--illegal-access=permit', '--add-exports', 'java.base/jdk.internal.ref=ALL-UNNAMED']
 }
 
 ////////////////////////////////////// Godiva 3 //////////////////////////////////////
@@ -283,6 +274,8 @@ sourceSets {
 }
 
 task "before${taskName.capitalize()}"(type: AppBeforeIntegrationTestTask, group: 'gretty') {
+  // needs access to the war artifact
+  dependsOn assemble
   description = "Starts server before $taskName."
   inplace = false
   integrationTestTask taskName
@@ -351,4 +344,5 @@ configurations.all {
               ...
    */
   exclude group: 'stax', module: 'stax-api'
+  exclude group: 'org.slf4j', module: 'slf4j-log4j12'
 }

--- a/tds/src/main/java/thredds/server/config/TdsInit.java
+++ b/tds/src/main/java/thredds/server/config/TdsInit.java
@@ -307,6 +307,7 @@ public class TdsInit implements ApplicationListener<ContextRefreshedEvent>, Disp
     // how to choose the typical dataset ?
     String typicalDataset = ThreddsConfig.get("Aggregation.typicalDataset", "penultimate");
     Aggregation.setTypicalDatasetMode(typicalDataset);
+    ucar.nc2.internal.ncml.Aggregation.setTypicalDatasetMode(typicalDataset);
     startupLog.info("TdsInit: Aggregation.setTypicalDatasetMode= " + typicalDataset);
 
     ////////////////////////////////////////////////////////////////
@@ -334,10 +335,25 @@ public class TdsInit implements ApplicationListener<ContextRefreshedEvent>, Disp
         new File(tdsContext.getThreddsDirectory().getPath(), "/cache/agg/").getPath());
     scourSecs = ThreddsConfig.getSeconds("AggregationCache.scour", 24 * 60 * 60);
     maxAgeSecs = ThreddsConfig.getSeconds("AggregationCache.maxAge", 90 * 24 * 60 * 60);
+
+    // non-builder API
     DiskCache2 aggCache = new DiskCache2(dir, false, maxAgeSecs / 60, scourSecs / 60);
     String cachePathPolicy = ThreddsConfig.get("AggregationCache.cachePathPolicy", null);
     aggCache.setPolicy(cachePathPolicy);
     Aggregation.setPersistenceCache(aggCache);
+
+    // builder API
+    String dir2;
+    if (dir.endsWith("/") || dir.endsWith("\\\\")) {
+      String sep = dir.substring(dir.length());
+      dir2 = dir.substring(0, dir.length() - 1) + "New" + sep;
+    } else {
+      dir2 = dir + "New/";
+    }
+
+    DiskCache2 aggCache2 = new DiskCache2(dir2, false, maxAgeSecs / 60, scourSecs / 60);
+    aggCache2.setPolicy(cachePathPolicy);
+    ucar.nc2.internal.ncml.Aggregation.setPersistenceCache(aggCache2);
     startupLog.info("TdsInit: AggregationCache= " + dir + " scour = " + scourSecs + " maxAgeSecs = " + maxAgeSecs);
 
     /* 4.3.15: grib index file placement, using DiskCache2 */

--- a/tds/src/main/webapp/WEB-INF/spring-servlet.xml
+++ b/tds/src/main/webapp/WEB-INF/spring-servlet.xml
@@ -25,7 +25,7 @@
     <bean id="customTemplateResolver" class="thredds.server.views.TdsExtensibleTemplateResolver">
         <property name="prefix" value="/templates/"/>
         <property name="suffix" value=".html"/>
-        <property name="templateMode" value="HTML5"/>
+        <property name="templateMode" value="HTML"/>
         <property name="order" value="0"/>
         <property name="cacheable" value="false"/>
         <property name="characterEncoding" value="UTF-8"/>
@@ -34,7 +34,7 @@
     <bean id="defaultTemplateResolver" class="org.thymeleaf.spring5.templateresolver.SpringResourceTemplateResolver">
         <property name="prefix" value="/WEB-INF/"/>
         <property name="suffix" value=".html"/>
-        <property name="templateMode" value="HTML5"/>
+        <property name="templateMode" value="HTML"/>
         <property name="order" value="1"/>
         <property name="cacheable" value="false"/>
         <property name="characterEncoding" value="UTF-8"/>

--- a/tds/src/main/webapp/WEB-INF/web.xml
+++ b/tds/src/main/webapp/WEB-INF/web.xml
@@ -101,6 +101,14 @@
     <url-pattern>/wms/*</url-pattern>
   </servlet-mapping>
 
+  <listener>
+    <listener-class>org.h2.server.web.DbStarter</listener-class>
+  </listener>
+
+  <listener>
+    <listener-class>uk.ac.rdg.resc.edal.wms.WmsContextListener</listener-class>
+  </listener>
+
   <!-- end edal-wms servlet -->
 
   <!-- edal-wms screenshot servlet -->

--- a/tds/src/test/java/thredds/server/catalog/tracker/TestChronicleTracker.java
+++ b/tds/src/test/java/thredds/server/catalog/tracker/TestChronicleTracker.java
@@ -1,5 +1,5 @@
 /* Copyright */
-package thredds.server.catalog;
+package thredds.server.catalog.tracker;
 
 import net.openhft.chronicle.map.*;
 import org.jdom2.Element;
@@ -10,7 +10,8 @@ import thredds.client.catalog.CatalogRef;
 import thredds.client.catalog.Dataset;
 import thredds.client.catalog.tools.CatalogCrawler;
 import thredds.server.catalog.tracker.DatasetExt;
-import java.io.Externalizable;
+import thredds.server.catalog.tracker.DatasetExtBytesMarshaller;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -65,10 +66,10 @@ public class TestChronicleTracker {
 
       File file = new File(pathname);
 
-      ChronicleMapBuilder<String, Externalizable> builder =
-          ChronicleMapBuilder.of(String.class, Externalizable.class).averageValueSize(1000).entries(1000 * 1000);
+      ChronicleMapBuilder<String, DatasetExt> builder = ChronicleMapBuilder.of(String.class, DatasetExt.class)
+          .averageValueSize(1000).entries(1000 * 1000).valueMarshaller(DatasetExtBytesMarshaller.INSTANCE);
 
-      final ChronicleMap<String, Externalizable> map = builder.createPersistedTo(file);
+      final ChronicleMap<String, DatasetExt> map = builder.createPersistedTo(file);
 
       final int chunk = 10000;
       final int chunk10 = 100000;


### PR DESCRIPTION
* Use unidata snapshot of `edal-java`, which is compiled against `5.4.2` (base dependency is compiled against `5.3.3`).
* Use chronicle-map [custom serializers](https://github.com/OpenHFT/Chronicle-Map/blob/ea/docs/CM_Tutorial.adoc#custom-serializers) for persisting instead of relying on `Externalizable`.
* Make sure the new builder-based Aggregation code is configured to use a DiskCache and uses the same proto dataset as the now deprecated Aggregation code.
* Squash a few startup warning messages related to Thymeleaf (template mode) deprecation.
* Make only one slf4j binding makes it on the classpath, otherwise we lose control of logging.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidata/tds/132)
<!-- Reviewable:end -->
