### PR TITLE
[5.x] Fix context problem

### DIFF
--- a/tdcommon/src/main/java/thredds/server/catalog/ConfigCatalogCache.java
+++ b/tdcommon/src/main/java/thredds/server/catalog/ConfigCatalogCache.java
@@ -50,7 +50,7 @@ public class ConfigCatalogCache implements CatalogReader {
         // .removalListener(MY_LISTENER)
         .build(new CacheLoader<String, ConfigCatalog>() {
           public ConfigCatalog load(String key) throws IOException {
-            return readCatalog(key);
+            return readCatalog(key, context);
           }
         });
 
@@ -83,7 +83,7 @@ public class ConfigCatalogCache implements CatalogReader {
       return get(catKey);
     }
 
-    return readCatalog(catalogFullPath);
+    return readCatalog(catalogFullPath, context);
   }
 
 
@@ -99,7 +99,7 @@ public class ConfigCatalogCache implements CatalogReader {
        * }
        */
 
-      return cache.get(catKey, () -> readCatalog(rootPath + catKey));
+      return cache.get(catKey, () -> readCatalog(rootPath + catKey, context));
 
     } catch (ExecutionException e) {
       Throwable c = e.getCause();
@@ -109,7 +109,12 @@ public class ConfigCatalogCache implements CatalogReader {
     }
   }
 
