### PR TITLE
Add subproject for TDS toolsUI

### DIFF
--- a/gradle/any/dependencies.gradle
+++ b/gradle/any/dependencies.gradle
@@ -32,6 +32,13 @@ repositories {
   maven {
     url 'https://artifacts.unidata.ucar.edu/repository/unidata-snapshots/'
   }
+  maven {
+    url 'https://artifacts.unidata.ucar.edu/repository/unidata-3rdparty/'
+    content {
+      // this repository *only* used for artifacts with group "org.bounce" (NcML editor in toolsUI)
+      includeGroup 'org.bounce'
+    }
+  }
 }
 
 //////////////////////////// Transitive dependency replacements and exclusions ////////////////////////////

--- a/settings.gradle
+++ b/settings.gradle
@@ -15,6 +15,7 @@ include 'tds-plugin-bom'
 include 'tds-platform'
 include 'tds-testing-platform'
 include 'tds'
+include 'tds-ui'
 
 // Set name of the opendap servlet artifact
 project(':opendap:server').name = 'opendap-servlet'

--- a/tds-ui/README.md
+++ b/tds-ui/README.md
@@ -1,0 +1,9 @@
+# TDS-UI
+
+ToolsUI for the THREDDS Data Server (TDS) is a version of ToolsUI that corresponds to the version of netCDF-Java in use by the TDS, plus extras that are not included with toolsUI, like the `cdm-s3` subproject from netCDF-Java.
+This exists simply for developer convenience.
+To run toolsUI from the TDS project, execute the following gradle command from the top of the repository:
+
+~~~shell
+./gradlew :tds-ui:run
+~~~

--- a/tds-ui/build.gradle
+++ b/tds-ui/build.gradle
@@ -1,0 +1,20 @@
+description = 'ToolsUI for the THREDDS Data Server (TDS) is a version of ToolsUI that corresponds to ' +
+        'the version of netCDF-Java in use by the TDS, plus extras that are not included with toolsUI, ' +
+        'like the cdm-s3 subproject from netCDF-Java. This exists simply for developer convenience.'
+ext.title = 'ToolsUI for the TDS'
+ext.url = 'https://www.unidata.ucar.edu/software/tds/'
+
+apply from: "$rootDir/gradle/any/dependencies.gradle"
+apply plugin: 'application'
+
+dependencies {
+    implementation enforcedPlatform(project(':tds-platform'))
+    testCompile enforcedPlatform(project(':tds-testing-platform'))
+
+    runtime 'edu.ucar:uicdm'
+    runtime 'edu.ucar:cdm-s3'
+}
+
+application {
+    mainClass.set("ucar.nc2.ui.ToolsUI")
+}


### PR DESCRIPTION
This PR adds a subproject called `tds-ui`, which is a version of ToolsUI that corresponds to the version of netCDF-Java in use by the TDS, plus extras that are not included with toolsUI, like the `cdm-s3` subproject from netCDF-Java. This exists simply for developer convenience and is not published anywhere. To run toolsUI from the TDS project, execute the following gradle command from the top of the repository:

~~~shell
./gradlew :tds-ui:run
~~~

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidata/tds/234)
<!-- Reviewable:end -->
