### PR TITLE
Fix accept parameters

### DIFF
--- a/docs/userguide/src/site/pages/thredds/NcssPoint.md
+++ b/docs/userguide/src/site/pages/thredds/NcssPoint.md
@@ -48,8 +48,8 @@ If none, return the time closest to the present.
 
 * `csv`: Comma-separated values, one feature per line
 * `xml`: Collection of feature elements 
-* `netCDF`: CF/NetCDF-3
-* `netCDF4`: CF/NetCDF-4 classic model   
+* `netCDF` or `netCDF3`: CF/NetCDF-3
+* `netCDF4` or `netCDF-classic`: CF/NetCDF-4 classic model   
 * `netCDF4ext`: NetCDF-4 extended model
 * `WaterML2`: OGC WaterML 2.0 Timeseries (station only)
 

--- a/docs/userguide/src/site/pages/thredds/NcssRef.md
+++ b/docs/userguide/src/site/pages/thredds/NcssRef.md
@@ -93,8 +93,8 @@ If none, return the time closest to the present.
 #### Output Format (`accept` Parameter)
 * `csv`: Comma-separated values, one feature per line
 * `xml`: Collection of feature elements
-* `netCDF`: CF/NetCDF-3
-* `netCDF4`: CF/NetCDF-4 classic model
+* `netCDF` or `netCDF3`: CF/NetCDF-3
+* `netCDF4` or `netCDF4-classic`: CF/NetCDF-4 classic model
 * `netCDF4ext`: NetCDF-4 extended model
 * `WaterML2`: OGC WaterML 2.0 Timeseries (station only)
 

--- a/tds/src/integrationTests/java/thredds/server/ncss/NcssGridIntegrationTest.java
+++ b/tds/src/integrationTests/java/thredds/server/ncss/NcssGridIntegrationTest.java
@@ -139,8 +139,10 @@ public class NcssGridIntegrationTest {
     skipTestIfNetCDF4NotPresent();
 
     checkFileType("netcdf3", HttpServletResponse.SC_OK, ".nc");
+    checkFileType("netcdf", HttpServletResponse.SC_OK, ".nc");
     checkFileType("netcdf4-classic", HttpServletResponse.SC_OK, ".nc4");
-    checkFileType("netcdf4", HttpServletResponse.SC_BAD_REQUEST, ".nc4"); // Not currently enabled in TdsInit
+    checkFileType("netcdf4", HttpServletResponse.SC_OK, ".nc4");
+    checkFileType("netcdf4ext", HttpServletResponse.SC_BAD_REQUEST, ".nc4"); // Not currently enabled in TdsInit
   }
 
   private void checkFileType(String acceptParameter, int expectedResponseCode, String expectedSuffix)

--- a/tds/src/main/java/thredds/server/ncss/controller/NcssGridController.java
+++ b/tds/src/main/java/thredds/server/ncss/controller/NcssGridController.java
@@ -104,7 +104,7 @@ public class NcssGridController extends AbstractNcssController {
 
   private void handleRequestGrid(HttpServletResponse res, NcssGridParamsBean params, String datasetPath,
       CoverageCollection gcd) throws IOException, NcssException, InvalidRangeException {
-    // Supported formats are netcdf3 (default) and netcdf4 (not currently turned on in TdsInit), netcdf4-classic (turned
+    // Supported formats are netcdf3 (default) and netcdf4ext (not currently turned on in TdsInit), netcdf4 (turned
     // on in TdsInit if C library is present)
     SupportedFormat sf = SupportedOperation.GRID_REQUEST.getSupportedFormat(params.getAccept());
     NetcdfFileFormat version = getNetcdfFileFormat(sf);

--- a/tds/src/main/java/thredds/server/ncss/format/SupportedFormat.java
+++ b/tds/src/main/java/thredds/server/ncss/format/SupportedFormat.java
@@ -30,9 +30,6 @@ public enum SupportedFormat {
 
   WATERML2("waterml2", true, false, ".xml", ContentType.xml, "waterml2");
 
-  /*
-   * First alias is used as content-type in the http headers
-   */
   private final List<String> aliases;
   private final String formatName;
   private final String fileSuffix;

--- a/tds/src/main/java/thredds/server/ncss/format/SupportedFormat.java
+++ b/tds/src/main/java/thredds/server/ncss/format/SupportedFormat.java
@@ -16,17 +16,17 @@ import java.util.List;
 public enum SupportedFormat {
 
   CSV_STREAM("csv", true, false, ".csv", ContentType.csv, "csv_stream", "text/csv"),
-  CSV_FILE("csv_file", false, false, ".csv", ContentType.csv, "csv_file"),
+  CSV_FILE("csv_file", false, false, ".csv", ContentType.csv),
 
-  XML_STREAM("xml", true, false, ".xml", ContentType.xml, "xml_stream", "xml"),
-  XML_FILE("xml_file", false, false, ".xml", ContentType.xml, "xml_file"),
+  XML_STREAM("xml", true, false, ".xml", ContentType.xml, "xml_stream"),
+  XML_FILE("xml_file", false, false, ".xml", ContentType.xml),
 
-  NETCDF3("netcdf3", false, true, ".nc", ContentType.netcdf, "netcdf", "netcdf3"),
-  NETCDF4("netcdf4-classic", false, true, ".nc4", ContentType.netcdf, "netcdf4-classic"),
-  NETCDF4EXT("netcdf4", false, true, ".nc4", ContentType.netcdf, "netcdf4"),
+  NETCDF3("netcdf3", false, true, ".nc", ContentType.netcdf, "netcdf"),
+  NETCDF4("netcdf4-classic", false, true, ".nc4", ContentType.netcdf, "netcdf4"),
+  NETCDF4EXT("netcdf4", false, true, ".nc4", ContentType.netcdf),
 
-  JSON("json", false, false, ".json", ContentType.json, "json", "geojson"),
-  WKT("wkt", false, false, ".txt", ContentType.text, "wkt"),
+  JSON("json", false, false, ".json", ContentType.json, "geojson"),
+  WKT("wkt", false, false, ".txt", ContentType.text),
 
   WATERML2("waterml2", true, false, ".xml", ContentType.xml, "waterml2");
 

--- a/tds/src/main/java/thredds/server/ncss/format/SupportedFormat.java
+++ b/tds/src/main/java/thredds/server/ncss/format/SupportedFormat.java
@@ -23,7 +23,7 @@ public enum SupportedFormat {
 
   NETCDF3("netcdf3", false, true, ".nc", ContentType.netcdf, "netcdf"),
   NETCDF4("netcdf4-classic", false, true, ".nc4", ContentType.netcdf, "netcdf4"),
-  NETCDF4EXT("netcdf4", false, true, ".nc4", ContentType.netcdf),
+  NETCDF4EXT("netcdf4ext", false, true, ".nc4", ContentType.netcdf),
 
   JSON("json", false, false, ".json", ContentType.json, "geojson"),
   WKT("wkt", false, false, ".txt", ContentType.text),


### PR DESCRIPTION
In PR https://github.com/Unidata/tds/pull/307, I mistakenly thought accept parameter `netcdf4` should refer to the extended netcdf4, when it should refer to the netcdf4-classic. This PR fixes the accept parameters and the documentation about that.

In addition, I did one small cleanup to make the SupportedFormat class clearer-- when checking if an accept parameter `isAlias` for one of the formats, the `formatName` and list of aliases are checked, so the `formatName` does not need to be repeated in the aliases.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidata/tds/308)
<!-- Reviewable:end -->