-  public ConfigCatalog readCatalog(String catalogFullPath) throws IOException {
+  static public ConfigCatalog readCatalog(String catalogFullPath) throws IOException {
+    final String defaultContext = "thredds";
+    return readCatalog(catalogFullPath, defaultContext);
+  }
+
+  static public ConfigCatalog readCatalog(String catalogFullPath, String context) throws IOException {
 
     // see if it exists
     File catFile = new File(catalogFullPath);
@@ -127,7 +132,7 @@ public class ConfigCatalogCache implements CatalogReader {
       return null;
     }
 
-    ConfigCatalogBuilder builder = new ConfigCatalogBuilder(this.context);
+    ConfigCatalogBuilder builder = new ConfigCatalogBuilder(context);
     ConfigCatalog cat = (ConfigCatalog) builder.buildFromURI(uri); // LOOK use file and keep lastModified
     if (builder.hasFatalError()) {
       throw new IOException("invalid catalog " + catalogFullPath);

--- a/tdcommon/src/main/java/thredds/server/catalog/ConfigCatalogCache.java
+++ b/tdcommon/src/main/java/thredds/server/catalog/ConfigCatalogCache.java
@@ -9,7 +9,6 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.context.annotation.DependsOn;
 import org.springframework.stereotype.Component;
 import thredds.server.catalog.builder.ConfigCatalogBuilder;
 import ucar.unidata.util.StringUtil2;
@@ -29,7 +28,6 @@ import java.util.concurrent.ExecutionException;
  * @since 3/21/2015
  */
 @Component
-@DependsOn("TdsContext")
 public class ConfigCatalogCache implements CatalogReader {
   static private final Logger logger = LoggerFactory.getLogger(ConfigCatalogCache.class);
   static private final String ERROR = "*** ERROR ";

--- a/tdcommon/src/main/java/thredds/server/catalog/ConfigCatalogCache.java
+++ b/tdcommon/src/main/java/thredds/server/catalog/ConfigCatalogCache.java
@@ -34,6 +34,8 @@ public class ConfigCatalogCache implements CatalogReader {
   static private final Logger logger = LoggerFactory.getLogger(ConfigCatalogCache.class);
   static private final String ERROR = "*** ERROR ";
 
+  private String context;
+
   private String rootPath;
   private Cache<String, ConfigCatalog> cache;
 
@@ -44,7 +46,7 @@ public class ConfigCatalogCache implements CatalogReader {
     this.cache = CacheBuilder.newBuilder().maximumSize(maxSize).recordStats().build();
   }
 
-  public void init(String rootPath, int maxSize) {
+  public void init(String rootPath, int maxSize, String context) {
     this.rootPath = rootPath;
     this.cache = CacheBuilder.newBuilder().maximumSize(maxSize).recordStats()
         // .removalListener(MY_LISTENER)
@@ -53,6 +55,8 @@ public class ConfigCatalogCache implements CatalogReader {
             return readCatalog(key);
           }
         });
+
+    this.context = context;
   }
 
   public void put(String catKey, ConfigCatalog cat) throws IOException {
@@ -107,7 +111,7 @@ public class ConfigCatalogCache implements CatalogReader {
     }
   }
 
-  static public ConfigCatalog readCatalog(String catalogFullPath) throws IOException {
+  public ConfigCatalog readCatalog(String catalogFullPath) throws IOException {
 
     // see if it exists
     File catFile = new File(catalogFullPath);
@@ -125,7 +129,7 @@ public class ConfigCatalogCache implements CatalogReader {
       return null;
     }
 
-    ConfigCatalogBuilder builder = new ConfigCatalogBuilder();
+    ConfigCatalogBuilder builder = new ConfigCatalogBuilder(this.context);
     ConfigCatalog cat = (ConfigCatalog) builder.buildFromURI(uri); // LOOK use file and keep lastModified
     if (builder.hasFatalError()) {
       throw new IOException("invalid catalog " + catalogFullPath);

--- a/tdcommon/src/main/java/thredds/server/catalog/builder/ConfigCatalogBuilder.java
+++ b/tdcommon/src/main/java/thredds/server/catalog/builder/ConfigCatalogBuilder.java
@@ -27,11 +27,6 @@ public class ConfigCatalogBuilder extends CatalogBuilder {
 
   private final String context;
 
-  public ConfigCatalogBuilder() {
-    super();
-    context = "thredds";
-  }
-
   public ConfigCatalogBuilder(String context) {
     super();
     if (context.startsWith("/"))

--- a/tds/src/main/java/thredds/server/config/TdsInit.java
+++ b/tds/src/main/java/thredds/server/config/TdsInit.java
@@ -426,7 +426,8 @@ public class TdsInit implements ApplicationListener<ContextRefreshedEvent>, Disp
     // Config Cat Cache
     max = ThreddsConfig.getInt("ConfigCatalog.keepInMemory", 100);
     String rootPath = tdsContext.getContentRootPathProperty() + "thredds/";
-    ccc.init(rootPath, max);
+    final String context = tdsContext.getContextPath();
+    ccc.init(rootPath, max, context);
 
     // Config Dataset Tracker
     String trackerDir = ThreddsConfig.get("ConfigCatalog.dir",

--- a/tds/src/test/java/thredds/server/catalog/TestConfigCatalogBuilder.java
+++ b/tds/src/test/java/thredds/server/catalog/TestConfigCatalogBuilder.java
@@ -31,6 +31,7 @@ import java.util.List;
 @Category(NeedsCdmUnitTest.class)
 public class TestConfigCatalogBuilder {
   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+  private static final String CONTEXT = "thredds";
 
   @Before
   public void setup() {
@@ -44,7 +45,7 @@ public class TestConfigCatalogBuilder {
     if (url == null)
       return null;
 
-    ConfigCatalogBuilder builder = new ConfigCatalogBuilder();
+    ConfigCatalogBuilder builder = new ConfigCatalogBuilder(CONTEXT);
     Catalog cat = builder.buildFromLocation("file:" + url.getPath(), null);
     if (builder.hasFatalError()) {
       System.out.printf("%s%n", builder.getErrorMessage());
@@ -62,7 +63,7 @@ public class TestConfigCatalogBuilder {
 
   static public ConfigCatalog open(String urlString) throws IOException {
     System.out.printf("Open %s%n", urlString);
-    ConfigCatalogBuilder builder = new ConfigCatalogBuilder();
+    ConfigCatalogBuilder builder = new ConfigCatalogBuilder(CONTEXT);
     Catalog cat = builder.buildFromLocation(urlString, null);
     if (builder.hasFatalError()) {
       System.out.printf("%s%n", builder.getErrorMessage());
@@ -201,7 +202,7 @@ public class TestConfigCatalogBuilder {
     URL url = cl.getResource("thredds/server/catalog/testInheritied.xml");
     assert (url != null);
 
-    ConfigCatalogBuilder catFactory = new ConfigCatalogBuilder();
+    ConfigCatalogBuilder catFactory = new ConfigCatalogBuilder(CONTEXT);
     Catalog cat = catFactory.buildFromLocation("file:" + url.getPath(), null);
     CatalogXmlWriter writer = new CatalogXmlWriter();
     System.out.printf("%s%n", writer.writeXML(cat));

--- a/tds/src/test/java/thredds/server/catalog/TestUseRemoteReference.java
+++ b/tds/src/test/java/thredds/server/catalog/TestUseRemoteReference.java
@@ -35,7 +35,7 @@ public class TestUseRemoteReference {
     // get test catalog location
     ClassLoader cl = this.getClass().getClassLoader();
     URL url = cl.getResource(testCatalog);
-    ConfigCatalogBuilder catFactory = new ConfigCatalogBuilder();
+    ConfigCatalogBuilder catFactory = new ConfigCatalogBuilder("thredds");
     cat = catFactory.buildFromLocation("file:" + url.getPath(), null);
     // cat = catFactory.buildFromURI(url); // LOOK does this work ??
   }

--- a/tds/src/test/java/thredds/server/catalogservice/TestContext.java
+++ b/tds/src/test/java/thredds/server/catalogservice/TestContext.java
@@ -45,11 +45,11 @@ public class TestContext {
 
   @Test
   public void shouldReturnCorrectContext() throws Exception {
-    final String myPath = "/catalog/enhancedCatalog.xml";
+    final String path = "/catalog/enhancedCatalog.xml";
     final ServletContext servletContext = webApplicationContext.getServletContext();
     assertThat(servletContext).isNotNull();
     final String context = servletContext.getContextPath();
-    RequestBuilder requestBuilder = MockMvcRequestBuilders.get(myPath).servletPath(myPath);
+    RequestBuilder requestBuilder = MockMvcRequestBuilders.get(path).servletPath(path);
 
     final String expectedResult = "catalogRef xlink:href=\"/" + context + "/catalog/testEnhanced/catalog.xml\"";
     this.mockMvc.perform(requestBuilder).andExpect(MockMvcResultMatchers.status().is(HttpStatus.SC_OK))

--- a/tds/src/test/java/thredds/server/catalogservice/TestContext.java
+++ b/tds/src/test/java/thredds/server/catalogservice/TestContext.java
@@ -1,0 +1,58 @@
+package thredds.server.catalogservice;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.lang.invoke.MethodHandles;
+import javax.servlet.ServletContext;
+import org.apache.http.HttpStatus;
+import org.hamcrest.core.StringContains;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.RequestBuilder;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import thredds.mock.web.MockTdsContextLoader;
+import ucar.unidata.util.test.category.NeedsCdmUnitTest;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@WebAppConfiguration
+@ContextConfiguration(locations = {"/WEB-INF/applicationContext.xml", "/WEB-INF/spring-servlet.xml"},
+    loader = MockTdsContextLoader.class)
+@Category(NeedsCdmUnitTest.class)
+public class TestContext {
+  private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+  @Autowired
+  private WebApplicationContext webApplicationContext;
+
+  private MockMvc mockMvc;
+
+  @Before
+  public void setup() {
+    this.mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext).build();
+  }
+
+  @Test
+  public void shouldReturnCorrectContext() throws Exception {
+    final String myPath = "/catalog/enhancedCatalog.xml";
+    final ServletContext servletContext = webApplicationContext.getServletContext();
+    assertThat(servletContext).isNotNull();
+    final String context = servletContext.getContextPath();
+    RequestBuilder requestBuilder = MockMvcRequestBuilders.get(myPath).servletPath(myPath);
+
+    final String expectedResult = "catalogRef xlink:href=\"/" + context + "/catalog/testEnhanced/catalog.xml\"";
+    this.mockMvc.perform(requestBuilder).andExpect(MockMvcResultMatchers.status().is(HttpStatus.SC_OK))
+        .andExpect(MockMvcResultMatchers.content().string(new StringContains(expectedResult))).andReturn();
+  }
+}


### PR DESCRIPTION
- Remove hardcoded "thredds" context from ConfigCatalogBuilder that was being used when creating DatasetScans and FeatureCollections
- Add some tests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidata/tds/211)
<!-- Reviewable:end -->
