### PR TITLE
Add test for WMS for aggregation issue

### DIFF
--- a/tds/src/integrationTests/java/thredds/server/wms/TestWmsServer.java
+++ b/tds/src/integrationTests/java/thredds/server/wms/TestWmsServer.java
@@ -105,4 +105,15 @@ public class TestWmsServer {
       System.setProperty("httpservices.urlencode", "true");
     }
   }
+
+  @Test
+  public void shouldGetMapForAggregationVariableThatDoesNotDependOnAggregationDimension() {
+    final String endpoint = TestOnLocalServer.withHttpPath("/wms/aggJoinExisting?FORMAT=image/png&TRANSPARENT=TRUE"
+        + "&STYLES=default-scalar/psu-viridis&LAYERS=Visibility&TIME=2006-09-26T00:00:00.000Z&COLORSCALERANGE=-50,50"
+        + "&NUMCOLORBANDS=20&ABOVEMAXCOLOR=extend&BELOWMINCOLOR=extend&BGCOLOR=extend&LOGSCALE=false&SERVICE=WMS"
+        + "&VERSION=1.1.1&REQUEST=GetMap&SRS=EPSG:4326"
+        + "&BBOX=-71.317178725829,36.796624819867,-65.279244210597,42.834559335098&WIDTH=256&HEIGHT=256");
+    final byte[] result = TestOnLocalServer.getContent(endpoint, HttpServletResponse.SC_OK, ContentType.png.toString());
+    assertThat(result).isNotEmpty();
+  }
 }

--- a/tds/src/test/content/thredds/catalog.xml
+++ b/tds/src/test/content/thredds/catalog.xml
@@ -209,6 +209,16 @@
       </ncml:netcdf>
     </dataset>
 
+    <dataset name="Test Aggregation with joinExisting dimension that some variables don't depend on"
+      ID="aggJoinExisting" urlPath="aggJoinExisting">
+      <serviceName>all</serviceName>
+      <netcdf xmlns="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2">
+        <aggregation dimName="height_above_ground" type="joinExisting">
+          <netcdf location="${cdmUnitTest}/ncml/nc/namExtract/20060925_1800.nc"/>
+        </aggregation>
+      </netcdf>
+    </dataset>
+
     <!-- test NcML in datasetScan -->
     <datasetScan name="ModifyDatasetScan" ID="ModifyDatasetScan" path="ModifyDatasetScan" location="${cdmUnitTest}/tds/">
       <metadata inherited="true">


### PR DESCRIPTION
Add test for WMS GetMap for an aggregation dataset variable that does not depend on aggregation dimension. This tests fix in https://github.com/Unidata/edal-java/pull/4

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidata/tds/309)
<!-- Reviewable:end -->
