### PR TITLE
Fix wms cache for aggregations

### DIFF
--- a/tds/src/main/java/thredds/server/wms/TdsWmsDatasetFactory.java
+++ b/tds/src/main/java/thredds/server/wms/TdsWmsDatasetFactory.java
@@ -23,6 +23,15 @@ public class TdsWmsDatasetFactory extends CdmGridDatasetFactory {
   }
 
   /**
+   * Get time of last modification of the underlying netcdfDataset
+   *
+   * @return time of last modification in Unix time (msecs since reference), or 0 if unknown
+   */
+  long getLastModified() {
+    return netcdfDataset.getLastModified();
+  }
+
+  /**
    *
    * None of this matters really. For NcML datasets, we cannot rely on a location, as the
    * ncml is modifying the dataset in memory. So, we are ignoring location and force reset

--- a/tds/src/main/java/thredds/server/wms/ThreddsWmsCatalogue.java
+++ b/tds/src/main/java/thredds/server/wms/ThreddsWmsCatalogue.java
@@ -147,6 +147,15 @@ public class ThreddsWmsCatalogue implements WmsCatalogue {
     return tdsDatasetPath;
   }
 
+  /**
+   * Get time of last modification of the underlying netcdfDataset
+   *
+   * @return time of last modification in Unix time (msecs since reference), or 0 if unknown
+   */
+  long getLastModified() {
+    return datasetFactory.getLastModified();
+  }
+
   @Override
   public FeaturesAndMemberName getFeaturesForLayer(String layerName, PlottingDomainParams params) throws EdalException {
     /*

--- a/tds/src/main/java/thredds/server/wms/ThreddsWmsServlet.java
+++ b/tds/src/main/java/thredds/server/wms/ThreddsWmsServlet.java
@@ -61,10 +61,10 @@ import ucar.nc2.dataset.NetcdfDataset;
 public class ThreddsWmsServlet extends WmsServlet {
 
   private static class CachedWmsCatalogue {
-    public final WmsCatalogue wmsCatalogue;
+    public final ThreddsWmsCatalogue wmsCatalogue;
     public final long lastModified;
 
-    public CachedWmsCatalogue(WmsCatalogue wmsCatalogue, long lastModified) {
+    public CachedWmsCatalogue(ThreddsWmsCatalogue wmsCatalogue, long lastModified) {
       this.wmsCatalogue = wmsCatalogue;
       this.lastModified = lastModified;
     }
@@ -121,7 +121,7 @@ public class ThreddsWmsServlet extends WmsServlet {
       }
       catalogue = new ThreddsWmsCatalogue(ncd, tdsDataset.getPath());
       final CachedWmsCatalogue cachedWmsCatalogue =
-          new CachedWmsCatalogue(catalogue, TdsRequestedDataset.getLastModified(tdsDataset.getPath()));
+          new CachedWmsCatalogue((ThreddsWmsCatalogue) catalogue, ncd.getLastModified());
       catalogueCache.put(tdsDataset.getPath(), cachedWmsCatalogue);
     }
 
@@ -135,9 +135,10 @@ public class ThreddsWmsServlet extends WmsServlet {
   // package private for testing
   static boolean useCachedCatalogue(String tdsDatasetPath) {
     if (containsCachedCatalogue(tdsDatasetPath)) {
-      final long lastModified = TdsRequestedDataset.getLastModified(tdsDatasetPath);
+      // This date last modified will be updated e.g. in the case of an aggregation with a recheckEvery
+      final long netcdfDatasetLastModified = catalogueCache.get(tdsDatasetPath).wmsCatalogue.getLastModified();
       final long cacheLastModified = catalogueCache.get(tdsDatasetPath).lastModified;
-      return cacheLastModified >= lastModified;
+      return cacheLastModified >= netcdfDatasetLastModified;
     }
     return false;
   }

--- a/tds/src/main/java/thredds/server/wms/ThreddsWmsServlet.java
+++ b/tds/src/main/java/thredds/server/wms/ThreddsWmsServlet.java
@@ -132,12 +132,18 @@ public class ThreddsWmsServlet extends WmsServlet {
     super.dispatchWmsRequest(request, params, httpServletRequest, httpServletResponse, catalogue);
   }
 
-  private boolean useCachedCatalogue(String tdsDatasetPath) {
+  // package private for testing
+  static boolean useCachedCatalogue(String tdsDatasetPath) {
     final long lastModified = TdsRequestedDataset.getLastModified(tdsDatasetPath);
-    if (catalogueCache.containsKey(tdsDatasetPath)) {
+    if (containsCachedCatalogue(tdsDatasetPath)) {
       final long cacheLastModified = catalogueCache.get(tdsDatasetPath).lastModified;
       return cacheLastModified >= lastModified;
     }
     return false;
+  }
+
+  // package private for testing
+  static boolean containsCachedCatalogue(String tdsDatasetPath) {
+    return catalogueCache.containsKey(tdsDatasetPath);
   }
 }

--- a/tds/src/main/java/thredds/server/wms/ThreddsWmsServlet.java
+++ b/tds/src/main/java/thredds/server/wms/ThreddsWmsServlet.java
@@ -134,8 +134,8 @@ public class ThreddsWmsServlet extends WmsServlet {
 
   // package private for testing
   static boolean useCachedCatalogue(String tdsDatasetPath) {
-    final long lastModified = TdsRequestedDataset.getLastModified(tdsDatasetPath);
     if (containsCachedCatalogue(tdsDatasetPath)) {
+      final long lastModified = TdsRequestedDataset.getLastModified(tdsDatasetPath);
       final long cacheLastModified = catalogueCache.get(tdsDatasetPath).lastModified;
       return cacheLastModified >= lastModified;
     }

--- a/tds/src/test/content/thredds/catalogUpdateAgg.xml
+++ b/tds/src/test/content/thredds/catalogUpdateAgg.xml
@@ -66,4 +66,22 @@
     </dataset>
 
   </dataset>
+
+  <dataset name="Test aggregation with recheck every min" ID="aggRecheckMinute" urlPath="aggRecheck/minute">
+    <serviceName>all</serviceName>
+    <netcdf xmlns="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2">
+      <aggregation dimName="time" type="joinExisting" recheckEvery="1 min">
+        <scan location="content/testdata/" suffix="testUpdate.nc"/>
+      </aggregation>
+    </netcdf>
+  </dataset>
+
+  <dataset name="Test aggregation with recheck every millisecond" ID="aggRecheckMillisecond" urlPath="aggRecheck/millisecond">
+    <serviceName>all</serviceName>
+    <netcdf xmlns="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2">
+      <aggregation dimName="time" type="joinExisting" recheckEvery="1 msec">
+        <scan location="content/testdata/" suffix="testUpdate.nc"/>
+      </aggregation>
+    </netcdf>
+  </dataset>
 </catalog>

--- a/tds/src/test/java/thredds/server/wms/TestWmsCache.java
+++ b/tds/src/test/java/thredds/server/wms/TestWmsCache.java
@@ -1,0 +1,124 @@
+package thredds.server.wms;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import javax.servlet.ServletException;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import java.lang.invoke.MethodHandles;
+
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@WebAppConfiguration
+@ContextConfiguration(locations = {"/WEB-INF/applicationContext.xml"})
+public class TestWmsCache {
+  private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+  private static final String DIR = "src/test/content/thredds/public/testdata/";
+  private static final Path TEST_FILE = Paths.get(DIR, "testGridAsPoint.nc");
+  private static final Path TEMP_FILE = Paths.get(DIR, "testUpdate.nc");
+  private static final String TEST_PATH = "localContent/testUpdate.nc";
+  private static final String S3_TEST_PATH = "s3-thredds-test-data/ncml/nc/namExtract/20060925_0600.nc";
+  private static final String AGGREGATION_RECHECK_MSEC_PATH = "aggRecheck/millisecond";
+  private static final String AGGREGATION_RECHECK_MINUTE_PATH = "aggRecheck/minute";
+
+  final private ThreddsWmsServlet threddsWmsServlet = new ThreddsWmsServlet();
+
+  @Before
+  public void createTestFiles() throws IOException {
+    Files.copy(TEST_FILE, TEMP_FILE);
+  }
+
+  @After
+  public void cleanupTestFiles() throws IOException {
+    Files.delete(TEMP_FILE);
+  }
+
+  @Test
+  public void shouldCacheFile() throws IOException, ServletException {
+    assertThat(ThreddsWmsServlet.containsCachedCatalogue(TEST_PATH)).isFalse();
+    getCapabilities(TEST_PATH);
+    assertThat(ThreddsWmsServlet.containsCachedCatalogue(TEST_PATH)).isTrue();
+    assertThat(ThreddsWmsServlet.useCachedCatalogue(TEST_PATH)).isTrue();
+  }
+
+  // TODO also test updating an S3 file (currently not implemented through MFileS3)
+  @Test
+  public void shouldCacheS3File() throws IOException, ServletException {
+    assertThat(ThreddsWmsServlet.containsCachedCatalogue(S3_TEST_PATH)).isFalse();
+    getCapabilities(S3_TEST_PATH);
+    assertThat(ThreddsWmsServlet.containsCachedCatalogue(S3_TEST_PATH)).isTrue();
+    assertThat(ThreddsWmsServlet.useCachedCatalogue(S3_TEST_PATH)).isTrue();
+  }
+
+  @Test
+  public void shouldNotUseOutdatedCacheFile() throws IOException, ServletException {
+    getCapabilities(TEST_PATH);
+    assertThat(ThreddsWmsServlet.containsCachedCatalogue(TEST_PATH)).isTrue();
+    assertThat(ThreddsWmsServlet.useCachedCatalogue(TEST_PATH)).isTrue();
+
+    updateTestFile();
+    assertThat(ThreddsWmsServlet.containsCachedCatalogue(TEST_PATH)).isTrue();
+    assertThat(ThreddsWmsServlet.useCachedCatalogue(TEST_PATH)).isFalse();
+  }
+
+  @Test
+  public void shouldUseUnchangedAggregation() throws IOException, ServletException {
+    getCapabilities(AGGREGATION_RECHECK_MINUTE_PATH);
+    assertThat(ThreddsWmsServlet.containsCachedCatalogue(AGGREGATION_RECHECK_MINUTE_PATH)).isTrue();
+    assertThat(ThreddsWmsServlet.useCachedCatalogue(AGGREGATION_RECHECK_MINUTE_PATH)).isTrue();
+  }
+
+  @Test
+  public void shouldUseRecheckedButUnchangedAggregation() throws IOException, ServletException {
+    getCapabilities(AGGREGATION_RECHECK_MSEC_PATH);
+    assertThat(ThreddsWmsServlet.containsCachedCatalogue(AGGREGATION_RECHECK_MSEC_PATH)).isTrue();
+    assertThat(ThreddsWmsServlet.useCachedCatalogue(AGGREGATION_RECHECK_MSEC_PATH)).isTrue();
+
+    // Will be rechecked after 1 ms
+    assertThat(ThreddsWmsServlet.containsCachedCatalogue(AGGREGATION_RECHECK_MSEC_PATH)).isTrue();
+    assertThat(ThreddsWmsServlet.useCachedCatalogue(AGGREGATION_RECHECK_MSEC_PATH)).isTrue();
+  }
+
+  @Test
+  public void shouldNotUseOutdatedAggregation() throws IOException, ServletException {
+    getCapabilities(AGGREGATION_RECHECK_MSEC_PATH);
+    assertThat(ThreddsWmsServlet.containsCachedCatalogue(AGGREGATION_RECHECK_MSEC_PATH)).isTrue();
+    assertThat(ThreddsWmsServlet.useCachedCatalogue(AGGREGATION_RECHECK_MSEC_PATH)).isTrue();
+
+    updateTestFile();
+    assertThat(ThreddsWmsServlet.containsCachedCatalogue(AGGREGATION_RECHECK_MSEC_PATH)).isTrue();
+    assertThat(ThreddsWmsServlet.useCachedCatalogue(AGGREGATION_RECHECK_MSEC_PATH)).isFalse();
+  }
+
+  private void updateTestFile() throws IOException {
+    Files.copy(TEST_FILE, TEMP_FILE, StandardCopyOption.REPLACE_EXISTING);
+  }
+
+  private void getCapabilities(String path) throws ServletException, IOException {
+    final String uri = "/thredds/wms/" + path;
+    final MockHttpServletRequest request = new MockHttpServletRequest("GET", uri);
+    request.setParameter("service", "WMS");
+    request.setParameter("version", "1.3.0");
+    request.setParameter("request", "GetCapabilities");
+    request.setPathInfo(path);
+    final MockHttpServletResponse response = new MockHttpServletResponse();
+
+    threddsWmsServlet.service(request, response);
+    assertThat(response.getStatus()).isEqualTo(MockHttpServletResponse.SC_OK);
+  }
+}


### PR DESCRIPTION
This PR addresses the issue with WMS not updating its cache for aggregations with a scan with a `recheckEvery` attribute.

Previously, the cache was getting the date last modified by looking at the date last modified of a `File` with the location from the request, which does not work for aggregations (or S3 files), so the date last modified was always -1 and the cached file was always used. This PR instead uses the date last modified from the underlying `NetcdfDataset`, which in the case of an aggregation, will rescan the files according to the `recheckEvery`.

The `NetcdfDataset::getLastModified` I am using here overrides the deprecated method `NetcdfFile::getLastModified`. I am not sure why that is deprecated or if that is a problem?

I am going to try to fix the date last modified for S3 files in a follow up PR, as this is not working correctly still.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidata/tds/320)
<!-- Reviewable:end -->
