### PR TITLE
Update content type expected in test

### DIFF
--- a/tds/src/integrationTests/java/thredds/server/fileserver/TestFileServer.java
+++ b/tds/src/integrationTests/java/thredds/server/fileserver/TestFileServer.java
@@ -45,7 +45,7 @@ public class TestFileServer {
 
     // TODO - Consider consolidating files and catalog.
     // Currently uses files from various locations and served through different catalog files.
-    result.add(new Object[] {"fileServer/scanLocal/point.covjson.json", ContentType.json.getContentHeader(),
+    result.add(new Object[] {"fileServer/scanLocal/point.covjson.json", ContentType.json.toString(),
         "33fea472b71590b888e31870d745d71b"});
     result.add(new Object[] {"fileServer/rdaTest/ds094.2_dt/files/flxf01.gdas.A_PCP.SFC.01Z.grb2.gbx9",
         ContentType.binary.toString(), "f86072586ad8d66feed8cad2168f24a0"});


### PR DESCRIPTION
Upgrading gretty from 3.0.3 to 3.0.9 changed the content type that fileserver returns in its header for json from `application/json;charset=UTF-8` to `application/json`. I don't think this matters, the other content types never mentioned the charset.

This change would fix two failing tests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidata/tds/292)
<!-- Reviewable:end -->
