### PR TITLE
Throw an exception when using DAP4 until we get it functional

### DIFF
--- a/tds/src/main/java/thredds/server/dap4/Dap4Controller.java
+++ b/tds/src/main/java/thredds/server/dap4/Dap4Controller.java
@@ -65,7 +65,8 @@ public class Dap4Controller extends DapController {
 
   @RequestMapping("**")
   public void handleRequest(HttpServletRequest req, HttpServletResponse res) throws IOException {
-    super.handleRequest(req, res);
+    throw new UnsupportedOperationException("DAP4 is not currently functional, but we are working on it!");
+    // super.handleRequest(req, res);
   }
 
   //////////////////////////////////////////////////


### PR DESCRIPTION
DAP4 is not completely working yet and so we have removed it from `netcdfAll`. However, recently a user reported lots of errors from TDS when using DAP4, so it is still apparently allowed to be configured and used from TDS.

This PR would throw an exception when DAP4 is used from TDS, so that hopefully it is clearer that it is not yet functional, but we are working on it. Suggestions for better messages welcome!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidata/tds/288)
<!-- Reviewable:end -->
