### PR TITLE
Ignore tests that require netcdf4 library if this cannot be found

### DIFF
--- a/tds/src/integrationTests/java/thredds/server/ncss/NcssGridIntegrationTest.java
+++ b/tds/src/integrationTests/java/thredds/server/ncss/NcssGridIntegrationTest.java
@@ -17,12 +17,14 @@ import ucar.nc2.NetcdfFiles;
 import ucar.nc2.dataset.NetcdfDataset;
 import ucar.nc2.dataset.NetcdfDatasets;
 import ucar.nc2.dt.grid.GridDataset;
+import ucar.nc2.ffi.netcdf.NetcdfClibrary;
 import ucar.unidata.util.test.category.NeedsCdmUnitTest;
 
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assume.assumeTrue;
 
 @Category(NeedsCdmUnitTest.class)
 public class NcssGridIntegrationTest {
@@ -111,6 +113,8 @@ public class NcssGridIntegrationTest {
   // this fails when _ChunkSizes are left on
   @Test
   public void testNcssFailure() throws Exception {
+    skipTestIfNetCDF4NotPresent();
+
     String filename =
         "scanCdmUnitTests/formats/netcdf4/COMPRESS_LEV2_20140201000000-GLOBCURRENT-L4-CURekm_15m-ERAWS_EEM-v02.0-fv01.0.nc";
     String endpoint = TestOnLocalServer.withHttpPath("/ncss/grid/" + filename
@@ -121,5 +125,9 @@ public class NcssGridIntegrationTest {
 
     // Open the binary response in memory
     openBinaryNew(content, "eastward_ekman_current_velocity");
+  }
+
+  private static void skipTestIfNetCDF4NotPresent() {
+    assumeTrue(NetcdfClibrary.isLibraryPresent());
   }
 }

--- a/tds/src/test/java/thredds/server/ncss/controller/grid/GridDatasetControllerTest.java
+++ b/tds/src/test/java/thredds/server/ncss/controller/grid/GridDatasetControllerTest.java
@@ -4,6 +4,8 @@
  */
 package thredds.server.ncss.controller.grid;
 
+import static org.junit.Assume.assumeTrue;
+
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 import org.junit.Before;
@@ -26,6 +28,7 @@ import org.springframework.web.context.WebApplicationContext;
 import thredds.mock.web.MockTdsContextLoader;
 import thredds.server.ncss.format.SupportedFormat;
 import thredds.util.Constants;
+import ucar.nc2.ffi.netcdf.NetcdfClibrary;
 import ucar.unidata.util.test.category.NeedsCdmUnitTest;
 import java.lang.invoke.MethodHandles;
 
@@ -70,6 +73,8 @@ public class GridDatasetControllerTest {
 
   @Test
   public void getGridSubsetOnGridDatasetNc4() throws Exception {
+    skipTestIfNetCDF4NotPresent();
+
     RequestBuilder rb = MockMvcRequestBuilders.get("/ncss/grid/testGFSfmrc/GFS_CONUS_80km_nc_best.ncd")
         .servletPath("/ncss/grid/testGFSfmrc/GFS_CONUS_80km_nc_best.ncd")
         .param("accept", SupportedFormat.NETCDF4.getFormatName())
@@ -111,4 +116,7 @@ public class GridDatasetControllerTest {
     }
   }
 
+  private static void skipTestIfNetCDF4NotPresent() {
+    assumeTrue(NetcdfClibrary.isLibraryPresent());
+  }
 }

--- a/tds/src/test/java/thredds/server/ncss/controller/grid/SpatialSubsettingTest.java
+++ b/tds/src/test/java/thredds/server/ncss/controller/grid/SpatialSubsettingTest.java
@@ -37,6 +37,7 @@ import ucar.nc2.NetcdfFiles;
 import ucar.nc2.dataset.NetcdfDataset;
 import ucar.nc2.dataset.NetcdfDatasets;
 import ucar.nc2.dt.GridDataset;
+import ucar.nc2.ffi.netcdf.NetcdfClibrary;
 import ucar.unidata.geoloc.LatLonPoint;
 import ucar.unidata.geoloc.LatLonRect;
 import ucar.unidata.util.test.category.NeedsCdmUnitTest;
@@ -46,6 +47,7 @@ import java.lang.invoke.MethodHandles;
 import java.util.*;
 
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
 /**
  * @author marcos
@@ -64,6 +66,7 @@ public class SpatialSubsettingTest {
   private MockMvc mockMvc;
   private RequestBuilder requestBuilder;
 
+  private SupportedFormat format;
   private String accept;
   private String pathInfo;
   private List<String> vars;
@@ -89,6 +92,7 @@ public class SpatialSubsettingTest {
   }
 
   public SpatialSubsettingTest(SupportedFormat format, String pathInfo, List<String> vars, double[] latlonRectParams) {
+    this.format = format;
     this.accept = format.getAliases().get(0);
     this.pathInfo = pathInfo;
     this.vars = vars;
@@ -125,6 +129,7 @@ public class SpatialSubsettingTest {
 
   @Test
   public void shouldGetVariablesSubset() throws Exception {
+    skipTestIfNetCDF4NotPresent();
 
     // gridDataController.getGridSubset(params, validationResult, response);
 
@@ -154,5 +159,11 @@ public class SpatialSubsettingTest {
       f.format(" %s=%s%n", name, req.getParameter(name));
     }
     System.out.printf("%s%n%s%n", req.getRequestURI(), f);
+  }
+
+  private void skipTestIfNetCDF4NotPresent() {
+    if (format == SupportedFormat.NETCDF4) {
+      assumeTrue(NetcdfClibrary.isLibraryPresent());
+    }
   }
 }

--- a/tds/src/test/java/thredds/server/ncss/controller/grid/TemporalSpaceSubsettingTest.java
+++ b/tds/src/test/java/thredds/server/ncss/controller/grid/TemporalSpaceSubsettingTest.java
@@ -31,6 +31,7 @@ import ucar.nc2.NetcdfFile;
 import ucar.nc2.NetcdfFiles;
 import ucar.nc2.dataset.NetcdfDataset;
 import ucar.nc2.dataset.NetcdfDatasets;
+import ucar.nc2.ffi.netcdf.NetcdfClibrary;
 import ucar.unidata.util.test.category.NeedsCdmUnitTest;
 
 import java.io.IOException;
@@ -39,6 +40,7 @@ import java.util.Arrays;
 import java.util.Collection;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeTrue;
 
 /**
  * @author mhermida
@@ -56,6 +58,7 @@ public class TemporalSpaceSubsettingTest {
   private MockMvc mockMvc;
   private MockHttpServletRequestBuilder requestBuilder;
 
+  private SupportedFormat format;
   private String pathInfo;
   private int lengthTimeDim; // Expected time dimension length
 
@@ -102,6 +105,7 @@ public class TemporalSpaceSubsettingTest {
 
   public TemporalSpaceSubsettingTest(SupportedFormat format, int expectedLengthTimeDim, String pathInfoForTest,
       String temporal, String time, String time_window, String time_start, String time_end, String time_duration) {
+    this.format = format;
     lengthTimeDim = expectedLengthTimeDim;
     pathInfo = pathInfoForTest;
     String servletPath = pathInfo;
@@ -119,6 +123,7 @@ public class TemporalSpaceSubsettingTest {
 
   @Test
   public void shouldGetTimeRange() throws Exception {
+    skipTestIfNetCDF4NotPresent();
 
     MvcResult mvc = this.mockMvc.perform(requestBuilder).andReturn();
 
@@ -144,5 +149,9 @@ public class TemporalSpaceSubsettingTest {
 
   }
 
-
+  private void skipTestIfNetCDF4NotPresent() {
+    if (format == SupportedFormat.NETCDF4) {
+      assumeTrue(NetcdfClibrary.isLibraryPresent());
+    }
+  }
 }

--- a/tds/src/test/java/thredds/server/ncss/controller/grid/VariableSpaceSubsettingTest.java
+++ b/tds/src/test/java/thredds/server/ncss/controller/grid/VariableSpaceSubsettingTest.java
@@ -34,6 +34,7 @@ import ucar.nc2.NetcdfFiles;
 import ucar.nc2.dataset.NetcdfDataset;
 import ucar.nc2.dataset.NetcdfDatasets;
 import ucar.nc2.dt.grid.GeoGrid;
+import ucar.nc2.ffi.netcdf.NetcdfClibrary;
 import ucar.unidata.util.test.category.NeedsCdmUnitTest;
 
 import java.io.IOException;
@@ -45,6 +46,7 @@ import java.util.List;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
 /**
  * @author marcos
@@ -63,6 +65,7 @@ public class VariableSpaceSubsettingTest {
   private MockMvc mockMvc;
   private RequestBuilder requestBuilder;
 
+  private SupportedFormat format;
   private String accept;
   private String pathInfo;
   private int[][] expectedShapes;
@@ -99,6 +102,7 @@ public class VariableSpaceSubsettingTest {
   }
 
   public VariableSpaceSubsettingTest(SupportedFormat format, int[][] result, String pathInfo, List<String> vars) {
+    this.format = format;
     this.accept = format.getAliases().get(0);
     this.expectedShapes = result;
     this.pathInfo = pathInfo;
@@ -123,6 +127,7 @@ public class VariableSpaceSubsettingTest {
 
   @Test
   public void shouldGetVariablesSubset() throws Exception {
+    skipTestIfNetCDF4NotPresent();
 
     mockMvc.perform(requestBuilder).andExpect(MockMvcResultMatchers.status().isOk()).andExpect(new ResultMatcher() {
       public void match(MvcResult result) throws Exception {
@@ -147,4 +152,9 @@ public class VariableSpaceSubsettingTest {
     });
   }
 
+  private void skipTestIfNetCDF4NotPresent() {
+    if (format == SupportedFormat.NETCDF4) {
+      assumeTrue(NetcdfClibrary.isLibraryPresent());
+    }
+  }
 }

--- a/tds/src/test/java/thredds/server/ncss/controller/point/TestStationFCController.java
+++ b/tds/src/test/java/thredds/server/ncss/controller/point/TestStationFCController.java
@@ -6,6 +6,7 @@
 package thredds.server.ncss.controller.point;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assume.assumeTrue;
 
 import org.junit.Before;
 import org.junit.Ignore;
@@ -30,6 +31,7 @@ import thredds.mock.web.MockTdsContextLoader;
 import thredds.server.ncss.exception.FeaturesNotFoundException;
 import thredds.server.ncss.format.SupportedFormat;
 import thredds.util.ContentType;
+import ucar.nc2.ffi.netcdf.NetcdfClibrary;
 import ucar.unidata.util.test.category.NeedsCdmUnitTest;
 import java.lang.invoke.MethodHandles;
 
@@ -59,6 +61,8 @@ public class TestStationFCController {
 
   @Test
   public void getClosestStationData() throws Exception {
+    skipTestIfNetCDF4NotPresent();
+
     long start = System.currentTimeMillis();
     RequestBuilder rb = MockMvcRequestBuilders.get(dataset).servletPath(dataset).param("longitude", "-105.203")
         .param("latitude", "40.019").param("accept", "netcdf4").param("time_start", "2006-03-028T00:00:00Z")
@@ -164,5 +168,8 @@ public class TestStationFCController {
     this.mockMvc.perform(rb).andExpect(MockMvcResultMatchers.status().isBadRequest());
   }
 
+  private static void skipTestIfNetCDF4NotPresent() {
+    assumeTrue(NetcdfClibrary.isLibraryPresent());
+  }
 }
 


### PR DESCRIPTION
If you don't have the netcdf4 library installed and the right environment variable set pointing to it, then some tests will fail (other than the ones on Jenkins that fail). This change would ignore those tests if the library isn't found, otherwise run them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidata/tds/252)
<!-- Reviewable:end -->
