### PR TITLE
Fix ncml location lookup

### DIFF
--- a/tds/src/test/content/thredds/catalog.xml
+++ b/tds/src/test/content/thredds/catalog.xml
@@ -240,6 +240,13 @@
       </ncml:netcdf>
     </dataset>
 
+    <dataset name="Test with a featureCollection path as prefix in urlPath and a location in the ncml"
+      ID="ncmlLocationFeatureCollection" urlPath="testGFSfmrc/ncmlLocation">
+      <serviceName>all</serviceName>
+      <ncml:netcdf xmlns="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2"
+        location="content/testdata/testData.nc">
+      </ncml:netcdf>
+    </dataset>
   </dataset>
 
   <!-- END UNTESTED-->

--- a/tds/src/test/java/thredds/server/fileserver/FileServerControllerTest.java
+++ b/tds/src/test/java/thredds/server/fileserver/FileServerControllerTest.java
@@ -60,4 +60,12 @@ public class FileServerControllerTest {
 
     mockMvc.perform(rb).andExpect(MockMvcResultMatchers.status().isOk()).andReturn();
   }
+
+  @Test
+  public void shouldReturnFileWithFeatureCollectionPathInUrlPathAndLocationInNcml() throws Exception {
+    final String path = "/fileServer/testGFSfmrc/ncmlLocation";
+    final RequestBuilder rb = MockMvcRequestBuilders.get(path).servletPath(path);
+
+    mockMvc.perform(rb).andExpect(MockMvcResultMatchers.status().isOk()).andReturn();
+  }
 }

--- a/tds/src/test/java/thredds/server/ncss/controller/grid/GridDatasetControllerTest.java
+++ b/tds/src/test/java/thredds/server/ncss/controller/grid/GridDatasetControllerTest.java
@@ -99,6 +99,14 @@ public class GridDatasetControllerTest {
     mockMvc.perform(rb).andExpect(MockMvcResultMatchers.status().isOk()).andReturn();
   }
 
+  @Test
+  public void shouldReturnFileWithFeatureCollectionPathInUrlPathAndLocationInNcml() throws Exception {
+    final String path = "/ncss/grid/testGFSfmrc/ncmlLocation/dataset.xml";
+    final RequestBuilder rb = MockMvcRequestBuilders.get(path).servletPath(path);
+
+    mockMvc.perform(rb).andExpect(MockMvcResultMatchers.status().isOk()).andReturn();
+  }
+
   private class FilenameMatcher extends BaseMatcher<String> {
     String suffix;
 


### PR DESCRIPTION
Fix FileNotFound error that occurred when a ncml dataset had a urlPath with a prefix that happened to be a featureCollection path.

- Switch the order of lookup: first check if there is a ncml location before doing anything with the urlPath, such as checking it for featureCollection roots or datasetRoots
- Add tests for this

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidata/tds/306)
<!-- Reviewable:end -->
