### PR TITLE
Add more info about chronicle map cache configuration parameters

### DIFF
--- a/docs/adminguide/src/site/pages/thredds/ThreddsConfigRef.md
+++ b/docs/adminguide/src/site/pages/thredds/ThreddsConfigRef.md
@@ -448,23 +448,29 @@ The cache information is updated based on the `recheckEvery` field in the `joinE
 ### FeatureCollection Cache
 
 This is where persistent information is kept about FMRCs, in order to speed them up.
+This cache is currently implemented with [Chronicle Map](https://chronicle.software/open-hft/map/){:target="_blank"}.
 We recommend that you use the default settings, by not specifying this option.
 
 ~~~xml
- <FeatureCollection>
-   <dir>${tds.content.root.path}/thredds/cache/collection/</dir>
-   <maxEntries>1000</maxEntries>
-   <maxBloatFactor>1</maxBloatFactor>
- </FeatureCollection>
+<FeatureCollection>
+  <dir>${tds.content.root.path}/thredds/cache/collection/</dir>
+  <maxEntries>1000</maxEntries>
+  <maxBloatFactor>1</maxBloatFactor>
+</FeatureCollection>
 ~~~
 
-* `dir`: location of Feature Collection cache, currently implemented
-  with [Chronicle Map](https://chronicle.software/open-hft/map/){:target="_blank"}.
+* `dir`: location of Feature Collection cache.
   If not otherwise set, the TDS will use the`${tds.content.root.path}/thredds/cache/collection/` directory.
   We recommend that you use this default, by not specifying a `FeatureCollection.dir` element.
-* `maxEntries`: the number of entries the cache is going to hold, _at most_.
+* `maxEntries`: the number of entries the cache is going to hold, _at most_. Each FMRC file is one "entry" in the cache. The default value for this is 1000.
+  If the `maxBloatFactor` is set to 1 (the default), then this value is the maximum possible number of FMRC files allowed.
+  If you have more than 1000 FMRC files, then we recommend increasing the `maxEntries` value to be the maximum number of FMRC files you expect to have.
   See [here](https://gerrit.googlesource.com/modules/cache-chroniclemap/+/HEAD/src/main/resources/Documentation/config.md#configuration-parameters) for more details.
-* `maxBloatFactor`: the maximun number of times the cache is allowed to grow in size. See [here](https://gerrit.googlesource.com/modules/cache-chroniclemap/+/HEAD/src/main/resources/Documentation/config.md#configuration-parameters) for more details.
+* `maxBloatFactor`: the maximum number of times the cache is allowed to grow in size.
+  The default value for this is 1 (the cache cannot grow in size).
+  If it is possible to have more FMRC files than your `maxEntries`, then this value should be increased.
+  It is strongly advised not to configure this value to more than 10, as the cache works progressively slower when the actual size grows far beyond the size configured in your `maxEntries`.
+  See [here](https://gerrit.googlesource.com/modules/cache-chroniclemap/+/HEAD/src/main/resources/Documentation/config.md#configuration-parameters) for more details.
 
 ### GRIB Index Redirection
 

--- a/docs/devguide/src/site/pages/thredds/ThreddsConfigRef.md
+++ b/docs/devguide/src/site/pages/thredds/ThreddsConfigRef.md
@@ -447,23 +447,29 @@ The cache information is updated based on the `recheckEvery` field in the `joinE
 ### FeatureCollection Cache
 
 This is where persistent information is kept about FMRCs, in order to speed them up.
