### PR TITLE
Add log messages for aws sdk

### DIFF
--- a/docs/userguide/src/site/pages/tds_tutorial/faq/faq.md
+++ b/docs/userguide/src/site/pages/tds_tutorial/faq/faq.md
@@ -472,4 +472,4 @@ If you want to log a summary of every request/response you can add:
       <appender-ref ref="threddsServlet"/>
     </logger>
 ~~~
-Note: this is a debugging suggestion and is probably too verbose to be used in production.
+Note: Do not log at "debug" level in your production environments because it is verbose and could log sensitive data!

--- a/docs/userguide/src/site/pages/tds_tutorial/faq/faq.md
+++ b/docs/userguide/src/site/pages/tds_tutorial/faq/faq.md
@@ -461,3 +461,15 @@ You must restart tomcat for this to take effect.
 ### Logging is not working
 
 You must use a version of Tomcat >= 7.0.43. See [log4j2 docs](http://logging.apache.org/log4j/2.0/manual/webapp.html){:target="_blank"}.
+
+### How do I get detailed log info of Object Store requests for debugging?
+
+You can edit the `WEB-INF/classes/log4j2.xml` log settings before starting up TDS.
+For instance, you can change the log level of `software.amazon.awssdk` to `debug`.
+If you want to log a summary of every request/response you can add:
+~~~
+    <logger name="software.amazon.awssdk.request" level="debug" additivity="false">
+      <appender-ref ref="threddsServlet"/>
+    </logger>
+~~~
+Note: this is a debugging suggestion and is probably too verbose to be used in production.

--- a/tds/src/main/webapp/WEB-INF/classes/log4j2.xml
+++ b/tds/src/main/webapp/WEB-INF/classes/log4j2.xml
@@ -19,6 +19,10 @@
       <PatternLayout pattern="%d %c: %m%n"/>
     </File>
 
+    <File name="awssdk" fileName="${tds.log.dir}/awssdk.log" append="false">
+      <PatternLayout pattern="%d %c: %m%n"/>
+    </File>
+
     <RollingFile name="fcScan" fileName="${tds.log.dir}/featureCollection.log" filePattern="${tds.log.dir}/featureCollection.%i.log">
       <PatternLayout pattern="[%d{yyyy-MM-dd'T'HH:mm:ss.SSSZ}] %-5p %c: %m%n"/>
       <Policies>
@@ -168,6 +172,19 @@
 
     <logger name="thredds.server.metadata" level="warn" additivity="false">
       <appender-ref ref="threddsServlet"/>
+    </logger>
+
+    <!-- ASW SDK -->
+    <logger name="software.amazon.awssdk" level="debug" additivity="false">
+      <appender-ref ref="awssdk"/>
+    </logger>
+
+    <logger name="software.amazon.awssdk.request" level="debug" additivity="false">
+      <appender-ref ref="awssdk"/>
+    </logger>
+
+    <logger name="org.apache.http.wire" level="debug" additivity="false">
+      <appender-ref ref="awssdk"/>
     </logger>
 
     <!-- log issues related to loading custom color palettes -->

--- a/tds/src/main/webapp/WEB-INF/classes/log4j2.xml
+++ b/tds/src/main/webapp/WEB-INF/classes/log4j2.xml
@@ -171,6 +171,7 @@
     </logger>
 
     <!-- ASW SDK -->
+    <!-- Note: Do not log at "debug" level it in your production environments because it could log sensitive data! -->
     <logger name="software.amazon.awssdk" level="warn" additivity="false">
       <appender-ref ref="threddsServlet"/>
     </logger>

--- a/tds/src/main/webapp/WEB-INF/classes/log4j2.xml
+++ b/tds/src/main/webapp/WEB-INF/classes/log4j2.xml
@@ -19,10 +19,6 @@
       <PatternLayout pattern="%d %c: %m%n"/>
     </File>
 
-    <File name="awssdk" fileName="${tds.log.dir}/awssdk.log" append="false">
-      <PatternLayout pattern="%d %c: %m%n"/>
-    </File>
-
     <RollingFile name="fcScan" fileName="${tds.log.dir}/featureCollection.log" filePattern="${tds.log.dir}/featureCollection.%i.log">
       <PatternLayout pattern="[%d{yyyy-MM-dd'T'HH:mm:ss.SSSZ}] %-5p %c: %m%n"/>
       <Policies>
@@ -175,16 +171,8 @@
     </logger>
 
     <!-- ASW SDK -->
-    <logger name="software.amazon.awssdk" level="debug" additivity="false">
-      <appender-ref ref="awssdk"/>
-    </logger>
-
-    <logger name="software.amazon.awssdk.request" level="debug" additivity="false">
-      <appender-ref ref="awssdk"/>
-    </logger>
-
-    <logger name="org.apache.http.wire" level="debug" additivity="false">
-      <appender-ref ref="awssdk"/>
+    <logger name="software.amazon.awssdk" level="warn" additivity="false">
+      <appender-ref ref="threddsServlet"/>
     </logger>
 
     <!-- log issues related to loading custom color palettes -->


### PR DESCRIPTION
After the discussion in https://github.com/Unidata/tds/issues/194, it seems useful to log aws sdk warnings and higher. In addition, I added a note to the FAQs about how to change log settings for debugging object store requests.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidata/tds/298)
<!-- Reviewable:end -->
