### PR TITLE
[5.x] Improve ncss error handling and service description

### DIFF
--- a/tds/src/main/java/thredds/core/DatasetManager.java
+++ b/tds/src/main/java/thredds/core/DatasetManager.java
@@ -348,8 +348,15 @@ public class DatasetManager implements InitializingBean {
       } else {
         ncd = NetcdfDataset.wrap(ncfile, NetcdfDataset.getDefaultEnhanceMode());
       }
-      return (FeatureDatasetPoint) FeatureDatasetFactoryManager.wrap(FeatureType.ANY_POINT, ncd, null, errlog);
 
+      final FeatureDatasetPoint featureDatasetPoint =
+          (FeatureDatasetPoint) FeatureDatasetFactoryManager.wrap(FeatureType.ANY_POINT, ncd, null, errlog);
+
+      if (featureDatasetPoint != null) {
+        return featureDatasetPoint;
+      } else {
+        throw new UnsupportedOperationException("Could not open as a PointDataset: " + errlog);
+      }
     } catch (Throwable t) {
       if (ncd == null)
         ncfile.close();
@@ -358,6 +365,10 @@ public class DatasetManager implements InitializingBean {
 
       if (t instanceof IOException)
         throw (IOException) t;
+
+      if (t instanceof UnsupportedOperationException) {
+        throw (UnsupportedOperationException) t;
+      }
 
       String msg = ncd == null ? "Problem wrapping NetcdfFile in NetcdfDataset; "
           : "Problem calling FeatureDatasetFactoryManager; ";

--- a/tds/src/main/java/thredds/server/TdsErrorHandling.java
+++ b/tds/src/main/java/thredds/server/TdsErrorHandling.java
@@ -35,7 +35,7 @@ import static org.springframework.web.util.HtmlUtils.htmlEscape;
  * ServiceNotAllowed FORBIDDEN
  * FileNotFoundException NOT_FOUND
  * IOException INTERNAL_SERVER_ERROR
- * UnsupportedOperationException METHOD_NOT_ALLOWED
+ * UnsupportedOperationException UNPROCESSABLE_ENTITY
  * IllegalArgumentException BAD_REQUEST
  * BindException BAD_REQUEST
  * Throwable INTERNAL_SERVER_ERROR
@@ -111,7 +111,7 @@ public class TdsErrorHandling implements HandlerExceptionResolver {
     HttpHeaders responseHeaders = new HttpHeaders();
     responseHeaders.setContentType(MediaType.TEXT_PLAIN);
     return new ResponseEntity<>("UnsupportedOperationException: " + htmlEscape(ex.getMessage()), responseHeaders,
-        HttpStatus.METHOD_NOT_ALLOWED);
+        HttpStatus.UNPROCESSABLE_ENTITY);
   }
 
   @ExceptionHandler(IllegalArgumentException.class)

--- a/tds/src/main/java/thredds/server/TdsErrorHandling.java
+++ b/tds/src/main/java/thredds/server/TdsErrorHandling.java
@@ -35,7 +35,7 @@ import static org.springframework.web.util.HtmlUtils.htmlEscape;
  * ServiceNotAllowed FORBIDDEN
  * FileNotFoundException NOT_FOUND
  * IOException INTERNAL_SERVER_ERROR
- * UnsupportedOperationException BAD_REQUEST
+ * UnsupportedOperationException METHOD_NOT_ALLOWED
  * IllegalArgumentException BAD_REQUEST
  * BindException BAD_REQUEST
  * Throwable INTERNAL_SERVER_ERROR
@@ -102,6 +102,16 @@ public class TdsErrorHandling implements HandlerExceptionResolver {
     responseHeaders.setContentType(MediaType.TEXT_PLAIN);
     return new ResponseEntity<>("IOException sending File " + htmlEscape(ex.getMessage()), responseHeaders,
         HttpStatus.INTERNAL_SERVER_ERROR);
+  }
+
+  @ExceptionHandler(UnsupportedOperationException.class)
+  public ResponseEntity<String> handle(UnsupportedOperationException ex) {
+    logger.warn("TDS Error", ex);
+
+    HttpHeaders responseHeaders = new HttpHeaders();
+    responseHeaders.setContentType(MediaType.TEXT_PLAIN);
+    return new ResponseEntity<>("UnsupportedOperationException: " + htmlEscape(ex.getMessage()), responseHeaders,
+        HttpStatus.METHOD_NOT_ALLOWED);
   }
 
   @ExceptionHandler(IllegalArgumentException.class)

--- a/tds/src/main/java/thredds/server/catalogservice/CatalogViewContextParser.java
+++ b/tds/src/main/java/thredds/server/catalogservice/CatalogViewContextParser.java
@@ -596,11 +596,22 @@ class DatasetContext {
       }
       Map<String, String> accessMap = new HashMap<>();
       accessMap.put("serviceTypeName", s.getServiceTypeName());
-      accessMap.put("serviceDesc", s.getDesc());
+      accessMap.put("serviceDesc", getDescription(s));
       accessMap.put("accessType", s.getAccessType());
       accessMap.put("href", queryString == null ? urlString : urlString + "?" + queryString);
       this.access.add(accessMap);
     }
