### PR TITLE
[5.x] Allow self-signed certificates to fix failing tests

### DIFF
--- a/tds-test-utils/src/main/java/thredds/test/util/TestOnLocalServer.java
+++ b/tds-test-utils/src/main/java/thredds/test/util/TestOnLocalServer.java
@@ -40,7 +40,6 @@ public class TestOnLocalServer {
 
   static {
     // Trust self-signed certificates when testing
-    HTTPSession.TESTING = true;
     HTTPSession.allowSelfSignedCertificatesForTesting();
   }
 

--- a/tds-test-utils/src/main/java/thredds/test/util/TestOnLocalServer.java
+++ b/tds-test-utils/src/main/java/thredds/test/util/TestOnLocalServer.java
@@ -38,6 +38,12 @@ public class TestOnLocalServer {
    */
   public static final String server = "localhost:8081/thredds/";
 
+  static {
+    // Trust self-signed certificates when testing
+    HTTPSession.TESTING = true;
+    HTTPSession.allowSelfSignedCertificatesForTesting();
+  }
+
   /**
    * Construct a URL using the specified protocol and path. Its format will be: {@code <protocol>://<server>/<path>}.
    *


### PR DESCRIPTION
Together with the [netcdf-java PR](https://github.com/Unidata/netcdf-java/pull/1046), this change would fix the tests that were failing in TestAdminDebug by allowing self-signed certificates.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidata/tds/244)
<!-- Reviewable:end -->
