### PR TITLE
Upgrade to log4j 2.17.0

### DIFF
--- a/gradle/any/shared-mvn-coords.gradle
+++ b/gradle/any/shared-mvn-coords.gradle
@@ -22,14 +22,13 @@ ext {
   depVersion = [:]
   depVersion.slf4j = '1.7.28'
   depVersion.gwt = '2.8.2'
-  depVersion.log4jWeb = '2.16.0'
   depVersion.jaxen = '1.1.6'
   depVersion.netcdfJava = '5.4.2'
   // gradle seems to have issues with the compileOnly configuration, so we need to provide the full maven
   // coordinates for javax.servlet-api if the gradle plugin in applied. If we don't, we see errors like this:
   depVersion.javaxServletApi = '3.1.0'
   depVersion.hibernateValidator = '6.1.5.Final'
-  // TODO: figure out way to keep this verion in sync with netcdf-java version
+  // TODO: figure out way to keep this version in sync with netcdf-java version
   // It is included in the netcdf-java-bom (via netcdf-java-platform), but we can't
   // reference that version in a gradle build script (see gradle/any/protobuf.gradle)
   depVersion.protobuf = '3.12.4'

--- a/tds-platform/build.gradle
+++ b/tds-platform/build.gradle
@@ -17,6 +17,7 @@ dependencies {
   api enforcedPlatform('org.springframework:spring-framework-bom:5.3.12')
   api enforcedPlatform('org.springframework.security:spring-security-bom:5.4.7')
   api platform('net.openhft:chronicle-bom:2.21ea74')
+  api enforcedPlatform("org.apache.logging.log4j:log4j-bom:2.17.0")
 
   constraints {
     // dependencies without explicit versions are getting their version set by one of the platforms above
@@ -53,7 +54,7 @@ dependencies {
 
     // tds logging
     api 'org.slf4j:slf4j-api'
-    api 'org.apache.logging.log4j:log4j-slf4j-impl:2.16.0'
+    api 'org.apache.logging.log4j:log4j-slf4j-impl'
     runtime 'ch.qos.logback:logback-classic'
 
     // Spring
@@ -75,8 +76,8 @@ dependencies {
     api 'edu.ucar:d4core'
     api 'edu.ucar:d4lib'
     api 'edu.ucar:d4cdm'
-    // defined in tds-testing-platform as well, but using api config, that's why we need to reference depVersion
-    runtime "org.apache.logging.log4j:log4j-web:${depVersion.log4jWeb}"
+    // defined in tds-testing-platform as well, but using api config
+    runtime 'org.apache.logging.log4j:log4j-web'
 
     // reify
     api 'org.apache.httpcomponents:httpcore'

--- a/tds-testing-platform/build.gradle
+++ b/tds-testing-platform/build.gradle
@@ -25,8 +25,8 @@ dependencies {
     api 'org.apache.taglibs:taglibs-standard-impl'
 
     // dap4
-    // defined in tds-platform as well, but using runtime config, that's why we need to reference depVersion
-    api "org.apache.logging.log4j:log4j-web:${depVersion.log4jWeb}" // api because of :dap4:d4tests)
+    // defined in tds-platform as well, but using runtime config
+    api 'org.apache.logging.log4j:log4j-web' // api because of :dap4:d4tests)
 
     // threddsIso
     api 'EDS:tds-plugin:2.4.0-SNAPSHOT' // api because of :it


### PR DESCRIPTION
Use the log4j bom with enforcedPlatform in tds-platform project to allow us to define the log4j version in one spot while controlling transitive version resolution at the same time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidata/tds/183)
<!-- Reviewable:end -->
