### PR TITLE
Fix service init sequence

### DIFF
--- a/tds/src/main/java/thredds/server/config/TdsUpdateConfigBean.java
+++ b/tds/src/main/java/thredds/server/config/TdsUpdateConfigBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998-2018 John Caron and University Corporation for Atmospheric Research/Unidata
+ * Copyright (c) 1998-2021 John Caron and University Corporation for Atmospheric Research/Unidata
  * See LICENSE for license information.
  */
 
@@ -61,7 +61,7 @@ public class TdsUpdateConfigBean {
     int connectionTimeout = 3; // http connection timeout in seconds
     Map<String, String> latestVersionInfo = new HashMap<>();
 
-    String versionUrl = "https://www.unidata.ucar.edu/software/tds/latest.xml";
+    String versionUrl = "https://downloads.unidata.ucar.edu/tds/startup/latest.xml";
     try {
       try (HTTPMethod method = HTTPFactory.Get(versionUrl)) {
         HTTPSession httpClient = method.getSession();


### PR DESCRIPTION
Make sure the OPeNDAP and WCS init sequence happens after threddsConfig.xml has been read. This issue was introduce after migrating to a new version of spring and was just now noticed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidata/tds/154)
<!-- Reviewable:end -->
