### PR TITLE
Use new netCDF-java API

### DIFF
--- a/tds/src/main/java/thredds/core/DatasetManager.java
+++ b/tds/src/main/java/thredds/core/DatasetManager.java
@@ -85,7 +85,7 @@ public class DatasetManager implements InitializingBean {
 
   // controls whether or not we use the new builder api of netCDF-Java
   // note: will always use new stuff when accessing object stores
-  private boolean useNetcdfJavaBuilders = false;
+  private static final boolean useNetcdfJavaBuilders = true;
 
   @Override
   public void afterPropertiesSet() throws Exception {
@@ -102,10 +102,6 @@ public class DatasetManager implements InitializingBean {
       }
     }
     this.datasetTracker = datasetTracker;
-  }
-
-  public void setUseNetcdfJavaBuilders(boolean use) {
-    this.useNetcdfJavaBuilders = use;
   }
 
   public boolean useNetcdfJavaBuilders() {

--- a/tds/src/main/java/thredds/featurecollection/InvDatasetFcFmrc.java
+++ b/tds/src/main/java/thredds/featurecollection/InvDatasetFcFmrc.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998-2018 John Caron and University Corporation for Atmospheric Research/Unidata
+ * Copyright (c) 1998-2021 John Caron and University Corporation for Atmospheric Research/Unidata
  * See LICENSE for license information.
  */
 package thredds.featurecollection;
@@ -44,22 +44,22 @@ import java.util.*;
 
 @ThreadSafe
 public class InvDatasetFcFmrc extends InvDatasetFeatureCollection {
-  static private final Logger logger = org.slf4j.LoggerFactory.getLogger(InvDatasetFcFmrc.class);
+  private static final Logger logger = org.slf4j.LoggerFactory.getLogger(InvDatasetFcFmrc.class);
 
-  static private final String FMRC = "fmrc.ncd";
-  static private final String BEST = "best.ncd";
+  private static final String FMRC = "fmrc.ncd";
+  private static final String BEST = "best.ncd";
 
-  static private final String RUNS = "runs";
-  static private final String RUN_NAME = "RUN_";
-  static private final String RUN_TITLE = "Forecast Model Run";
+  private static final String RUNS = "runs";
+  private static final String RUN_NAME = "RUN_";
+  private static final String RUN_TITLE = "Forecast Model Run";
 
-  static private final String FORECAST = "forecast";
-  static private final String FORECAST_NAME = "ConstantForecast_";
-  static private final String FORECAST_TITLE = "Constant Forecast Date";
+  private static final String FORECAST = "forecast";
+  private static final String FORECAST_NAME = "ConstantForecast_";
+  private static final String FORECAST_TITLE = "Constant Forecast Date";
 
-  static private final String OFFSET = "offset";
-  static private final String OFFSET_NAME = "Offset_";
-  static private final String OFFSET_TITLE = "Constant Forecast Offset";
+  private static final String OFFSET = "offset";
+  private static final String OFFSET_NAME = "Offset_";
+  private static final String OFFSET_TITLE = "Constant Forecast Offset";
 
   //////////////////////////////////////////////////////////////////////////////
 

--- a/tds/src/main/java/thredds/featurecollection/InvDatasetFeatureCollection.java
+++ b/tds/src/main/java/thredds/featurecollection/InvDatasetFeatureCollection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998-2018 John Caron and University Corporation for Atmospheric Research/Unidata
+ * Copyright (c) 1998-2021 John Caron and University Corporation for Atmospheric Research/Unidata
  * See LICENSE for license information.
  */
 
@@ -50,33 +50,29 @@ import java.util.List;
 public abstract class InvDatasetFeatureCollection implements Closeable {
   private static org.slf4j.Logger logger = org.slf4j.LoggerFactory.getLogger(InvDatasetFeatureCollection.class);
 
-  static protected final String LATEST_DATASET_CATALOG = "latest.xml";
-  static protected final String VARIABLES = "?metadata=variableMap";
-  static protected final String FILES = "files";
+  protected static final String LATEST_DATASET_CATALOG = "latest.xml";
+  protected static final String VARIABLES = "?metadata=variableMap";
+  protected static final String FILES = "files";
+  protected static final boolean useNetcdfJavaBuilders = true;
 
   // can be changed
-  static protected AllowedServices allowedServices;
-  static protected String contextName = "/thredds"; // set by TdsInit
-  static protected boolean useNetcdfJavaBuilders = false;
+  protected static AllowedServices allowedServices;
+  protected static String contextName = "/thredds"; // set by TdsInit
 
   // cant use spring wiring because InvDatasetFeatureCollection not a spring component because depends on catalog config
-  static public void setContextName(String c) {
+  public static void setContextName(String c) {
     contextName = c;
   }
 
-  static public void setUseNetcdfJavaBuilders(boolean use) {
-    useNetcdfJavaBuilders = use;
-  }
-
-  static public void setAllowedServices(AllowedServices _allowedServices) {
+  public static void setAllowedServices(AllowedServices _allowedServices) {
     allowedServices = _allowedServices;
   }
 
-  static protected String buildCatalogServiceHref(String path) {
+  protected static String buildCatalogServiceHref(String path) {
     return contextName + "/catalog/" + path + "/catalog.xml";
   }
 
-  static public InvDatasetFeatureCollection factory(FeatureCollectionRef parent, FeatureCollectionConfig config) {
+  public static InvDatasetFeatureCollection factory(FeatureCollectionRef parent, FeatureCollectionConfig config) {
     InvDatasetFeatureCollection result;
     if (config.type == FeatureCollectionType.FMRC)
       result = new InvDatasetFcFmrc(parent, config);
@@ -256,7 +252,7 @@ public abstract class InvDatasetFeatureCollection implements Closeable {
   // for subclasses
 
   // localState is synched, may be directly changed
-  abstract protected void updateCollection(State localState, CollectionUpdateType force);
+  protected abstract void updateCollection(State localState, CollectionUpdateType force);
 
   ////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -377,9 +373,9 @@ public abstract class InvDatasetFeatureCollection implements Closeable {
    * @param catURI the base URI for the catalog to be made, used to resolve relative URLs.
    * @return containing catalog
    */
-  abstract public CatalogBuilder makeCatalog(String match, String orgPath, URI catURI) throws IOException;
+  public abstract CatalogBuilder makeCatalog(String match, String orgPath, URI catURI) throws IOException;
 
-  abstract protected DatasetBuilder makeDatasetTop(URI catURI, State localState) throws IOException;
+  protected abstract DatasetBuilder makeDatasetTop(URI catURI, State localState) throws IOException;
 
   /**
    * Make the containing catalog of this feature collection

--- a/tds/src/main/java/thredds/server/config/TdsInit.java
+++ b/tds/src/main/java/thredds/server/config/TdsInit.java
@@ -225,11 +225,6 @@ public class TdsInit implements ApplicationListener<ContextRefreshedEvent>, Disp
     // initialize the tds configuration beans
     tdsConfigMapper.init(tdsContext);
 
-    // use new builders in netCDF-Java (default - true)
-    useBuilders = ThreddsConfig.getBoolean("Experimental.useNetcdfJavaBuilders", true);
-
-    datasetManager.setUseNetcdfJavaBuilders(useBuilders);
-
     // prefer cdmRemote when available
     DataFactory.setPreferCdm(true);
     // netcdf-3 files can only grow, not have metadata changes
@@ -268,7 +263,6 @@ public class TdsInit implements ApplicationListener<ContextRefreshedEvent>, Disp
 
     allowedServices.finish(); // finish when we know everything is wired
     InvDatasetFeatureCollection.setAllowedServices(allowedServices);
-    InvDatasetFeatureCollection.setUseNetcdfJavaBuilders(useBuilders);
     DatasetScan.setSpecialServices(allowedServices.getStandardService(StandardService.resolver),
         allowedServices.getStandardService(StandardService.httpServer));
     DatasetScan.setAllowedServices(allowedServices);


### PR DESCRIPTION
No longer allow the use of the old API at runtime as a `threddsConfig.xml` option or Java systems property. Also, fix a few modifier order issues.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidata/tds/140)
<!-- Reviewable:end -->
