### PR TITLE
[5.x] Udt 134933 s3 fileserver problems

### DIFF
--- a/tds-test-utils/src/main/java/thredds/test/util/TestOnLocalServer.java
+++ b/tds-test-utils/src/main/java/thredds/test/util/TestOnLocalServer.java
@@ -100,6 +100,10 @@ public class TestOnLocalServer {
   }
 
   public static byte[] getContent(Credentials cred, String endpoint, int[] expectCodes, String expectContentType) {
+    return getContent(cred, endpoint, expectCodes, expectContentType, null);
+  }
+
+  public static byte[] getContent(Credentials cred, String endpoint, int[] expectCodes, String expectContentType, long[] byteRange) {
     logger.debug("req = '{}'", endpoint);
 
     try (HTTPSession session = HTTPFactory.newSession(endpoint)) {
@@ -112,6 +116,10 @@ public class TestOnLocalServer {
       session.setCredentialsProvider(bcp);
 
       HTTPMethod method = HTTPFactory.Get(session);
+
+      if (byteRange != null)
+        method.setRange(byteRange[0], byteRange[1]);
+
       int statusCode = method.execute();
 
       if (expectCodes == null) {
@@ -127,7 +135,7 @@ public class TestOnLocalServer {
             ok);
       }
 
-      if (statusCode != 200) {
+      if (statusCode != 200 && statusCode != 206) {
         logger.warn("statusCode = {} '{}'", statusCode, method.getResponseAsString());
         return null;
       }

--- a/tds-test-utils/src/main/java/thredds/test/util/TestOnLocalServer.java
+++ b/tds-test-utils/src/main/java/thredds/test/util/TestOnLocalServer.java
@@ -103,7 +103,8 @@ public class TestOnLocalServer {
     return getContent(cred, endpoint, expectCodes, expectContentType, null);
   }
 
-  public static byte[] getContent(Credentials cred, String endpoint, int[] expectCodes, String expectContentType, long[] byteRange) {
+  public static byte[] getContent(Credentials cred, String endpoint, int[] expectCodes, String expectContentType,
+      long[] byteRange) {
     logger.debug("req = '{}'", endpoint);
 
     try (HTTPSession session = HTTPFactory.newSession(endpoint)) {

--- a/tds/src/integrationTests/java/thredds/server/fileserver/TestFileServer.java
+++ b/tds/src/integrationTests/java/thredds/server/fileserver/TestFileServer.java
@@ -43,9 +43,8 @@ public class TestFileServer {
     result.add(new Object[] {"fileServer/scanLocal/esfgTest.html", ContentType.html.toString()});
     result.add(new Object[] {"fileServer/testNAMfmrc/files/20060925_0600.nc", ContentType.netcdf.toString()});
 
-    // TODO UDT-134933
-    // result.add(new Object[] {"fileServer/s3-thredds-test-data/ncml/nc/namExtract/20060925_0600.nc",
-    // ContentType.netcdf.toString()});
+    result.add(new Object[] {"fileServer/s3-thredds-test-data/ncml/nc/namExtract/20060925_0600.nc",
+        ContentType.netcdf.toString()});
 
     // make sure files don't get removed
     result.add(

--- a/tds/src/integrationTests/java/thredds/server/fileserver/TestFileServer.java
+++ b/tds/src/integrationTests/java/thredds/server/fileserver/TestFileServer.java
@@ -4,6 +4,9 @@
  */
 package thredds.server.fileserver;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -16,6 +19,8 @@ import ucar.unidata.util.test.category.NeedsCdmUnitTest;
 import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.List;
+
+import static com.google.common.truth.Truth.assertThat;
 
 /**
  * Describe
@@ -34,36 +39,53 @@ public class TestFileServer {
 
     // TODO - Consider consolidating files and catalog.
     // Currently uses files from various locations and served through different catalog files.
-    result.add(new Object[] {"fileServer/scanLocal/point.covjson.json", ContentType.json.getContentHeader()});
+    result.add(new Object[] {"fileServer/scanLocal/point.covjson.json", ContentType.json.getContentHeader(),
+        "33fea472b71590b888e31870d745d71b"});
     result.add(new Object[] {"fileServer/rdaTest/ds094.2_dt/files/flxf01.gdas.A_PCP.SFC.01Z.grb2.gbx9",
-        ContentType.binary.toString()});
+        ContentType.binary.toString(), "f86072586ad8d66feed8cad2168f24a0"});
     result.add(new Object[] {"fileServer/testStationFeatureCollection/files/Surface_METAR_20060325_0000.nc",
-        ContentType.netcdf.toString()});
-    result.add(new Object[] {"fileServer/scanLocal/2004050312_eta_211.nc", ContentType.netcdf.toString()});
-    result.add(new Object[] {"fileServer/scanLocal/esfgTest.html", ContentType.html.toString()});
-    result.add(new Object[] {"fileServer/testNAMfmrc/files/20060925_0600.nc", ContentType.netcdf.toString()});
+        ContentType.netcdf.toString(), "4cc46253988cc9d1292f4fe4cd73f71f"});
+    result.add(new Object[] {"fileServer/scanLocal/2004050312_eta_211.nc", ContentType.netcdf.toString(),
+        "ed42786276bd33960e123941712d6ea4"});
+    result.add(new Object[] {"fileServer/scanLocal/esfgTest.html", ContentType.html.toString(),
+        "78e429e61fd0e605547ffcabd48178d0"});
+    result.add(new Object[] {"fileServer/testNAMfmrc/files/20060925_0600.nc", ContentType.netcdf.toString(),
+        "9bfc2f566b18851b02ee472f20be1acd"});
 
     result.add(new Object[] {"fileServer/s3-thredds-test-data/ncml/nc/namExtract/20060925_0600.nc",
-        ContentType.netcdf.toString()});
+        ContentType.netcdf.toString(), "9bfc2f566b18851b02ee472f20be1acd"});
 
     // make sure files don't get removed
-    result.add(
-        new Object[] {"fileServer/scanCdmUnitTests/formats/netcdf3/files/ctest0.nc", ContentType.netcdf.toString()});
+    result.add(new Object[] {"fileServer/scanCdmUnitTests/formats/netcdf3/files/ctest0.nc",
+        ContentType.netcdf.toString(), "4b514d280c034222e8e5b8401fee268c"});
 
     return result;
   }
 
   String path;
   String type;
+  String md5;
 
-  public TestFileServer(String path, String type) {
+  public TestFileServer(String path, String type, String md5) {
     this.path = path;
     this.type = type;
+    this.md5 = md5;
   }
 
   @Test
   public void downloadFile() {
     String endpoint = TestOnLocalServer.withHttpPath(path);
     TestOnLocalServer.getContent(endpoint, 200, type);
+  }
+
+  @Test
+  public void shouldHaveCorrectContent() throws IOException {
+    final String endpoint = TestOnLocalServer.withHttpPath(path);
+    final byte[] content = TestOnLocalServer.getContent(endpoint, 200);
+
+    try (InputStream is = new ByteArrayInputStream(content)) {
+      String observedMd5 = org.apache.commons.codec.digest.DigestUtils.md5Hex(is);
+      assertThat(observedMd5).isEqualTo(md5);
+    }
   }
 }

--- a/tds/src/integrationTests/java/thredds/server/fileserver/TestPartialContent.java
+++ b/tds/src/integrationTests/java/thredds/server/fileserver/TestPartialContent.java
@@ -41,7 +41,7 @@ public class TestPartialContent {
     final String endpoint = TestOnLocalServer.withHttpPath(path);
 
     final byte[] content = TestOnLocalServer.getContent(null, endpoint,
-        new int[]{HttpServletResponse.SC_PARTIAL_CONTENT}, contentType, byteRange);
+        new int[] {HttpServletResponse.SC_PARTIAL_CONTENT}, contentType, byteRange);
     assertThat(content).isNotNull();
 
     final long expectedLength = Math.min(byteRange[1] - byteRange[0] + 1, maxSize);

--- a/tds/src/integrationTests/java/thredds/server/fileserver/TestPartialContent.java
+++ b/tds/src/integrationTests/java/thredds/server/fileserver/TestPartialContent.java
@@ -35,8 +35,8 @@ public class TestPartialContent {
 
   @Test
   public void shouldReturnPartialContent() {
-    final String path = "fileServer/testNAMfmrc/files/20060925_0600.nc";
-    final long maxSize = 898948;
+    final String path = "fileServer/scanLocal/mydata1.nc";
+    final long maxSize = 66832;
     final String contentType = ContentType.netcdf.toString();
     final String endpoint = TestOnLocalServer.withHttpPath(path);
 

--- a/tds/src/integrationTests/java/thredds/server/fileserver/TestPartialContent.java
+++ b/tds/src/integrationTests/java/thredds/server/fileserver/TestPartialContent.java
@@ -1,0 +1,50 @@
+package thredds.server.fileserver;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.lang.invoke.MethodHandles;
+import java.util.ArrayList;
+import java.util.List;
+import javax.servlet.http.HttpServletResponse;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import thredds.test.util.TestOnLocalServer;
+import thredds.util.ContentType;
+
+@RunWith(Parameterized.class)
+public class TestPartialContent {
+  private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+  @Parameterized.Parameters(name = "{0}")
+  static public List<long[]> getTestParameters() {
+    final List<long[]> result = new ArrayList<>();
+
+    result.add(new long[] {0, 0});
+    result.add(new long[] {0, 1});
+    result.add(new long[] {42, 1000});
+    result.add(new long[] {0, 1000000000});
+
+    return result;
+  }
+
+  @Parameterized.Parameter()
+  public long[] byteRange;
+
+  @Test
+  public void shouldReturnPartialContent() {
+    final String path = "fileServer/testNAMfmrc/files/20060925_0600.nc";
+    final long maxSize = 898948;
+    final String contentType = ContentType.netcdf.toString();
+    final String endpoint = TestOnLocalServer.withHttpPath(path);
+
+    final byte[] content = TestOnLocalServer.getContent(null, endpoint,
+        new int[]{HttpServletResponse.SC_PARTIAL_CONTENT}, contentType, byteRange);
+    assertThat(content).isNotNull();
+
+    final long expectedLength = Math.min(byteRange[1] - byteRange[0] + 1, maxSize);
+    assertThat(content.length).isEqualTo(expectedLength);
+  }
+}

--- a/tds/src/main/java/thredds/server/fileserver/FileServerController.java
+++ b/tds/src/main/java/thredds/server/fileserver/FileServerController.java
@@ -5,8 +5,10 @@
 
 package thredds.server.fileserver;
 
+import javax.xml.crypto.Data;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
+import thredds.core.DatasetManager;
 import thredds.core.TdsRequestedDataset;
 import thredds.servlet.ServletUtil;
 import thredds.util.TdsPathUtils;
@@ -34,6 +36,13 @@ public class FileServerController {
 
     if (!TdsRequestedDataset.resourceControlOk(req, res, reqPath)) { // LOOK or process in TdsRequestedDataset.getFile
                                                                      // ??
+      return;
+    }
+
+    final String location = TdsRequestedDataset.getLocationFromRequestPath(reqPath);
+
+    if (DatasetManager.isLocationObjectStore(location)) {
+      ServletUtil.returnS3Object(req, res, reqPath);
       return;
     }
 

--- a/tds/src/main/java/thredds/server/fileserver/FileServerController.java
+++ b/tds/src/main/java/thredds/server/fileserver/FileServerController.java
@@ -5,17 +5,14 @@
 
 package thredds.server.fileserver;
 
-import javax.xml.crypto.Data;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
-import thredds.core.DatasetManager;
 import thredds.core.TdsRequestedDataset;
 import thredds.servlet.ServletUtil;
 import thredds.util.TdsPathUtils;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.io.File;
 import java.io.IOException;
 
 /**
@@ -39,28 +36,7 @@ public class FileServerController {
       return;
     }
 
-    final String location = TdsRequestedDataset.getLocationFromRequestPath(reqPath);
-
-    if (DatasetManager.isLocationObjectStore(location)) {
-      ServletUtil.returnS3Object(req, res, reqPath);
-      return;
-    }
-
-    File file = getFile(reqPath);
-    ServletUtil.returnFile(null, req, res, file, null);
-  }
-
-  private File getFile(String reqPath) {
-    if (reqPath == null)
-      return null;
-
-    File file = TdsRequestedDataset.getFile(reqPath);
-    if (file == null)
-      return null;
-    if (!file.exists())
-      return null;
-
-    return file;
+    ServletUtil.writeMFileToResponse(req, res, reqPath);
   }
 
 }

--- a/tds/src/main/java/thredds/servlet/ServletUtil.java
+++ b/tds/src/main/java/thredds/servlet/ServletUtil.java
@@ -267,6 +267,8 @@ public class ServletUtil {
    */
   public static void returnS3Object(HttpServletRequest request, HttpServletResponse response, String requestPath)
       throws IOException {
+    response.setContentType(getContentType(requestPath, request.getServletContext()));
+
     final NetcdfFile netcdfFile = TdsRequestedDataset.getNetcdfFile(request, response, requestPath);
     final String netcdfFileString = netcdfFile.toString();
     response.setContentLength(netcdfFileString.length());

--- a/tds/src/main/java/thredds/servlet/ServletUtil.java
+++ b/tds/src/main/java/thredds/servlet/ServletUtil.java
@@ -6,6 +6,7 @@
 package thredds.servlet;
 
 import java.nio.charset.StandardCharsets;
+import javax.servlet.ServletContext;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -127,9 +128,13 @@ public class ServletUtil {
     // Set the type of the file
     String filename = file.getPath();
 
+    contentType = contentType == null ? getContentType(filename, req.getServletContext()) : contentType;
+    returnFile(req, res, file, contentType);
+  }
+
+  private static String getContentType(String filename, ServletContext servletContext) {
     // Check for server configured (well-known) content-type
-    if (contentType == null)
-      contentType = req.getServletContext().getMimeType(filename);
+    String contentType = servletContext.getMimeType(filename);
 
     // If not, check for a TDS known content-type
     if (contentType == null) {
@@ -141,7 +146,7 @@ public class ServletUtil {
         contentType = ContentType.binary.getContentHeader();
     }
 
-    returnFile(req, res, file, contentType);
+    return contentType;
   }
 
   /**

--- a/tds/src/main/java/thredds/servlet/ServletUtil.java
+++ b/tds/src/main/java/thredds/servlet/ServletUtil.java
@@ -6,9 +6,14 @@
 package thredds.servlet;
 
 import java.nio.charset.StandardCharsets;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import thredds.core.ConfigCatalogHtmlWriter;
+import thredds.core.TdsRequestedDataset;
 import thredds.util.ContentType;
 import thredds.util.RequestForwardUtils;
+import ucar.nc2.NetcdfFile;
 import ucar.nc2.util.EscapeStrings;
 import ucar.nc2.util.IO;
 import ucar.unidata.io.RandomAccessFile;
@@ -245,6 +250,24 @@ public class ServletUtil {
       if (!res.isCommitted())
         res.sendError(HttpServletResponse.SC_NOT_FOUND, "Problem sending file: " + e.getMessage());
     }
+  }
+
+  /**
+   * Write an s3 object as a file to the response stream.
+   *
+   * @param request the HttpServletRequest
+   * @param response the HttpServletResponse
+   * @param requestPath the s3 path
+   * @throws IOException if an I/O error occurs while writing the response.
+   */
+  public static void returnS3Object(HttpServletRequest request, HttpServletResponse response, String requestPath)
+      throws IOException {
+    final NetcdfFile netcdfFile = TdsRequestedDataset.getNetcdfFile(request, response, requestPath);
+    final String netcdfFileString = netcdfFile.toString();
+    response.setContentLength(netcdfFileString.length());
+
+    ServletOutputStream outputStream = response.getOutputStream();
+    IO.writeContents(netcdfFileString, outputStream);
   }
 
   /**

--- a/tds/src/main/java/thredds/servlet/ServletUtil.java
+++ b/tds/src/main/java/thredds/servlet/ServletUtil.java
@@ -240,7 +240,7 @@ public class ServletUtil {
 
   private static boolean isRangeRequest(String rangeRequest) {
     if (rangeRequest != null) { // bytes=12-34 or bytes=12-
-        return rangeRequest.indexOf("=") > 0 && rangeRequest.indexOf("-") > 0;
+      return rangeRequest.indexOf("=") > 0 && rangeRequest.indexOf("-") > 0;
     }
 
     return false;


### PR DESCRIPTION
- For fileserver, use `MFile:writeToStream` to write both files and s3 objects to response (see [netcd-java PR](https://github.com/Unidata/netcdf-java/pull/988))
- Refactoring of `ServletUtil:returnFile` to pull out common code for use in `writeMFileToResponse` function
- Unignore s3 fileserver test
- Update fileserver tests to check md5 of file downloaded
- Add tests for partial content and head

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidata/tds/208)
<!-- Reviewable:end -->
