### PR TITLE
upgrade protobuf and exclude netty from AWS deps

### DIFF
--- a/gradle/any/shared-mvn-coords.gradle
+++ b/gradle/any/shared-mvn-coords.gradle
@@ -31,5 +31,5 @@ ext {
   // TODO: figure out way to keep this version in sync with netcdf-java version
   // It is included in the netcdf-java-bom (via netcdf-java-platform), but we can't
   // reference that version in a gradle build script (see gradle/any/protobuf.gradle)
-  depVersion.protobuf = '3.19.3'
+  depVersion.protobuf = '3.21.7'
 }

--- a/tds/build.gradle
+++ b/tds/build.gradle
@@ -32,7 +32,9 @@ dependencies {
   // Allow for the use of AWS Security Token Service by cdm-s3
   // version matches that used by netCDF-Java
   // todo: remove once this is a runtime dependency of netCDF-Java
-  runtimeOnly 'software.amazon.awssdk:sts:2.17.156'
+  runtimeOnly ('software.amazon.awssdk:sts:2.17.156') {
+    exclude group: 'software.amazon.awssdk', module: 'netty-nio-client'
+  }
 
   // DAP4 Dependencies (technically forward)
   compile 'edu.ucar:d4cdm'


### PR DESCRIPTION
- exclude netty from dependencies to avoid CVES
- upgrade protobuf to match netcdf-java

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidata/tds/303)
<!-- Reviewable:end -->
