### PR TITLE
[5.x] Remote catalog as xml

### DIFF
--- a/tds/src/main/java/thredds/server/catalogservice/RemoteCatalogServiceController.java
+++ b/tds/src/main/java/thredds/server/catalogservice/RemoteCatalogServiceController.java
@@ -5,6 +5,7 @@
 
 package thredds.server.catalogservice;
 
+import java.util.Locale;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.validation.BindException;
@@ -79,6 +80,9 @@ public class RemoteCatalogServiceController {
     if (builder.hasFatalError() || catalog == null) {
       Formatter f = new Formatter();
       f.format("Error reading catalog '%s' err=%s%n", uri, builder.getErrorMessage());
+      if (!uri.toString().toLowerCase(Locale.ROOT).endsWith(".xml")) {
+        f.format("Expected catalog uri = '" + uri + "' to end with '.xml'");
+      }
       log.debug(f.toString());
       response.sendError(HttpServletResponse.SC_BAD_REQUEST, f.toString());
       return null;

--- a/tds/src/main/java/thredds/server/catalogservice/RemoteCatalogServiceController.java
+++ b/tds/src/main/java/thredds/server/catalogservice/RemoteCatalogServiceController.java
@@ -93,8 +93,13 @@ public class RemoteCatalogServiceController {
     // Otherwise, handle catalog as indicated by "command".
     switch (params.getCommand()) {
       case SHOW:
-        response.setContentType(ContentType.html.getContentHeader());
-        return new ModelAndView("templates/catalog", parser.getCatalogViewContext(catalog, request, false));
+        if (params.isHtmlView()) {
+          response.setContentType(ContentType.html.getContentHeader());
+          return new ModelAndView("templates/catalog", parser.getCatalogViewContext(catalog, request, false));
+        } else {
+          response.setContentType(ContentType.xml.getContentHeader());
+          return new ModelAndView("threddsInvCatXmlView", "catalog", catalog);
+        }
 
       case SUBSET:
         String datasetId = params.getDataset();

--- a/tds/src/test/java/thredds/server/catalogservice/RemoteCatalogControllerTest.java
+++ b/tds/src/test/java/thredds/server/catalogservice/RemoteCatalogControllerTest.java
@@ -57,8 +57,8 @@ public class RemoteCatalogControllerTest {
     MvcResult result = this.mockMvc.perform(rb).andExpect(MockMvcResultMatchers.status().is(200))
         .andExpect(MockMvcResultMatchers.content().contentType(htmlContent)).andReturn();
 
-    System.out.printf("showCommandTest status=%d%n", result.getResponse().getStatus());
-    System.out.printf("%s%n", result.getResponse().getContentAsString());
+    logger.debug("showCommandTest status= " + result.getResponse().getStatus());
+    logger.debug(result.getResponse().getContentAsString());
   }
 
   @Test
@@ -69,8 +69,8 @@ public class RemoteCatalogControllerTest {
     MvcResult result = this.mockMvc.perform(rb).andExpect(MockMvcResultMatchers.status().is(200))
         .andExpect(MockMvcResultMatchers.content().contentType(htmlContent)).andReturn();
 
-    System.out.printf("subsetCommandTest status=%d%n", result.getResponse().getStatus());
-    System.out.printf("%s%n", result.getResponse().getContentAsString());
+    logger.debug("subsetCommandTest status= " + result.getResponse().getStatus());
+    logger.debug(result.getResponse().getContentAsString());
   }
 
   @Test
@@ -81,8 +81,8 @@ public class RemoteCatalogControllerTest {
     MvcResult result = this.mockMvc.perform(rb).andExpect(MockMvcResultMatchers.status().is(200))
         .andExpect(MockMvcResultMatchers.content().contentType(htmlContent)).andReturn();
 
-    System.out.printf("validateCommandTest status=%d%n", result.getResponse().getStatus());
-    System.out.printf("%s%n", result.getResponse().getContentAsString());
+    logger.debug("validateCommandTest status= " + result.getResponse().getStatus());
+    logger.debug(result.getResponse().getContentAsString());
   }
 
 }

--- a/tds/src/test/java/thredds/server/catalogservice/RemoteCatalogControllerTest.java
+++ b/tds/src/test/java/thredds/server/catalogservice/RemoteCatalogControllerTest.java
@@ -20,6 +20,7 @@ import org.springframework.web.context.WebApplicationContext;
 import thredds.core.AllowedServices;
 import thredds.core.StandardService;
 import thredds.mock.web.MockTdsContextLoader;
+import thredds.util.ContentType;
 import ucar.unidata.util.test.category.NeedsContentRoot;
 import ucar.unidata.util.test.category.NeedsExternalResource;
 import java.lang.invoke.MethodHandles;
@@ -46,43 +47,109 @@ public class RemoteCatalogControllerTest {
 
   String dataset = "casestudies/ccs039/grids/netCDF/1998062912_eta.nc";
   String catalog = "https://thredds.ucar.edu/thredds/catalog/casestudies/ccs039/grids/netCDF/catalog.xml";
+
   String path = "/remoteCatalogService";
-  String htmlContent = "text/html;charset=UTF-8";
+  String htmlContent = ContentType.html.getContentHeader();
+  String xmlContent = ContentType.xml.getContentHeader();
+  String defaultContent = htmlContent;
 
   @Test
-  public void showCommandTest() throws Exception {
+  public void shouldFailForCatalogHtmlUri() throws Exception {
+    String htmlCatalog = "https://thredds.ucar.edu/thredds/catalog/casestudies/ccs039/grids/netCDF/catalog.html";
+
+    RequestBuilder rb =
+        MockMvcRequestBuilders.get(path).servletPath(path).param("command", "SHOW").param("catalog", htmlCatalog);
+
+    this.mockMvc.perform(rb).andExpect(MockMvcResultMatchers.status().is(400)).andReturn();
+  }
+
+  @Test
+  public void showCommandWithDefaultContentType() throws Exception {
     RequestBuilder rb =
         MockMvcRequestBuilders.get(path).servletPath(path).param("command", "SHOW").param("catalog", catalog);
 
     MvcResult result = this.mockMvc.perform(rb).andExpect(MockMvcResultMatchers.status().is(200))
-        .andExpect(MockMvcResultMatchers.content().contentType(htmlContent)).andReturn();
+        .andExpect(MockMvcResultMatchers.content().contentType(defaultContent)).andReturn();
 
     logger.debug("showCommandTest status= " + result.getResponse().getStatus());
     logger.debug(result.getResponse().getContentAsString());
   }
 
   @Test
-  public void subsetCommandTest() throws Exception {
+  public void showCommandWithXmlContent() throws Exception {
+    RequestBuilder rb = MockMvcRequestBuilders.get(path).servletPath(path).param("command", "SHOW")
+        .param("catalog", catalog).param("htmlView", "false");
+
+    this.mockMvc.perform(rb).andExpect(MockMvcResultMatchers.status().is(200))
+        .andExpect(MockMvcResultMatchers.content().contentType(xmlContent)).andReturn();
+  }
+
+  @Test
+  public void showCommandWithHtmlContent() throws Exception {
+    RequestBuilder rb = MockMvcRequestBuilders.get(path).servletPath(path).param("command", "SHOW")
+        .param("catalog", catalog).param("htmlView", "true");
+
+    this.mockMvc.perform(rb).andExpect(MockMvcResultMatchers.status().is(200))
+        .andExpect(MockMvcResultMatchers.content().contentType(htmlContent)).andReturn();
+  }
+
+  @Test
+  public void subsetCommandWithDefaultContentType() throws Exception {
     RequestBuilder rb = MockMvcRequestBuilders.get(path).servletPath(path).param("command", "SUBSET")
         .param("catalog", catalog).param("dataset", dataset);
 
     MvcResult result = this.mockMvc.perform(rb).andExpect(MockMvcResultMatchers.status().is(200))
-        .andExpect(MockMvcResultMatchers.content().contentType(htmlContent)).andReturn();
+        .andExpect(MockMvcResultMatchers.content().contentType(defaultContent)).andReturn();
 
     logger.debug("subsetCommandTest status= " + result.getResponse().getStatus());
     logger.debug(result.getResponse().getContentAsString());
   }
 
   @Test
-  public void validateCommandTest() throws Exception {
+  public void subsetCommandWithXmlContent() throws Exception {
+    RequestBuilder rb = MockMvcRequestBuilders.get(path).servletPath(path).param("command", "SUBSET")
+        .param("catalog", catalog).param("dataset", dataset).param("htmlView", "false");
+
+    this.mockMvc.perform(rb).andExpect(MockMvcResultMatchers.status().is(200))
+        .andExpect(MockMvcResultMatchers.content().contentType(xmlContent)).andReturn();
+  }
+
+  @Test
+  public void subsetCommandWithHtmlContent() throws Exception {
+    RequestBuilder rb = MockMvcRequestBuilders.get(path).servletPath(path).param("command", "SUBSET")
+        .param("catalog", catalog).param("dataset", dataset).param("htmlView", "true");
+
+    this.mockMvc.perform(rb).andExpect(MockMvcResultMatchers.status().is(200))
+        .andExpect(MockMvcResultMatchers.content().contentType(htmlContent)).andReturn();
+  }
+
+  @Test
+  public void validateCommandWithDefaultContentType() throws Exception {
     RequestBuilder rb = MockMvcRequestBuilders.get(path).servletPath(path).param("command", "VALIDATE")
         .param("catalog", catalog).param("dataset", dataset);
 
     MvcResult result = this.mockMvc.perform(rb).andExpect(MockMvcResultMatchers.status().is(200))
-        .andExpect(MockMvcResultMatchers.content().contentType(htmlContent)).andReturn();
+        .andExpect(MockMvcResultMatchers.content().contentType(defaultContent)).andReturn();
 
     logger.debug("validateCommandTest status= " + result.getResponse().getStatus());
     logger.debug(result.getResponse().getContentAsString());
   }
 
+  @Test
+  public void validateCommandWithXmlContent() throws Exception {
+    RequestBuilder rb = MockMvcRequestBuilders.get(path).servletPath(path).param("command", "VALIDATE")
+        .param("catalog", catalog).param("dataset", dataset).param("htmlView", "false");
+
+    this.mockMvc.perform(rb).andExpect(MockMvcResultMatchers.status().is(200))
+        .andExpect(MockMvcResultMatchers.content().contentType(xmlContent)).andReturn();
+  }
+
+  @Test
+  public void validateCommandWithHtmlContent() throws Exception {
+    RequestBuilder rb = MockMvcRequestBuilders.get(path).servletPath(path).param("command", "VALIDATE")
+        .param("catalog", catalog).param("dataset", dataset).param("htmlView", "true");
+
+    this.mockMvc.perform(rb).andExpect(MockMvcResultMatchers.status().is(200))
+        .andExpect(MockMvcResultMatchers.content().contentType(htmlContent)).andReturn();
+  }
 }


### PR DESCRIPTION
- Add the parameter "htmlView" to remoteCatalogService command=show requests so that it is possible to get a whole catalog as xml (previously only allowed with command=subset)
- Extend tests to test this parameter

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidata/tds/228)
<!-- Reviewable:end -->
