### PR TITLE
make featurecollection cache configurable through threddsConfig

### DIFF
--- a/docs/devguide/src/site/pages/thredds/ThreddsConfigRef.md
+++ b/docs/devguide/src/site/pages/thredds/ThreddsConfigRef.md
@@ -452,18 +452,18 @@ We recommend that you use the default settings, by not specifying this option.
 ~~~xml
  <FeatureCollection>
    <dir>${tds.content.root.path}/thredds/cache/collection/</dir>
-   <maxSize>20 Mb</maxSize>
-   <jvmPercent>2</jvmPercent>
+   <maxEntries>1000</maxEntries>
+   <maxBloatFactor>1</maxBloatFactor>
  </FeatureCollection>
 ~~~
 
 * `dir`: location of Feature Collection cache, currently implemented
-with [Berkeley DB](https://www.oracle.com/technetwork/database/berkeleydb/overview/index-093405.html){:target="_blank"}. 
+with [Chronicle Map](https://chronicle.software/open-hft/map/){:target="_blank"}. 
   If not otherwise set, the TDS will use the`${tds.content.root.path}/thredds/cache/collection/` directory.
   We recommend that you use this default, by not specifying a `FeatureCollection.dir` element.
-* `maxSize`: maximum amount of memory to be used for this cache.
-* `jvmPercent`: alternately, set the memory use as a percent of JVM memory, i.e. `-Xmx` value.
-  `maxSize` will override if present. Default is 2 %.
+* `maxEntries`: the number of entries the cache is going to hold, _at most_. 
+See [here](https://gerrit.googlesource.com/modules/cache-chroniclemap/+/HEAD/src/main/resources/Documentation/config.md#configuration-parameters) for more details.
+* `maxBloatFactor`: the maximun number of times the cache is allowed to grow in size. See [here](https://gerrit.googlesource.com/modules/cache-chroniclemap/+/HEAD/src/main/resources/Documentation/config.md#configuration-parameters) for more details.
 
 ### GRIB Index Redirection
 

--- a/tds/src/main/java/thredds/featurecollection/cache/GridInventoryCacheChronicle.java
+++ b/tds/src/main/java/thredds/featurecollection/cache/GridInventoryCacheChronicle.java
@@ -28,10 +28,25 @@ public class GridInventoryCacheChronicle implements InventoryCacheProvider {
   private static final Logger logger = LoggerFactory.getLogger(GridInventoryCacheChronicle.class);
   private static ChronicleMap<String, byte[]> cache;
 
+  private static final int DEFAULT_ENTRIES = 1000;
+  private static final int DEFAULT_BLOAT_FACTOR = 1;
+
   /**
    * Initialize the inventory cache
    *
    * @param cacheDir Path to the cache directory. This location will be created if it does not exist.
+   * @throws IOException
+   */
+  public static void init(Path cacheDir) throws IOException {
+    init(cacheDir, DEFAULT_ENTRIES, DEFAULT_BLOAT_FACTOR);
+  }
+
+  /**
+   * Initialize the inventory cache
+   *
+   * @param cacheDir Path to the cache directory. This location will be created if it does not exist.
+   * @param maxEntries number of entries in the cache, at most
+   * @param maxBloatFactor max number of times the cache size can increase
    * @throws IOException
    */
   public static void init(Path cacheDir, int maxEntries, int maxBloatFactor) throws IOException {

--- a/tds/src/main/java/thredds/featurecollection/cache/GridInventoryCacheChronicle.java
+++ b/tds/src/main/java/thredds/featurecollection/cache/GridInventoryCacheChronicle.java
@@ -34,7 +34,7 @@ public class GridInventoryCacheChronicle implements InventoryCacheProvider {
    * @param cacheDir Path to the cache directory. This location will be created if it does not exist.
    * @throws IOException
    */
-  public static void init(Path cacheDir) throws IOException {
+  public static void init(Path cacheDir, int maxEntries, int maxBloatFactor) throws IOException {
     if (!Files.exists(cacheDir)) {
       logger.info("Creating cache directory at {}", cacheDir.toString());
       Files.createDirectories(cacheDir);
@@ -47,8 +47,8 @@ public class GridInventoryCacheChronicle implements InventoryCacheProvider {
     }
     if (cache == null) {
       cache = ChronicleMapBuilder.of(String.class, byte[].class).name("GridDatasetInv")
-          .averageKey("/data/project/analysis/file.ext").averageValueSize(4096).entries(1000)
-          .createOrRecoverPersistedTo(dbFile.toFile());
+          .averageKey("/data/project/analysis/file.ext").averageValueSize(4096).entries(maxEntries)
+          .maxBloatFactor(maxBloatFactor).createOrRecoverPersistedTo(dbFile.toFile());
     }
   }
 

--- a/tds/src/main/java/thredds/server/config/TdsInit.java
+++ b/tds/src/main/java/thredds/server/config/TdsInit.java
@@ -378,10 +378,12 @@ public class TdsInit implements ApplicationListener<ContextRefreshedEvent>, Disp
     if (fcCache == null)
       fcCache = ThreddsConfig.get("FeatureCollection.cacheDirectory",
           tdsContext.getThreddsDirectory().getPath() + "/cache/collection/"); // cacheDirectory is old way
+    int maxEntries = ThreddsConfig.getInt("FeatureCollection.maxEntries", 1000);
+    int maxBloatFactor = ThreddsConfig.getInt("FeatureCollection.maxBloatFactor", 1);
 
     Path fcCacheDir = Paths.get(fcCache);
     try {
-      GridInventoryCacheChronicle.init(fcCacheDir);
+      GridInventoryCacheChronicle.init(fcCacheDir, maxEntries, maxBloatFactor);
       startupLog.info("TdsInit: GridDatasetInv cache= {}", fcCache);
     } catch (Exception e) {
       startupLog.error("TdsInit: Failed initialize GridDatasetInv cache= {}", fcCache, e);

--- a/tds/src/test/content/thredds/threddsConfig.xml
+++ b/tds/src/test/content/thredds/threddsConfig.xml
@@ -103,6 +103,11 @@
     <cachePathPolicy>OneDirectory</cachePathPolicy>
   </AggregationCache>
 
+  <FeatureCollection>
+    <maxEntries>1024</maxEntries>
+    <maxBloatFactor>2</maxBloatFactor>
+  </FeatureCollection>
+
   <ConfigCatalog>
     <reread>check</reread>
     <maxDatasets>1000</maxDatasets>

--- a/tds/src/test/java/thredds/server/config/ThreddsConfigTest.java
+++ b/tds/src/test/java/thredds/server/config/ThreddsConfigTest.java
@@ -28,7 +28,6 @@ public class ThreddsConfigTest {
 
   @Before
   public void setUp() {
-    // threddsConfigPath ="/thredds/tds/src/test/content/thredds/threddsConfig.xml";
     threddsConfigPath = tdsContext.getContentRootPathProperty() + "/thredds/threddsConfig.xml";
     ThreddsConfig.init(threddsConfigPath);
   }
@@ -39,6 +38,8 @@ public class ThreddsConfigTest {
     assertEquals("true", ThreddsConfig.get("CatalogServices.allowRemote", null));
     assertEquals(null, ThreddsConfig.get("WMS.allow", null));
     assertEquals(52428800, ThreddsConfig.getBytes("NetcdfSubsetService.maxFileDownloadSize", -1L));
+    assertEquals(1024, ThreddsConfig.getInt("FeatureCollection.maxEntries", 1000));
+    assertEquals(2, ThreddsConfig.getInt("FeatureCollection.maxBloatFactor", 1));
   }
 
   // Tests the "cachePathPolicy" element, added in response to this message on the thredds mailing list:


### PR DESCRIPTION
Address #196 and #230:
- Make FeatureCollection cache `maxEntries` and `maxBloatFactor` parameters configurable through threddsConfig
- Update threddsConfig docs

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidata/tds/232)
<!-- Reviewable:end -->
