### PR TITLE
Update documentation about interval coordinate values

### DIFF
--- a/docs/adminguide/src/site/pages/tds_tutorial/faq/GribFaq.md
+++ b/docs/adminguide/src/site/pages/tds_tutorial/faq/GribFaq.md
@@ -141,3 +141,36 @@ double time(time=14);
 ~~~
 
 This is a *one-dimensional* time variable, and we use a scalar to avoid introducing an unneeded dimension of length 1.
+
+## Why isn't the coordinate for a time interval strictly monotonic?
+
+An example of an interval variable is "Total_precipitation_surface_Mixed_intervals_Accumulation" in NCEP GFS GRIB data.
+We call such variable a "mixed interval" variable because it is measured over time intervals that do not have a fixed length.
+For example, the `time_bounds` associated with the `time` coordinate for this variable has values:
+~~~
+time_bounds[254][2]
+    [0], 0.0, 3.0
+    [1], 0.0, 6.0
+    [2], 0.0, 9.0
+    [3], 6.0, 9.0
+    [4], 0.0, 12.0
+    [5], 6.0, 12.0
+    [6], 0.0, 15.0
+    [7], 12.0, 15.0
+    [8], 0.0, 18.0
+    [9], 12.0, 18.0
+    ...
+~~~
+
+Although the CF convention would allow any value in the interval to be the coordinate value, we currently choose the endpoint of the interval.
+This leads to a `time` coordinate with values:
+
+~~~
+time2[254]
+    3.0, 6.0, 9.0, 9.0, 12.0, 12.0, 15.0, 15.0, 18.0, 18.0,...
+~~~
+
+So currently, as shown in this example, a mixed interval time coordinate can have repeated values.
+In the future we plan to fix this so that the time coordinate is strictly monotonic in this situation, in order to be compliant with the NUG convention.
+
+See also the documentation about the [`intvFilter` option in the GRIB config](grib_collection_config_ref.html#intvfilter-filter-on-time-interval).

--- a/docs/adminguide/src/site/pages/thredds/GribConfigRef.md
+++ b/docs/adminguide/src/site/pages/thredds/GribConfigRef.md
@@ -175,8 +175,8 @@ Currently, the CDM places all intervals in the same variable (rather than create
 When all intervals have the same size, the interval size is added to the variable name. 
 Otherwise, the phrase "mixed_intervals" is added to the variable name.
 
-Generally, the CDM places the coordinate value at the midpoint of the interval.
-For example the time interval `(0,6)` will have a coordinate value `3`.
+Generally, the CDM places the coordinate value at the end of the interval.
+For example the time interval `(0,6)` will have a coordinate value `6`.
 The CDM looks for unique intervals in constructing the variable.
 This implies that the coordinate values are not always unique, but the coordinate bounds pair are always unique.
 Application code needs to understand this to handle this situation correctly, by checking `CoordinateAxis1D.isInterval()` or `CoordinateAxis2D.isInterval()`.

--- a/docs/devguide/src/site/pages/tds_tutorial/faq/GribFaq.md
+++ b/docs/devguide/src/site/pages/tds_tutorial/faq/GribFaq.md
@@ -141,3 +141,36 @@ double time(time=14);
 ~~~
 
 This is a *one-dimensional* time variable, and we use a scalar to avoid introducing an unneeded dimension of length 1.
+
+## Why isn't the coordinate for a time interval strictly monotonic?
+
+An example of an interval variable is "Total_precipitation_surface_Mixed_intervals_Accumulation" in NCEP GFS GRIB data.
+We call such variable a "mixed interval" variable because it is measured over time intervals that do not have a fixed length.
+For example, the `time_bounds` associated with the `time` coordinate for this variable has values:
+~~~
+time_bounds[254][2]
+    [0], 0.0, 3.0
+    [1], 0.0, 6.0
+    [2], 0.0, 9.0
+    [3], 6.0, 9.0
+    [4], 0.0, 12.0
+    [5], 6.0, 12.0
+    [6], 0.0, 15.0
+    [7], 12.0, 15.0
+    [8], 0.0, 18.0
+    [9], 12.0, 18.0
+    ...
+~~~
+
+Although the CF convention would allow any value in the interval to be the coordinate value, we currently choose the endpoint of the interval.
+This leads to a `time` coordinate with values:
+
+~~~
+time2[254]
+    3.0, 6.0, 9.0, 9.0, 12.0, 12.0, 15.0, 15.0, 18.0, 18.0,...
+~~~
+
+So currently, as shown in this example, a mixed interval time coordinate can have repeated values.
+In the future we plan to fix this so that the time coordinate is strictly monotonic in this situation, in order to be compliant with the NUG convention.
+
+See also the documentation about the [`intvFilter` option in the GRIB config](grib_collection_config_ref.html#intvfilter-filter-on-time-interval).

--- a/docs/devguide/src/site/pages/thredds/GribConfigRef.md
+++ b/docs/devguide/src/site/pages/thredds/GribConfigRef.md
@@ -175,8 +175,8 @@ Currently, the CDM places all intervals in the same variable (rather than create
 When all intervals have the same size, the interval size is added to the variable name. 
 Otherwise, the phrase "mixed_intervals" is added to the variable name.
 
-Generally, the CDM places the coordinate value at the midpoint of the interval.
-For example the time interval `(0,6)` will have a coordinate value `3`.
+Generally, the CDM places the coordinate value at the end of the interval.
+For example the time interval `(0,6)` will have a coordinate value `6`.
 The CDM looks for unique intervals in constructing the variable.
 This implies that the coordinate values are not always unique, but the coordinate bounds pair are always unique.
 Application code needs to understand this to handle this situation correctly, by checking `CoordinateAxis1D.isInterval()` or `CoordinateAxis2D.isInterval()`.

--- a/docs/quickstart/src/site/pages/tds_tutorial/faq/GribFaq.md
+++ b/docs/quickstart/src/site/pages/tds_tutorial/faq/GribFaq.md
@@ -141,3 +141,36 @@ double time(time=14);
 ~~~
 
 This is a *one-dimensional* time variable, and we use a scalar to avoid introducing an unneeded dimension of length 1.
+
+## Why isn't the coordinate for a time interval strictly monotonic?
+
+An example of an interval variable is "Total_precipitation_surface_Mixed_intervals_Accumulation" in NCEP GFS GRIB data.
+We call such variable a "mixed interval" variable because it is measured over time intervals that do not have a fixed length.
+For example, the `time_bounds` associated with the `time` coordinate for this variable has values:
+~~~
+time_bounds[254][2]
+    [0], 0.0, 3.0
+    [1], 0.0, 6.0
+    [2], 0.0, 9.0
+    [3], 6.0, 9.0
+    [4], 0.0, 12.0
+    [5], 6.0, 12.0
+    [6], 0.0, 15.0
+    [7], 12.0, 15.0
+    [8], 0.0, 18.0
+    [9], 12.0, 18.0
+    ...
+~~~
+
+Although the CF convention would allow any value in the interval to be the coordinate value, we currently choose the endpoint of the interval.
+This leads to a `time` coordinate with values:
+
+~~~
+time2[254]
+    3.0, 6.0, 9.0, 9.0, 12.0, 12.0, 15.0, 15.0, 18.0, 18.0,...
+~~~
+
+So currently, as shown in this example, a mixed interval time coordinate can have repeated values.
+In the future we plan to fix this so that the time coordinate is strictly monotonic in this situation, in order to be compliant with the NUG convention.
+
+See also the documentation about the [`intvFilter` option in the GRIB config](grib_collection_config_ref.html#intvfilter-filter-on-time-interval).

--- a/docs/quickstart/src/site/pages/thredds/GribConfigRef.md
+++ b/docs/quickstart/src/site/pages/thredds/GribConfigRef.md
@@ -175,8 +175,8 @@ Currently, the CDM places all intervals in the same variable (rather than create
 When all intervals have the same size, the interval size is added to the variable name. 
 Otherwise, the phrase "mixed_intervals" is added to the variable name.
 
-Generally, the CDM places the coordinate value at the midpoint of the interval.
-For example the time interval `(0,6)` will have a coordinate value `3`.
+Generally, the CDM places the coordinate value at the end of the interval.
+For example the time interval `(0,6)` will have a coordinate value `6`.
 The CDM looks for unique intervals in constructing the variable.
 This implies that the coordinate values are not always unique, but the coordinate bounds pair are always unique.
 Application code needs to understand this to handle this situation correctly, by checking `CoordinateAxis1D.isInterval()` or `CoordinateAxis2D.isInterval()`.

--- a/docs/userguide/src/site/pages/tds_tutorial/faq/GribFaq.md
+++ b/docs/userguide/src/site/pages/tds_tutorial/faq/GribFaq.md
@@ -141,3 +141,36 @@ double time(time=14);
 ~~~
 
 This is a *one-dimensional* time variable, and we use a scalar to avoid introducing an unneeded dimension of length 1.
+
+## Why isn't the coordinate for a time interval strictly monotonic?
+
+An example of an interval variable is "Total_precipitation_surface_Mixed_intervals_Accumulation" in NCEP GFS GRIB data.
+We call such variable a "mixed interval" variable because it is measured over time intervals that do not have a fixed length.
+For example, the `time_bounds` associated with the `time` coordinate for this variable has values:
+~~~
+time_bounds[254][2]
+    [0], 0.0, 3.0
+    [1], 0.0, 6.0
+    [2], 0.0, 9.0
+    [3], 6.0, 9.0
+    [4], 0.0, 12.0
+    [5], 6.0, 12.0
+    [6], 0.0, 15.0
+    [7], 12.0, 15.0
+    [8], 0.0, 18.0
+    [9], 12.0, 18.0
+    ...
+~~~
+
+Although the CF convention would allow any value in the interval to be the coordinate value, we currently choose the endpoint of the interval.
+This leads to a `time` coordinate with values:
+
+~~~
+time2[254]
+    3.0, 6.0, 9.0, 9.0, 12.0, 12.0, 15.0, 15.0, 18.0, 18.0,...
+~~~
+
+So currently, as shown in this example, a mixed interval time coordinate can have repeated values.
+In the future we plan to fix this so that the time coordinate is strictly monotonic in this situation, in order to be compliant with the NUG convention.
+
+See also the documentation about the [`intvFilter` option in the GRIB config](grib_collection_config_ref.html#intvfilter-filter-on-time-interval).

--- a/docs/userguide/src/site/pages/thredds/GribConfigRef.md
+++ b/docs/userguide/src/site/pages/thredds/GribConfigRef.md
@@ -175,8 +175,8 @@ Currently, the CDM places all intervals in the same variable (rather than create
 When all intervals have the same size, the interval size is added to the variable name. 
 Otherwise, the phrase "mixed_intervals" is added to the variable name.
 
-Generally, the CDM places the coordinate value at the midpoint of the interval.
-For example the time interval `(0,6)` will have a coordinate value `3`.
+Generally, the CDM places the coordinate value at the end of the interval.
+For example the time interval `(0,6)` will have a coordinate value `6`.
 The CDM looks for unique intervals in constructing the variable.
 This implies that the coordinate values are not always unique, but the coordinate bounds pair are always unique.
 Application code needs to understand this to handle this situation correctly, by checking `CoordinateAxis1D.isInterval()` or `CoordinateAxis2D.isInterval()`.


### PR DESCRIPTION
- Revert change to documentation to reflect change reverted in https://github.com/Unidata/netcdf-java/pull/1076.

- Add section to the GRIB FAQs about mixed interval time coordinates. Of course, this would have to be updated after Ethan's fix is merged, but I thought it might be useful to have an example there.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidata/tds/280)
<!-- Reviewable:end -->
