### PR TITLE
Fix admin show collection and add test trigger

### DIFF
--- a/tds/src/main/java/thredds/server/admin/AdminCollectionController.java
+++ b/tds/src/main/java/thredds/server/admin/AdminCollectionController.java
@@ -170,9 +170,12 @@ public class AdminCollectionController implements InitializingBean {
       showFeatureCollection(out, want);
 
       String uriParam = Escape.uriParam(want.getCollectionName());
-      String url = tdsContext.getContextPath() + PATH + "/" + TRIGGER + "?" + COLLECTION + "=" + uriParam + "&"
-          + TRIGGER + "=" + CollectionUpdateType.nocheck;
-      out.format("<p/><a href='%s'>Send trigger to %s</a>%n", url, Escape.html(want.getCollectionName()));
+      String url =
+          tdsContext.getContextPath() + PATH + "/" + TRIGGER + "?" + COLLECTION + "=" + uriParam + "&" + TRIGGER + "=";
+      out.format("<p/><a href='%s'>Send 'nocheck' trigger to %s</a>%n", url + CollectionUpdateType.nocheck,
+          Escape.html(want.getCollectionName()));
+      out.format("<p/><a href='%s'>Send 'test' trigger to %s</a>%n", url + CollectionUpdateType.test,
+          Escape.html(want.getCollectionName()));
 
       String url2 = tdsContext.getContextPath() + PATH + "/" + DOWNLOAD + "?" + COLLECTION + "=" + uriParam;
       out.format("<p/><a href='%s'>Download index file for %s</a>%n", url2, Escape.html(want.getCollectionName()));

--- a/tds/src/main/java/thredds/server/admin/AdminCollectionController.java
+++ b/tds/src/main/java/thredds/server/admin/AdminCollectionController.java
@@ -193,7 +193,7 @@ public class AdminCollectionController implements InitializingBean {
 
     for (FeatureCollectionRef fc : fcList) {
       String uriParam = Escape.uriParam(fc.getCollectionName());
-      String url = tdsContext.getContextPath() + PATH + "?" + COLLECTION + "=" + uriParam;
+      String url = tdsContext.getContextPath() + PATH + "/" + SHOW_COLLECTION + "?" + COLLECTION + "=" + uriParam;
       out.format("<p/><a href='%s'>%s</a> (%s)%n", url, fc.getCollectionName(), fc.getName());
       InvDatasetFeatureCollection fcd = datasetManager.openFeatureCollection(fc);
 


### PR DESCRIPTION
- Add "test" as well as "nocheck" trigger link to admin page

- Fix collection links on the “Show all collection status” page (`admin/collection/showStatus`). Previously this gave a 404 error. Now this leads to `admin/collection/showCollection?collection=name` which calls `showStatus` for a feature collection.  I am not actually sure if this useful as you could get to that page from the "Show collections" (`admin/debug?Collections/showCollection`) page already, but as far as I can tell this is what happened in TDS 4.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidata/tds/267)
<!-- Reviewable:end -->
