### PR TITLE
Support UGRID FMRCs in the TDS

### DIFF
--- a/tds-ugrid/src/main/java/ucar/nc2/dt/UGridDatatype.java
+++ b/tds-ugrid/src/main/java/ucar/nc2/dt/UGridDatatype.java
@@ -5,7 +5,11 @@
 
 package ucar.nc2.dt;
 
-import ucar.ma2.*;
+import ucar.ma2.Array;
+import ucar.ma2.DataType;
+import ucar.ma2.InvalidRangeException;
+import ucar.ma2.MAMath;
+import ucar.ma2.Range;
 import ucar.nc2.Dimension;
 import ucar.nc2.Attribute;
 import ucar.nc2.dataset.VariableDS;
@@ -22,7 +26,7 @@ import ucar.unidata.geoloc.LatLonPoint;
  *
  * @author caron
  */
-public interface UGridDatatype extends Comparable<UGridDatatype> {
+public interface UGridDatatype extends ucar.nc2.dt.GridDatatype {
 
   /**
    * Get the name of the Grid

--- a/tds-ugrid/src/main/java/ucar/nc2/dt/ugrid/MeshVariable.java
+++ b/tds-ugrid/src/main/java/ucar/nc2/dt/ugrid/MeshVariable.java
@@ -1,11 +1,16 @@
 /*
- * Copyright (c) 2011-2014 Applied Science Associates
+ * Copyright (c) 2011-2022 University Corporation for Atmospheric Research/Unidata and Applied Science Associates
+ * See LICENSE for license information.
  */
 
 package ucar.nc2.dt.ugrid;
 
+import com.google.common.collect.ImmutableList;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import ucar.nc2.dt.GridCoordSystem;
+import ucar.nc2.dt.GridDatatype;
+import ucar.nc2.dt.grid.GridCoordSys;
 import ucar.nc2.dt.ugrid.topology.Topology;
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -61,6 +66,16 @@ public class MeshVariable implements UGridDatatype {
     this.dataset = dataset;
     this.mydims = vs.getDimensions();
     this.cellLocation = vs.findAttributeIgnoreCase("location").getStringValue();
+  }
+
+  @Override
+  public String getFullName() {
+    return vs.getFullName();
+  }
+
+  @Override
+  public String getShortName() {
+    return vs.getShortName();
   }
 
   public String getName() {
@@ -172,6 +187,19 @@ public class MeshVariable implements UGridDatatype {
     throw new UnsupportedOperationException("Not supported yet.");
   }
 
+  @Override
+  public GridCoordSystem getCoordinateSystem() {
+    ImmutableList<CoordinateSystem> coordSystems = vs.getCoordinateSystems();
+    if (coordSystems.size() == 0) {
+      logger.error("Mesh variable {} has no coordinate system.", vs.getFullName());
+      return null;
+    } else if (coordSystems.size() > 1) {
+      logger.warn("Mesh variable {} has more than one coordinate system. Using the first encountered.",
+          vs.getFullName());
+    }
+    return new GridCoordSys(coordSystems.get(0), null);
+  }
+
   public Meshset getMeshset() {
     return meshset;
   }
@@ -227,6 +255,11 @@ public class MeshVariable implements UGridDatatype {
 
   public Array readDataSlice(int rt_index, int e_index, int t_index, int z_index, int y_index, int x_index)
       throws IOException {
+    throw new UnsupportedOperationException("Not supported yet.");
+  }
+
+  @Override
+  public Array readSubset(List<Range> subset) throws InvalidRangeException, IOException {
     throw new UnsupportedOperationException("Not supported yet.");
   }
 
@@ -609,5 +642,20 @@ public class MeshVariable implements UGridDatatype {
 
   public int compareTo(UGridDatatype g) {
     return getNameEscaped().compareTo(g.getNameEscaped());
+  }
+
+  @Override
+  public int compareTo(GridDatatype o) {
+    return 0;
+  }
+
+  @Override
+  public boolean hasMissing() {
+    return false;
+  }
+
+  @Override
+  public boolean isMissing(double val) {
+    return false;
   }
 }

--- a/tds-ugrid/src/main/resources/META-INF/services/ucar.nc2.dt.grid.internal.spi.GridDatasetProvider
+++ b/tds-ugrid/src/main/resources/META-INF/services/ucar.nc2.dt.grid.internal.spi.GridDatasetProvider
@@ -1,0 +1,1 @@
+ucar.nc2.dt.ugrid.UGridDataset$Factory

--- a/tds/build.gradle
+++ b/tds/build.gradle
@@ -27,6 +27,7 @@ dependencies {
   compile project(':tdcommon')
   compile 'edu.ucar:cdm-mcidas'
   compile 'edu.ucar:waterml'
+  implementation project(':tds-ugrid')
 
   // DAP4 Dependencies (technically forward)
   compile 'edu.ucar:d4cdm'

--- a/tds/src/integrationTests/java/ucar/nc2/dt/fmrc/TestUgridFmrc.java
+++ b/tds/src/integrationTests/java/ucar/nc2/dt/fmrc/TestUgridFmrc.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2022 University Corporation for Atmospheric Research/Unidata
+ * See LICENSE for license information.
+ */
+
+package ucar.nc2.dt.fmrc;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import java.io.IOException;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import thredds.test.util.TdsTestDir;
+import ucar.ma2.Array;
+import ucar.ma2.DataType;
+import ucar.ma2.InvalidRangeException;
+import ucar.nc2.NetcdfFile;
+import ucar.nc2.Variable;
+import ucar.nc2.dataset.NetcdfDatasets;
+import ucar.unidata.util.test.TestDir;
+import ucar.unidata.util.test.category.NeedsCdmUnitTest;
+
+public class TestUgridFmrc {
+
+  private static final String FILE_1 = TestDir.cdmUnitTestDir + "conventions/ugrid/USF_WSF/usf_fvcom_2019_01_27.nc";
+  private static final String FILE_2 = TestDir.cdmUnitTestDir + "conventions/ugrid/USF_WSF/usf_fvcom_2019_01_28.nc";
+
+  private static NetcdfFile ncf1;
+  private static NetcdfFile ncf2;
+
+  @BeforeClass
+  public static void openIndividualFiles() {
+    try {
+      ncf1 = NetcdfDatasets.openFile(FILE_1, null);
+      ncf2 = NetcdfDatasets.openFile(FILE_2, null);
+    } catch (IOException e) {
+      System.out.println("Could not setup the test. Failed to open one of the test files. " + e.getMessage());
+      assertThat(ncf1).isNotNull();
+      assertThat(ncf2).isNotNull();
+    }
+  }
+
+  /**
+   * Test that FMRC 2D collection is pulling data from the correct granules
+   */
+  @Test
+  @Category(NeedsCdmUnitTest.class)
+  public void test2DFmrc() throws IOException, InvalidRangeException {
+    final String urlPath2d = "/thredds/cdmremote/testUsfWsfUgridFmrc/USF_WSF_nc_fmrc.ncd";
+    final String tdsLocation = "cdmremote:http://" + TdsTestDir.remoteTestServer + urlPath2d;
+    String testVariableName = "salinity";
+    String singleRuntimeSection = ":,2,10:10000:100";
+    try (NetcdfFile fmrc2d = NetcdfDatasets.openFile(tdsLocation, null)) {
+      ImmutableList<Variable> vars = fmrc2d.getVariables();
+      assertThat(vars).isNotEmpty();
+      // read data from variable
+      Variable fmrcVar = fmrc2d.findVariable(testVariableName);
+      Array fmrcData = fmrcVar.read("0," + singleRuntimeSection);
+      // test against data from individual files
+      Variable ncf1Var = ncf1.findVariable(testVariableName);
+      Array ncf1Data = ncf1Var.read(singleRuntimeSection);
+      assertThat(ncf1Data.get1DJavaArray(DataType.FLOAT)).isEqualTo(fmrcData.get1DJavaArray(DataType.FLOAT));
+
+      Variable ncf2Var = ncf2.findVariable(testVariableName);
+      Array ncf2Data = ncf2Var.read(singleRuntimeSection);
+      assertThat(ncf2Data.get1DJavaArray(DataType.FLOAT)).isNotEqualTo(fmrcData.get1DJavaArray(DataType.FLOAT));
+
+      fmrcData = fmrcVar.read("1," + singleRuntimeSection);
+      assertThat(ncf2Data.get1DJavaArray(DataType.FLOAT)).isEqualTo(fmrcData.get1DJavaArray(DataType.FLOAT));
+    }
+  }
+
+  /**
+   * Test that FMRC Constant Forecast Offset collection is pulling data from the correct granules
+   */
+  @Test
+  @Category(NeedsCdmUnitTest.class)
+  public void testCFOFmrc() throws IOException, InvalidRangeException {
+    // 8 hour offset into a collection of runs that output hourly
+    final String urlPathCfo = "/thredds/cdmremote/testUsfWsfUgridFmrc/offset/USF_WSF_nc_Offset_8.0hr";
+    final String tdsLocation = "cdmremote:http://" + TdsTestDir.remoteTestServer + urlPathCfo;
+    String testVariableName = "salinity";
+    String singleSpatialSection = "2,10:10000:100";
+    // index 8 => forecast hour 8 since index 0 is forecast hour 0
+    String singleRunTimeIndex = "8";
+    try (NetcdfFile fmrcCfo = NetcdfDatasets.openFile(tdsLocation, null)) {
+      ImmutableList<Variable> vars = fmrcCfo.getVariables();
+      assertThat(vars).isNotEmpty();
+      // read data from variable
+      Variable fmrcVar = fmrcCfo.findVariable(testVariableName);
+      Array fmrcData = fmrcVar.read("0," + singleSpatialSection);
+      // test against data from individual files
+      Variable ncf1Var = ncf1.findVariable(testVariableName);
+      Array ncf1Data = ncf1Var.read(singleRunTimeIndex + "," + singleSpatialSection);
+      assertThat(ncf1Data.get1DJavaArray(DataType.FLOAT)).isEqualTo(fmrcData.get1DJavaArray(DataType.FLOAT));
+
+      Variable ncf2Var = ncf2.findVariable(testVariableName);
+      Array ncf2Data = ncf2Var.read(singleRunTimeIndex + "," + singleSpatialSection);
+      assertThat(ncf2Data.get1DJavaArray(DataType.FLOAT)).isNotEqualTo(fmrcData.get1DJavaArray(DataType.FLOAT));
+
+      fmrcData = fmrcVar.read("1," + singleSpatialSection);
+      assertThat(ncf2Data.get1DJavaArray(DataType.FLOAT)).isEqualTo(fmrcData.get1DJavaArray(DataType.FLOAT));
+    }
+  }
+
+  /**
+   * Test that FMRC Constant Forecast Time collection is pulling data from the correct granule
+   */
+  @Test
+  @Category(NeedsCdmUnitTest.class)
+  public void testCFTFmrc() throws IOException, InvalidRangeException {
+    // 8 hour offset into a collection of runs that output hourly
+    final String urlPathCft =
+        "/thredds/cdmremote/testUsfWsfUgridFmrc/forecast/USF_WSF_nc_ConstantForecast_2019-01-28T03:00:00Z";
+    final String tdsLocation = "cdmremote:http://" + TdsTestDir.remoteTestServer + urlPathCft;
+    String testVariableName = "salinity";
+    String singleSpatialSection = "2,10:10000:100";
+    // Forecast time 2019-01-28T03:00:00Z should be the 4th time index into the second granule of the collection
+    // 4th time value is index value 3 since zero based
+    String singleRunTimeIndex = "3";
+    try (NetcdfFile fmrcCfo = NetcdfDatasets.openFile(tdsLocation, null)) {
+      ImmutableList<Variable> vars = fmrcCfo.getVariables();
+      assertThat(vars).isNotEmpty();
+      // read data from variable
+      Variable fmrcVar = fmrcCfo.findVariable(testVariableName);
+      Array fmrcData = fmrcVar.read("0," + singleSpatialSection);
+      // test against data from individual file
+      Variable ncf2Var = ncf2.findVariable(testVariableName);
+      Array ncf2Data = ncf2Var.read(singleRunTimeIndex + "," + singleSpatialSection);
+      assertThat(ncf2Data.get1DJavaArray(DataType.FLOAT)).isEqualTo(fmrcData.get1DJavaArray(DataType.FLOAT));
+    }
+  }
+
+  /**
+   * Test that FMRC Forecast Model Run collection is pulling data from the correct granule
+   */
+  @Test
+  @Category(NeedsCdmUnitTest.class)
+  public void testFMRFmrc() throws IOException, InvalidRangeException {
+    // the 2019-01-28T00:00:00Z Forecast Model Run should be the same as the second granule that makes up collection.
+    final String urlPathCft = "/thredds/cdmremote/testUsfWsfUgridFmrc/runs/USF_WSF_nc_RUN_2019-01-28T00:00:00Z";
+    final String tdsLocation = "cdmremote:http://" + TdsTestDir.remoteTestServer + urlPathCft;
+    String testVariableName = "salinity";
+    String testSection = ":,2,10:10000:100";
+    try (NetcdfFile fmrcCfo = NetcdfDatasets.openFile(tdsLocation, null)) {
+      ImmutableList<Variable> vars = fmrcCfo.getVariables();
+      assertThat(vars).isNotEmpty();
+      // read data from variable
+      Variable fmrcVar = fmrcCfo.findVariable(testVariableName);
+      Array fmrcData = fmrcVar.read(testSection);
+      // test against data from individual file
+      Variable ncf2Var = ncf2.findVariable(testVariableName);
+      Array ncf2Data = ncf2Var.read(testSection);
+      assertThat(ncf2Data.get1DJavaArray(DataType.FLOAT)).isEqualTo(fmrcData.get1DJavaArray(DataType.FLOAT));
+    }
+  }
+
+  @AfterClass
+  public static void cleanup() throws IOException {
+    if (ncf1 != null) {
+      ncf1.close();
+    }
+    if (ncf2 != null) {
+      ncf2.close();
+    }
+  }
+}

--- a/tds/src/test/content/thredds/catalog.xml
+++ b/tds/src/test/content/thredds/catalog.xml
@@ -21,6 +21,16 @@
     <service name="uddc" serviceType="UDDC" base="/thredds/uddc/"/>
   </service>
 
+  <service name="ugrid" base="" serviceType="compound">
+    <service name="odap" serviceType="OpenDAP" base="/thredds/dodsC/"/>
+    <service name="http" serviceType="HTTPServer" base="/thredds/fileServer/"/>
+    <service name="wms" serviceType="WMS" base="/thredds/wms/"/>
+    <service name="cdmremote" serviceType="CdmRemote" base="/thredds/cdmremote/"/>
+    <service name="iso" serviceType="ISO" base="/thredds/iso/"/>
+    <service name="ncml" serviceType="NCML" base="/thredds/ncml/"/>
+    <service name="uddc" serviceType="UDDC" base="/thredds/uddc/"/>
+  </service>
+
   <service name="obstoreGrid" base="" serviceType="compound">
     <service name="odap" serviceType="OpenDAP" base="/thredds/dodsC/"/>
     <service name="wcs" serviceType="WCS" base="/thredds/wcs/"/>

--- a/tds/src/test/content/thredds/catalogFmrc.xml
+++ b/tds/src/test/content/thredds/catalogFmrc.xml
@@ -75,5 +75,15 @@
 
   </featureCollection>
 
+  <featureCollection featureType="FMRC" name="USF_WSF_nc" path="testUsfWsfUgridFmrc">
+    <metadata inherited="true">
+      <dataType>Grid</dataType>
+      <dataFormat>NetCDF</dataFormat>
+      <serviceName>ugrid</serviceName>
+    </metadata>
+    <collection spec="${cdmUnitTest}/conventions/ugrid/USF_WSF/usf_fvcom_#yyyy_MM_dd#.nc$" />
+    <update startup="true" trigger="allow"/>
+    <fmrcConfig regularize="true" datasetTypes="TwoD Best Files Runs ConstantForecasts ConstantOffsets"/>
+  </featureCollection>
 
 </catalog>


### PR DESCRIPTION
Enable Forecast Model Run Collections for data following the UGRID
conventions. The following services are supported:

* OPeNDAP
* HTTPServer
* CDMRemote
* THREDDS ISO Services (iso, ncml, uddc)
* WMS

Support for NCSS will be added in a future update.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidata/tds/272)
<!-- Reviewable:end -->
