### PR TITLE
WMS should not use outdated cache

### DIFF
--- a/tds/src/integrationTests/java/thredds/server/wms/TestUpdateWmsServer.java
+++ b/tds/src/integrationTests/java/thredds/server/wms/TestUpdateWmsServer.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 1998-2022 University Corporation for Atmospheric Research/Unidata
+ * See LICENSE.txt for license information.
+ */
+
+package thredds.server.wms;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import javax.servlet.http.HttpServletResponse;
+import org.jdom2.Document;
+import org.jdom2.Element;
+import org.jdom2.JDOMException;
+import org.jdom2.Namespace;
+import org.jdom2.filter.Filters;
+import org.jdom2.input.SAXBuilder;
+import org.jdom2.xpath.XPathExpression;
+import org.jdom2.xpath.XPathFactory;
+import org.junit.After;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+import java.lang.invoke.MethodHandles;
+import thredds.test.util.TestOnLocalServer;
+import thredds.util.ContentType;
+
+import static com.google.common.truth.Truth.assertThat;
+
+public class TestUpdateWmsServer {
+  private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+  private static final Namespace NS_WMS = Namespace.getNamespace("wms", "http://www.opengis.net/wms");
+
+  private static final String DIR = "src/test/content/thredds/public/testdata/";
+  private static final Path TEST_FILE = Paths.get(DIR, "testUpdate.nc");
+
+  @After
+  public void cleanupTestFile() throws IOException {
+    Files.delete(TEST_FILE);
+  }
+
+  @Test
+  public void testUpdateFile() throws IOException, JDOMException {
+    final String path = "/wms/localContent/testUpdate.nc?service=WMS&version=1.3.0&request=GetCapabilities";
+    final String endpoint = TestOnLocalServer.withHttpPath(path);
+
+    // Check initial WMS output
+    Files.copy(Paths.get(DIR, "testGridAsPoint.nc"), TEST_FILE);
+    final byte[] result = TestOnLocalServer.getContent(endpoint, HttpServletResponse.SC_OK, ContentType.xmlwms);
+    checkLayerNameInXml(result, "withT1Z1");
+
+    // Update test file and check that WMS output is updated
+    Files.copy(Paths.get(DIR, "testData.nc"), TEST_FILE, StandardCopyOption.REPLACE_EXISTING);
+    final byte[] updatedResult = TestOnLocalServer.getContent(endpoint, HttpServletResponse.SC_OK, ContentType.xmlwms);
+    checkLayerNameInXml(updatedResult, "Z_sfc");
+  }
+
+  private void checkLayerNameInXml(byte[] result, String expectedLayerName) throws IOException, JDOMException {
+    final Reader reader = new StringReader(new String(result, StandardCharsets.UTF_8));
+    final SAXBuilder saxBuilder = new SAXBuilder();
+    saxBuilder.setExpandEntities(false);
+    final Document doc = saxBuilder.build(reader);
+
+    final XPathExpression<Element> xpath = XPathFactory.instance()
+        .compile("//wms:Capability/wms:Layer/wms:Layer/wms:Layer/wms:Name", Filters.element(), null, NS_WMS);
+    final Element element = xpath.evaluateFirst(doc);
+    assertThat(element.getTextTrim()).isEqualTo(expectedLayerName);
+  }
+}

--- a/tds/src/main/java/thredds/server/wms/ThreddsWmsServlet.java
+++ b/tds/src/main/java/thredds/server/wms/ThreddsWmsServlet.java
@@ -60,7 +60,17 @@ import ucar.nc2.dataset.NetcdfDataset;
 @RequestMapping("/wms")
 public class ThreddsWmsServlet extends WmsServlet {
 
-  private static final Map<String, WmsCatalogue> catalogueCache = new HashMap<>();
+  private static class CachedWmsCatalogue {
+    public final WmsCatalogue wmsCatalogue;
+    public final long lastModified;
+
+    public CachedWmsCatalogue(WmsCatalogue wmsCatalogue, long lastModified) {
+      this.wmsCatalogue = wmsCatalogue;
+      this.lastModified = lastModified;
+    }
+  }
+
+  private static final Map<String, CachedWmsCatalogue> catalogueCache = new HashMap<>();
 
   @Override
   @RequestMapping(value = "**", method = {RequestMethod.GET})
@@ -81,8 +91,8 @@ public class ThreddsWmsServlet extends WmsServlet {
     // Look - is setting this to null the right thing to do??
     String removePrefix = null;
     TdsRequestedDataset tdsDataset = new TdsRequestedDataset(httpServletRequest, removePrefix);
-    if (catalogueCache.containsKey(tdsDataset.getPath())) {
-      catalogue = catalogueCache.get(tdsDataset.getPath());
+    if (useCachedCatalogue(tdsDataset.getPath())) {
+      catalogue = catalogueCache.get(tdsDataset.getPath()).wmsCatalogue;
     } else {
       NetcdfFile ncf = TdsRequestedDataset.getNetcdfFile(httpServletRequest, httpServletResponse, tdsDataset.getPath());
       NetcdfDataset ncd;
@@ -110,7 +120,9 @@ public class ThreddsWmsServlet extends WmsServlet {
         throw new EdalLayerNotFoundException("The requested dataset is not available on this server");
       }
       catalogue = new ThreddsWmsCatalogue(ncd, tdsDataset.getPath());
-      catalogueCache.put(tdsDataset.getPath(), catalogue);
+      final CachedWmsCatalogue cachedWmsCatalogue =
+          new CachedWmsCatalogue(catalogue, TdsRequestedDataset.getLastModified(tdsDataset.getPath()));
+      catalogueCache.put(tdsDataset.getPath(), cachedWmsCatalogue);
     }
 
     /*
@@ -118,5 +130,14 @@ public class ThreddsWmsServlet extends WmsServlet {
      * super implementation which will handle things from here.
      */
     super.dispatchWmsRequest(request, params, httpServletRequest, httpServletResponse, catalogue);
+  }
+
+  private boolean useCachedCatalogue(String tdsDatasetPath) {
+    final long lastModified = TdsRequestedDataset.getLastModified(tdsDatasetPath);
+    if (catalogueCache.containsKey(tdsDatasetPath)) {
+      final long cacheLastModified = catalogueCache.get(tdsDatasetPath).lastModified;
+      return cacheLastModified >= lastModified;
+    }
+    return false;
   }
 }


### PR DESCRIPTION
If you update a file, it does not update the output you get through WMS, since this is cached in a map with the key as the file name.

This PR checks the last modified date of the file against the cache in order to check if WMS catalogue cache is current, and if it is not then updates it. I also added an automated test for this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidata/tds/294)
<!-- Reviewable:end -->