+This cache is currently implemented with [Chronicle Map](https://chronicle.software/open-hft/map/){:target="_blank"}.
 We recommend that you use the default settings, by not specifying this option.
 
 ~~~xml
- <FeatureCollection>
-   <dir>${tds.content.root.path}/thredds/cache/collection/</dir>
-   <maxEntries>1000</maxEntries>
-   <maxBloatFactor>1</maxBloatFactor>
- </FeatureCollection>
+<FeatureCollection>
+  <dir>${tds.content.root.path}/thredds/cache/collection/</dir>
+  <maxEntries>1000</maxEntries>
+  <maxBloatFactor>1</maxBloatFactor>
+</FeatureCollection>
 ~~~
 
-* `dir`: location of Feature Collection cache, currently implemented
-with [Chronicle Map](https://chronicle.software/open-hft/map/){:target="_blank"}. 
+* `dir`: location of Feature Collection cache.
   If not otherwise set, the TDS will use the`${tds.content.root.path}/thredds/cache/collection/` directory.
   We recommend that you use this default, by not specifying a `FeatureCollection.dir` element.
-* `maxEntries`: the number of entries the cache is going to hold, _at most_. 
-See [here](https://gerrit.googlesource.com/modules/cache-chroniclemap/+/HEAD/src/main/resources/Documentation/config.md#configuration-parameters) for more details.
-* `maxBloatFactor`: the maximun number of times the cache is allowed to grow in size. See [here](https://gerrit.googlesource.com/modules/cache-chroniclemap/+/HEAD/src/main/resources/Documentation/config.md#configuration-parameters) for more details.
+* `maxEntries`: the number of entries the cache is going to hold, _at most_. Each FMRC file is one "entry" in the cache. The default value for this is 1000.
+  If the `maxBloatFactor` is set to 1 (the default), then this value is the maximum possible number of FMRC files allowed.
+  If you have more than 1000 FMRC files, then we recommend increasing the `maxEntries` value to be the maximum number of FMRC files you expect to have.
+  See [here](https://gerrit.googlesource.com/modules/cache-chroniclemap/+/HEAD/src/main/resources/Documentation/config.md#configuration-parameters) for more details.
+* `maxBloatFactor`: the maximum number of times the cache is allowed to grow in size.
+  The default value for this is 1 (the cache cannot grow in size).
+  If it is possible to have more FMRC files than your `maxEntries`, then this value should be increased.
+  It is strongly advised not to configure this value to more than 10, as the cache works progressively slower when the actual size grows far beyond the size configured in your `maxEntries`.
+  See [here](https://gerrit.googlesource.com/modules/cache-chroniclemap/+/HEAD/src/main/resources/Documentation/config.md#configuration-parameters) for more details.
 
 ### GRIB Index Redirection
 

--- a/docs/quickstart/src/site/pages/thredds/ThreddsConfigRef.md
+++ b/docs/quickstart/src/site/pages/thredds/ThreddsConfigRef.md
@@ -448,23 +448,29 @@ The cache information is updated based on the `recheckEvery` field in the `joinE
 ### FeatureCollection Cache
 
 This is where persistent information is kept about FMRCs, in order to speed them up.
+This cache is currently implemented with [Chronicle Map](https://chronicle.software/open-hft/map/){:target="_blank"}.
 We recommend that you use the default settings, by not specifying this option.
 
 ~~~xml
- <FeatureCollection>
-   <dir>${tds.content.root.path}/thredds/cache/collection/</dir>
-   <maxEntries>1000</maxEntries>
-   <maxBloatFactor>1</maxBloatFactor>
- </FeatureCollection>
+<FeatureCollection>
+  <dir>${tds.content.root.path}/thredds/cache/collection/</dir>
+  <maxEntries>1000</maxEntries>
+  <maxBloatFactor>1</maxBloatFactor>
+</FeatureCollection>
 ~~~
 
-* `dir`: location of Feature Collection cache, currently implemented
-  with [Chronicle Map](https://chronicle.software/open-hft/map/){:target="_blank"}.
+* `dir`: location of Feature Collection cache.
   If not otherwise set, the TDS will use the`${tds.content.root.path}/thredds/cache/collection/` directory.
   We recommend that you use this default, by not specifying a `FeatureCollection.dir` element.
-* `maxEntries`: the number of entries the cache is going to hold, _at most_.
+* `maxEntries`: the number of entries the cache is going to hold, _at most_. Each FMRC file is one "entry" in the cache. The default value for this is 1000.
+  If the `maxBloatFactor` is set to 1 (the default), then this value is the maximum possible number of FMRC files allowed.
+  If you have more than 1000 FMRC files, then we recommend increasing the `maxEntries` value to be the maximum number of FMRC files you expect to have.
   See [here](https://gerrit.googlesource.com/modules/cache-chroniclemap/+/HEAD/src/main/resources/Documentation/config.md#configuration-parameters) for more details.
-* `maxBloatFactor`: the maximun number of times the cache is allowed to grow in size. See [here](https://gerrit.googlesource.com/modules/cache-chroniclemap/+/HEAD/src/main/resources/Documentation/config.md#configuration-parameters) for more details.
+* `maxBloatFactor`: the maximum number of times the cache is allowed to grow in size.
+  The default value for this is 1 (the cache cannot grow in size).
+  If it is possible to have more FMRC files than your `maxEntries`, then this value should be increased.
+  It is strongly advised not to configure this value to more than 10, as the cache works progressively slower when the actual size grows far beyond the size configured in your `maxEntries`.
+  See [here](https://gerrit.googlesource.com/modules/cache-chroniclemap/+/HEAD/src/main/resources/Documentation/config.md#configuration-parameters) for more details.
 
 ### GRIB Index Redirection
 

--- a/docs/userguide/src/site/pages/tds_tutorial/feature_collections/FmrcRef.md
+++ b/docs/userguide/src/site/pages/tds_tutorial/feature_collections/FmrcRef.md
@@ -128,16 +128,16 @@ This evens out time coordinates, and compensates for missing forecast times in t
 
 ## Persistent Caching
 
-An `fmrInv.xml` file is made which records the essential grid information from each file. 
-It is cached in a persistent [Berkeley Database (bdb)](https://en.wikipedia.org/wiki/Berkeley_DB){:target="_blank"} key/value store, so that it only has to be done the first time the file is accessed in an FMRC. 
-Each collection becomes a separate `bdb` database, and each file in the collection is an element in the database, with the filename as the key and the `fmrInv.xml` as the value. 
+The FMRC cache, currently implemented with [Chronicle Map](https://chronicle.software/open-hft/map/){:target="_blank"},
+records the essential grid information from each file in a key/value store.
+This cache is persisted to disk, and so also persists between reboots.
 When a collection is scanned, any filenames already in the database are reused. 
 Any new ones are read and added to the database. 
 Any entries in the database that no longer have a filename associated with them are deleted.
+The cache database file is located in `${tds.content.root.path}/thredds/cache/collection/GridDatasetInv.dat`.
+See also [FMRC cache settings documentation](https://docs.unidata.ucar.edu/tds/current/userguide/tds_config_ref.html#featurecollection-cache).
 
-[ToolsUI](https://docs.unidata.ucar.edu/netcdf-java/{{site.netcdf-java_docset_version}}/userguide/toolsui_ref.html){:target="_blank"} `collections` tab allows you to delete database or individual elements.
-
-## Conversion Of `<datasetFmrc>` Yo `<featureCollection>`
+## Conversion of `<datasetFmrc>` to `<featureCollection>`
 
 There is no need to specify `forecastModelRunCollection` versus `forecastModelRunSingleCollection`, nor `timeUnitsChange`. 
 This is detected automatically.

--- a/docs/userguide/src/site/pages/thredds/ThreddsConfigRef.md
+++ b/docs/userguide/src/site/pages/thredds/ThreddsConfigRef.md
@@ -448,23 +448,29 @@ The cache information is updated based on the `recheckEvery` field in the `joinE
 ### FeatureCollection Cache
 
 This is where persistent information is kept about FMRCs, in order to speed them up.
+This cache is currently implemented with [Chronicle Map](https://chronicle.software/open-hft/map/){:target="_blank"}.
 We recommend that you use the default settings, by not specifying this option.
 
 ~~~xml
- <FeatureCollection>
+<FeatureCollection>
   <dir>${tds.content.root.path}/thredds/cache/collection/</dir>
   <maxEntries>1000</maxEntries>
   <maxBloatFactor>1</maxBloatFactor>
 </FeatureCollection>
 ~~~
 
-* `dir`: location of Feature Collection cache, currently implemented
-  with [Chronicle Map](https://chronicle.software/open-hft/map/){:target="_blank"}.
+* `dir`: location of Feature Collection cache.
   If not otherwise set, the TDS will use the`${tds.content.root.path}/thredds/cache/collection/` directory.
   We recommend that you use this default, by not specifying a `FeatureCollection.dir` element.
-* `maxEntries`: the number of entries the cache is going to hold, _at most_.
+* `maxEntries`: the number of entries the cache is going to hold, _at most_. Each FMRC file is one "entry" in the cache. The default value for this is 1000.
+  If the `maxBloatFactor` is set to 1 (the default), then this value is the maximum possible number of FMRC files allowed.
+  If you have more than 1000 FMRC files, then we recommend increasing the `maxEntries` value to be the maximum number of FMRC files you expect to have.
   See [here](https://gerrit.googlesource.com/modules/cache-chroniclemap/+/HEAD/src/main/resources/Documentation/config.md#configuration-parameters) for more details.
-* `maxBloatFactor`: the maximun number of times the cache is allowed to grow in size. See [here](https://gerrit.googlesource.com/modules/cache-chroniclemap/+/HEAD/src/main/resources/Documentation/config.md#configuration-parameters) for more details.
+* `maxBloatFactor`: the maximum number of times the cache is allowed to grow in size.
+  The default value for this is 1 (the cache cannot grow in size).
+  If it is possible to have more FMRC files than your `maxEntries`, then this value should be increased.
+  It is strongly advised not to configure this value to more than 10, as the cache works progressively slower when the actual size grows far beyond the size configured in your `maxEntries`.
+  See [here](https://gerrit.googlesource.com/modules/cache-chroniclemap/+/HEAD/src/main/resources/Documentation/config.md#configuration-parameters) for more details.
 
 ### GRIB Index Redirection
 


### PR DESCRIPTION
After a recent issues involving the FMRC cache settings (https://github.com/Unidata/tds/issues/275), I wanted to try to add extra info and clarify the documentation about these settings.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidata/tds/289)
<!-- Reviewable:end -->