+  }
+
+  private static String getDescription(Service service) {
+    if (service.getType() == ServiceType.NetcdfSubset) {
+      if (service.getBase().toLowerCase(Locale.ROOT).contains("grid")) {
+        return "A web service for subsetting CDM scientific grid datasets.";
+      } else if (service.getBase().toLowerCase(Locale.ROOT).contains("point")) {
+        return "A web service for subsetting CDM scientific point datasets.";
+      }
+    }
+    return service.getDesc();
   }
 
   private void setContributors() {

--- a/tds/src/test/java/thredds/server/ncss/controller/point/TestPointFCExceptions.java
+++ b/tds/src/test/java/thredds/server/ncss/controller/point/TestPointFCExceptions.java
@@ -97,7 +97,7 @@ public class TestPointFCExceptions {
     final RequestBuilder rb =
         MockMvcRequestBuilders.get(invalidDatasetPath).servletPath(invalidDatasetPath).param("accept", "netcdf");
 
-    this.mockMvc.perform(rb).andExpect(MockMvcResultMatchers.status().isMethodNotAllowed())
+    this.mockMvc.perform(rb).andExpect(MockMvcResultMatchers.status().isUnprocessableEntity())
         .andExpect(MockMvcResultMatchers.content()
             .string(new StringContains("UnsupportedOperationException: Could not open as a PointDataset")));
   }

--- a/tds/src/test/java/thredds/server/ncss/controller/point/TestPointFCExceptions.java
+++ b/tds/src/test/java/thredds/server/ncss/controller/point/TestPointFCExceptions.java
@@ -5,6 +5,7 @@
 
 package thredds.server.ncss.controller.point;
 
+import org.hamcrest.core.StringContains;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -89,5 +90,16 @@ public class TestPointFCExceptions {
     System.out.printf("%s%n", result.getResponse().getContentAsString());
   }
 
+  @Test
+  public void invalidDataset() throws Exception {
+    final String invalidDatasetPath = "/ncss/point/scanLocal/2004050300_eta_211.nc/dataset.html";
+
+    final RequestBuilder rb =
+        MockMvcRequestBuilders.get(invalidDatasetPath).servletPath(invalidDatasetPath).param("accept", "netcdf");
+
+    this.mockMvc.perform(rb).andExpect(MockMvcResultMatchers.status().isMethodNotAllowed())
+        .andExpect(MockMvcResultMatchers.content()
+            .string(new StringContains("UnsupportedOperationException: Could not open as a PointDataset")));
+  }
 }
 


### PR DESCRIPTION
- Improve /ncss/point error handling when dataset cannot be opened as a point dataset. Previously, nothing was logged and status was OK. Now the status returned is "method not allowed" and the error log is printed. I also added a test for this.

- Now the description shown in the browser for /ncss/grid or /ncss/point contains the word "grid" or "point" so that you can differentiate them if both are configured. It is a bit of a hacky fix, but they both correspond to the same ServiceType enum in Netcdf-java, and I thought it might not be a good to change that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidata/tds/251)
<!-- Reviewable:end -->
