### PR TITLE
Upgrade gretty and use mavenCentral

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,9 @@ buildscript {
   // The buildscript {} block is odd: even though we applied dependencies.gradle above, the repositories therein
   // do not get included here. Instead, we must explicitly define the repos again. Yay for duplication.
   repositories {
+    // Prefer mavenCentral to the Gradle Plugin Portal as the latter redirects to the unreliable JCenter
+    // see https://github.com/gradle/gradle/issues/15406
+    mavenCentral()
     gradlePluginPortal()
     exclusiveContent {
       forRepository {

--- a/gradle/any/gretty.gradle
+++ b/gradle/any/gretty.gradle
@@ -18,14 +18,14 @@ apply from: "$rootDir/gradle/any/properties.gradle"
 apply plugin: 'org.gretty'
 apply plugin: 'jacoco'
 
-// when applying the gretty buildScript to a project, make sure that project has access to the gradlePluginPortal
-// which is where the gretty tomcat runners live
+// when applying the gretty buildScript to a project, make sure that project has access to the gretty tomcat runners
 repositories {
   exclusiveContent {
     forRepository {
+      mavenCentral()
       gradlePluginPortal()
     }
-    // only look for unidata gretty related artifacts from the gradlePluginPortal
+    // only look for unidata gretty related artifacts from the above repos
     filter {
       includeGroup 'org.gretty'
     }

--- a/gradle/any/shared-mvn-coords.gradle
+++ b/gradle/any/shared-mvn-coords.gradle
@@ -5,7 +5,7 @@ ext {
 
   // plugin version management
   buildPlugins = [:]
-  buildPlugins.gretty = 'org.gretty:gretty:3.0.3'
+  buildPlugins.gretty = 'org.gretty:gretty:3.0.9'
   buildPlugins.shadow = 'com.github.jengelman.gradle.plugins:shadow:5.2.0'
   buildPlugins.sonarqube = 'org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:3.0'
   buildPlugins.spotless = 'com.diffplug.spotless:spotless-plugin-gradle:4.5.1'

--- a/gradle/root/publishing.gradle
+++ b/gradle/root/publishing.gradle
@@ -6,6 +6,7 @@ buildscript {
   // The buildscript {} block is odd: even though we applied dependencies.gradle above, the repositories therein
   // do not get included here. Instead, we must explicitly define the repos again. Yay for duplication.
   repositories {
+    mavenCentral()
     gradlePluginPortal()
     exclusiveContent {
       forRepository {


### PR DESCRIPTION
Gradle's plugin portal can use JCenter, which is being shutdown this year so is no longer reliable (https://blog.gradle.org/jcenter-shutdown).

This PR implements the workaround in the discussion [here](https://github.com/gradle/gradle/issues/15406), which is to just put `mavenCentral` first in the list of repos to check. So since I am leaving the `gradlePluginPortal` as the fallback option, I don't think this PR can break anything.

The second change is just a bump of Gretty's minor version.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidata/tds/290)
<!-- Reviewable:end -->
