### PR TITLE
[5.x] Ncss dataset root with location bug

### DIFF
--- a/tds/src/main/java/thredds/core/DatasetManager.java
+++ b/tds/src/main/java/thredds/core/DatasetManager.java
@@ -114,6 +114,11 @@ public class DatasetManager implements InitializingBean {
     return dataRootManager.getLocationFromRequestPath(reqPath);
   }
 
+  public String getLocationFromNcml(String reqPath) {
+    final String ncml = datasetTracker.findNcml(reqPath);
+    return ncml != null ? NcmlReader.getLocationFromNcml(ncml) : null;
+  }
+
   public static boolean isLocationObjectStore(String location) {
     return location != null ? (location.startsWith("cdms3:") || location.startsWith("s3:")) : false;
   }

--- a/tds/src/main/java/thredds/core/DatasetManager.java
+++ b/tds/src/main/java/thredds/core/DatasetManager.java
@@ -425,7 +425,7 @@ public class DatasetManager implements InitializingBean {
       }
 
       if (!opt.isPresent())
-        throw new FileNotFoundException("Not a Grid Dataset " + reqPath + " err=" + opt.getErrorMessage());
+        throw new FileNotFoundException("Error opening grid dataset " + reqPath + ". err=" + opt.getErrorMessage());
 
       if (log.isDebugEnabled())
         log.debug("  -- DatasetHandler found FeatureCollection from file= " + location);

--- a/tds/src/main/java/thredds/core/TdsRequestedDataset.java
+++ b/tds/src/main/java/thredds/core/TdsRequestedDataset.java
@@ -103,6 +103,10 @@ public class TdsRequestedDataset {
     return datasetManager.getLocationFromRequestPath(reqPath);
   }
 
+  public static String getLocationFromNcml(String reqPath) {
+    return datasetManager.getLocationFromNcml(reqPath);
+  }
+
   public static boolean useNetcdfJavaBuilders() {
     return datasetManager.useNetcdfJavaBuilders();
   }

--- a/tds/src/main/java/thredds/servlet/ServletUtil.java
+++ b/tds/src/main/java/thredds/servlet/ServletUtil.java
@@ -279,7 +279,9 @@ public class ServletUtil {
    */
   public static void writeMFileToResponse(HttpServletRequest request, HttpServletResponse response, String requestPath)
       throws IOException {
-    final String location = TdsRequestedDataset.getLocationFromRequestPath(requestPath);
+    final String ncmlLocation = TdsRequestedDataset.getLocationFromNcml(requestPath);
+    final String location =
+        ncmlLocation != null ? ncmlLocation : TdsRequestedDataset.getLocationFromRequestPath(requestPath);
     final MFile file = MFiles.create(location);
 
     if (file == null) {

--- a/tds/src/test/content/thredds/catalog.xml
+++ b/tds/src/test/content/thredds/catalog.xml
@@ -223,6 +223,13 @@
 
     </datasetScan>
 
+    <dataset name="Test datasetRoot in urlPath and location" ID="ncmlLocation" urlPath="localContent/ncmlLocation">
+      <serviceName>all</serviceName>
+      <ncml:netcdf xmlns="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2"
+        location="content/testdata/testData.nc">
+      </ncml:netcdf>
+    </dataset>
+
   </dataset>
 
   <!-- END UNTESTED-->

--- a/tds/src/test/java/thredds/server/fileserver/FileServerControllerTest.java
+++ b/tds/src/test/java/thredds/server/fileserver/FileServerControllerTest.java
@@ -14,6 +14,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.RequestBuilder;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import ucar.unidata.util.test.category.NeedsCdmUnitTest;
 import java.lang.invoke.MethodHandles;
@@ -48,5 +49,13 @@ public class FileServerControllerTest {
     // Throws NullPointerException if header doesn't exist
     // Throws IllegalArgumentException if header value is not a valid date.
     result.getResponse().getDateHeader("Last-Modified");
+  }
+
+  @Test
+  public void shouldReturnFileWithDatasetRootInUrlPathAndLocationInNcml() throws Exception {
+    final String path = "/fileServer/localContent/ncmlLocation";
+    final RequestBuilder rb = MockMvcRequestBuilders.get(path).servletPath(path);
+
+    mockMvc.perform(rb).andExpect(MockMvcResultMatchers.status().isOk()).andReturn();
   }
 }

--- a/tds/src/test/java/thredds/server/ncss/controller/grid/GridDatasetControllerTest.java
+++ b/tds/src/test/java/thredds/server/ncss/controller/grid/GridDatasetControllerTest.java
@@ -86,6 +86,14 @@ public class GridDatasetControllerTest {
     }
   }
 
+  @Test
+  public void shouldReturnFileWithDatasetRootInUrlPathAndLocationInNcml() throws Exception {
+    final String path = "/ncss/grid/localContent/ncmlLocation/dataset.xml";
+    final RequestBuilder rb = MockMvcRequestBuilders.get(path).servletPath(path);
+
+    mockMvc.perform(rb).andExpect(MockMvcResultMatchers.status().isOk()).andReturn();
+  }
+
   private class FilenameMatcher extends BaseMatcher<String> {
     String suffix;
 


### PR DESCRIPTION
Depends on [NetCDF-java PR](https://github.com/Unidata/netcdf-java/pull/1044). Issue reported in https://github.com/Unidata/tds/issues/235

- Add tests
- Fix order of lookup for NCSS-- should first check for an ncml `location` attribute, then look at datasetRoot in the `urlPath` (which may not point to a file in the case of a ncml `location`, which previously resulted in a FileNotFound exception).
- Improve error message
- Fix FileServer dataset lookup for a ncml `location` attribute.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidata/tds/240)
<!-- Reviewable:end -->
