### PR TITLE
Remove hardcoded thredds context

### DIFF
--- a/tdcommon/src/main/java/thredds/server/catalog/ConfigCatalog.java
+++ b/tdcommon/src/main/java/thredds/server/catalog/ConfigCatalog.java
@@ -46,21 +46,28 @@ public class ConfigCatalog extends Catalog {
   }
 
   // turn ConfigCatalog into a mutable CatalogBuilder so we can mutate
-  public CatalogBuilder makeCatalogBuilder() {
+  public CatalogBuilder makeCatalogBuilder(String context) {
     CatalogBuilder builder = new CatalogBuilder(this);
     for (Dataset ds : getDatasetsLocal()) {
-      builder.addDataset(makeDatasetBuilder(null, ds));
+      builder.addDataset(makeDatasetBuilder(null, ds, context));
     }
     return builder;
   }
 
-  private DatasetBuilder makeDatasetBuilder(DatasetBuilder parent, Dataset ds) {
+  /**
+   * @deprecated Use {@link #makeCatalogBuilder(String)} instead
+   */
+  public CatalogBuilder makeCatalogBuilder() {
+    return makeCatalogBuilder("thredds");
+  }
+
+  private DatasetBuilder makeDatasetBuilder(DatasetBuilder parent, Dataset ds, String context) {
 
     DatasetBuilder builder;
     if (ds instanceof CatalogScan)
-      builder = new CatalogScanBuilder(parent, (CatalogScan) ds);
+      builder = new CatalogScanBuilder(parent, (CatalogScan) ds, context);
     else if (ds instanceof FeatureCollectionRef)
-      builder = new FeatureCollectionRefBuilder(parent, (FeatureCollectionRef) ds);
+      builder = new FeatureCollectionRefBuilder(parent, (FeatureCollectionRef) ds, context);
     else if (ds instanceof CatalogRef)
       builder = new CatalogRefBuilder(parent, (CatalogRef) ds);
     else
@@ -72,7 +79,7 @@ public class ConfigCatalog extends Catalog {
 
     if (!(ds instanceof CatalogRef)) {
       for (Dataset nested : ds.getDatasetsLocal())
-        builder.addDataset(makeDatasetBuilder(builder, nested));
+        builder.addDataset(makeDatasetBuilder(builder, nested, context));
     }
 
     return builder;

--- a/tdcommon/src/main/java/thredds/server/catalog/builder/CatalogScanBuilder.java
+++ b/tdcommon/src/main/java/thredds/server/catalog/builder/CatalogScanBuilder.java
@@ -38,10 +38,7 @@ public class CatalogScanBuilder extends DatasetBuilder {
    * @deprecated Use {@link #CatalogScanBuilder(DatasetBuilder, CatalogScan, String)} instead
    */
   public CatalogScanBuilder(DatasetBuilder parent, CatalogScan from) {
-    super(parent, from);
-    this.path = from.getPath();
-    this.location = from.getLocation();
-    this.watch = from.getWatch();
+    this(parent, from, "thredds");
   }
 
   public CatalogScan makeDataset(DatasetNode parent) {

--- a/tdcommon/src/main/java/thredds/server/catalog/builder/CatalogScanBuilder.java
+++ b/tdcommon/src/main/java/thredds/server/catalog/builder/CatalogScanBuilder.java
@@ -4,6 +4,7 @@ package thredds.server.catalog.builder;
 import thredds.client.catalog.DatasetNode;
 import thredds.client.catalog.builder.DatasetBuilder;
 import thredds.server.catalog.CatalogScan;
+import ucar.unidata.util.StringUtil2;
 
 /**
  * CatalogScan Builder
@@ -22,9 +23,20 @@ public class CatalogScanBuilder extends DatasetBuilder {
     this.path = path;
     this.location = location;
     this.watch = watch;
-    this.context = context;
+    this.context = StringUtil2.trim(context, '/');
   }
 
+  public CatalogScanBuilder(DatasetBuilder parent, CatalogScan from, String context) {
+    super(parent, from);
+    this.path = from.getPath();
+    this.location = from.getLocation();
+    this.watch = from.getWatch();
+    this.context = StringUtil2.trim(context, '/');
+  }
+
+  /**
+   * @deprecated Use {@link #CatalogScanBuilder(DatasetBuilder, CatalogScan, String)} instead
+   */
   public CatalogScanBuilder(DatasetBuilder parent, CatalogScan from) {
     super(parent, from);
     this.path = from.getPath();

--- a/tdcommon/src/main/java/thredds/server/catalog/builder/FeatureCollectionRefBuilder.java
+++ b/tdcommon/src/main/java/thredds/server/catalog/builder/FeatureCollectionRefBuilder.java
@@ -64,9 +64,7 @@ public class FeatureCollectionRefBuilder extends DatasetBuilder {
    * @deprecated Use {@link #FeatureCollectionRefBuilder(DatasetBuilder, FeatureCollectionRef, String)} instead
    */
   public FeatureCollectionRefBuilder(DatasetBuilder parent, FeatureCollectionRef from) {
-    super(parent, from);
-    this.config = from.getConfig();
-    this.context = "thredds";
+    this(parent, from, "thredds");
   }
 
   public FeatureCollectionRef makeDataset(DatasetNode parent) {

--- a/tdcommon/src/main/java/thredds/server/catalog/builder/FeatureCollectionRefBuilder.java
+++ b/tdcommon/src/main/java/thredds/server/catalog/builder/FeatureCollectionRefBuilder.java
@@ -35,6 +35,7 @@ package thredds.server.catalog.builder;
 import thredds.client.catalog.DatasetNode;
 import thredds.client.catalog.builder.DatasetBuilder;
 import thredds.server.catalog.FeatureCollectionRef;
+import ucar.unidata.util.StringUtil2;
 
 /**
  * Builder of FeatureCollectionRef
@@ -50,9 +51,18 @@ public class FeatureCollectionRefBuilder extends DatasetBuilder {
       String context) {
     super(parent);
     this.config = config;
-    this.context = context;
+    this.context = StringUtil2.trim(context, '/');
   }
 
+  public FeatureCollectionRefBuilder(DatasetBuilder parent, FeatureCollectionRef from, String context) {
+    super(parent, from);
+    this.config = from.getConfig();
+    this.context = StringUtil2.trim(context, '/');
+  }
+
+  /**
+   * @deprecated Use {@link #FeatureCollectionRefBuilder(DatasetBuilder, FeatureCollectionRef, String)} instead
+   */
   public FeatureCollectionRefBuilder(DatasetBuilder parent, FeatureCollectionRef from) {
     super(parent, from);
     this.config = from.getConfig();

--- a/tds/src/main/java/thredds/core/CatalogManager.java
+++ b/tds/src/main/java/thredds/core/CatalogManager.java
@@ -79,7 +79,7 @@ public class CatalogManager {
         catBuilder = (CatalogBuilder) dyno;
       } else {
         ConfigCatalog configCatalog = (ConfigCatalog) dyno;
-        catBuilder = configCatalog.makeCatalogBuilder(); // turn it back into mutable object
+        catBuilder = configCatalog.makeCatalogBuilder(tdsContext.getContextPath()); // turn it back into mutable object
       }
       addGlobalServices(catBuilder);
       return catBuilder.makeCatalog();
@@ -89,7 +89,7 @@ public class CatalogManager {
     ConfigCatalog configCatalog = ccc.get(workPath);
     if (configCatalog == null)
       return null;
-    CatalogBuilder catBuilder = configCatalog.makeCatalogBuilder();
+    CatalogBuilder catBuilder = configCatalog.makeCatalogBuilder(tdsContext.getContextPath());
     addGlobalServices(catBuilder);
     return catBuilder.makeCatalog();
   }


### PR DESCRIPTION
Remove hardcoded "thredds" context and instead pass in correct context from `tdsContext` when building featureCollection or catalogScan.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidata/tds/301)
<!-- Reviewable:end -->
