### PR TITLE
Fix missing OpenStreetMap attribution for NCSS maps

### DIFF
--- a/tds/src/main/webapp/js/ncss/ncssApp.js
+++ b/tds/src/main/webapp/js/ncss/ncssApp.js
@@ -18,6 +18,7 @@ function initMap(horizExtentWKT) {
     var controls = [
         new ol.control.Zoom(),
         new ol.control.Rotate(),
+        new ol.control.Attribution(),
         mousePositionControl
     ];
 


### PR DESCRIPTION
The NetCDF Subset Service pages show a map with an OpenStreetMap layer, but there is no attribution to credit OpenStreetMap :
https://www.openstreetmap.org/copyright/en

The map with OpenStreetMap credit : 
![image](https://user-images.githubusercontent.com/5621630/134773553-6f71d58b-58d8-4798-8ee9-cc23e9dd4c76.png)
![image](https://user-images.githubusercontent.com/5621630/134773570-86b16abd-7b90-41a1-9810-f55af6a7e483.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidata/tds/159)
<!-- Reviewable:end -->
