### PR TITLE
Add averageValueSize to chronicle map cache

### DIFF
--- a/docs/userguide/src/site/pages/tds_tutorial/faq/faq.md
+++ b/docs/userguide/src/site/pages/tds_tutorial/faq/faq.md
@@ -285,6 +285,17 @@ to something like:
 Be aware if you install a new `thredds.war` to `${tomcat_home}/webapps`, the exploded directory—including all changes you made to `log4j2.xml` will be removed and the webapp will be redeployed from the new `thredds.war`. 
 We suggest you copy `log4j2.xml` to a different location for the deployment and then copy it back over afterwards.
 
+### Issues with Forecast Model Run Collections (FMRC)
+
+If your FMRC datasets are not working properly, and you see errors involving ChronicleMap in the `fmrc.log`, for instance:
+
+~~~
+[2022-09-12T16:02:50.065+0300] ERROR ucar.nc2.ft.fmrc.Fmrc: makeFmrcInv
+com.google.common.util.concurrent.UncheckedExecutionException: java.lang.IllegalStateException: ChronicleMap{name=GridDatasetInv, file=/content/thredds/cache/collection/GridDatasetInv.dat, identityHashCode=1659873263}: Attempt to allocate #3 extra segment tier, 2 is maximum.
+~~~
+
+then you may need to adjust your [FMRC cache settings](https://docs.unidata.ucar.edu/tds/current/userguide/tds_config_ref.html#featurecollection-cache).
+
 ## Caching
 
 ### We use compressed netCDF files, and the very first access to them are quite slow, although subsequent accesses are much faster, then become slow again after a while. 

--- a/docs/userguide/src/site/pages/thredds/ThreddsConfigRef.md
+++ b/docs/userguide/src/site/pages/thredds/ThreddsConfigRef.md
@@ -450,6 +450,7 @@ We recommend that you use the default settings, by not specifying this option.
   <dir>(see the note below)</dir>
   <maxEntries>1000</maxEntries>
   <maxBloatFactor>1</maxBloatFactor>
+  <averageValueSize>small</averageValueSize>
 </FeatureCollection>
 ~~~
 
@@ -465,6 +466,12 @@ We recommend that you use the default settings, by not specifying this option.
   If it is possible to have more FMRC files than your `maxEntries`, then this value should be increased.
   It is strongly advised not to configure this value to more than 10, as the cache works progressively slower when the actual size grows far beyond the size configured in your `maxEntries`.
   See [here](https://gerrit.googlesource.com/modules/cache-chroniclemap/+/HEAD/src/main/resources/Documentation/config.md#configuration-parameters) for more details.
+* `averageValueSize`: the average size of the cached value (the grid and variable information), which is used when allocating memory for the cache.
+  The possible values are `small`, `medium`, or `large`.
+  The default value is `small`.
+  In most cases the default value should work fine. However, if your FMRC datasets have hundreds of variables,
+  and you are experiencing issues with the cache filling up even though you have adjusted the `maxEntries` and `maxBloatFactor`,
+  then this may need to be increased to `medium`, or in very rare circumstances `large`.
 
 ### GRIB Index Redirection
 

--- a/tds/src/main/java/thredds/featurecollection/cache/GridInventoryCacheChronicle.java
+++ b/tds/src/main/java/thredds/featurecollection/cache/GridInventoryCacheChronicle.java
@@ -156,4 +156,26 @@ public class GridInventoryCacheChronicle implements InventoryCacheProvider {
       cache.close();
     }
   }
+
+  // For testing
+  static void resetCache() {
+    shutdown();
+    cache = null;
+  }
+
+  static long getNumberOfEntries() {
+    return cache.longSize();
+  }
+
+  static int getRemainingAutoResizes() {
+    return cache.remainingAutoResizes();
+  }
+
+  static int getPercentageFreeSpace() {
+    return cache.percentageFreeSpace();
+  }
+
+  static long getOffHeapMemoryUsed() {
+    return cache.offHeapMemoryUsed();
+  }
 }

--- a/tds/src/main/java/thredds/featurecollection/cache/GridInventoryCacheChronicle.java
+++ b/tds/src/main/java/thredds/featurecollection/cache/GridInventoryCacheChronicle.java
@@ -157,6 +157,22 @@ public class GridInventoryCacheChronicle implements InventoryCacheProvider {
     }
   }
 
+  /**
+   * Display cache info
+   */
+  public static void showCache(Formatter formatter) {
+    if (cache == null) {
+      formatter.format("%nFMRC GridInventoryCache: turned off%n");
+    } else {
+      formatter.format("%nFMRC GridInventoryCache:%n");
+      formatter.format("numberOfEntries=%d, ", getNumberOfEntries());
+      formatter.format("remainingAutoResizes=%d, ", getRemainingAutoResizes());
+      formatter.format("percentageFreeSpace=%d, ", getPercentageFreeSpace());
+      formatter.format("offHeapMemoryUsed=%d", getOffHeapMemoryUsed());
+      formatter.format("%n");
+    }
+  }
+
   // For testing
   static void resetCache() {
     shutdown();

--- a/tds/src/main/java/thredds/featurecollection/cache/GridInventoryCacheChronicle.java
+++ b/tds/src/main/java/thredds/featurecollection/cache/GridInventoryCacheChronicle.java
@@ -143,7 +143,7 @@ public class GridInventoryCacheChronicle implements InventoryCacheProvider {
   @Override
   public void put(MFile mfile, GridDatasetInv inventory) throws IOException {
     if (cache != null) {
-      String xml = inventory.writeXML(new Date(mfile.getLastModified()));
+      String xml = inventory.writeCompactXML(new Date(mfile.getLastModified()));
       cache.put(mfile.getPath(), xml.getBytes(Charsets.UTF_8));
     }
   }

--- a/tds/src/main/java/thredds/featurecollection/cache/GridInventoryCacheChronicle.java
+++ b/tds/src/main/java/thredds/featurecollection/cache/GridInventoryCacheChronicle.java
@@ -31,6 +31,16 @@ public class GridInventoryCacheChronicle implements InventoryCacheProvider {
   private static final int DEFAULT_ENTRIES = 1000;
   private static final int DEFAULT_BLOAT_FACTOR = 1;
 
+  private enum AverageValueSize {
+    small(4096), medium(16384), large(65536), defaultSize(small.size);
+
+    private final int size;
+
+    AverageValueSize(int size) {
+      this.size = size;
+    }
+  }
+
   /**
    * Initialize the inventory cache
    *
@@ -50,6 +60,36 @@ public class GridInventoryCacheChronicle implements InventoryCacheProvider {
    * @throws IOException
    */
   public static void init(Path cacheDir, int maxEntries, int maxBloatFactor) throws IOException {
+    init(cacheDir, maxEntries, maxBloatFactor, AverageValueSize.defaultSize.size);
+  }
+
+  /**
+   * Initialize the inventory cache
+   *
+   * @param cacheDir Path to the cache directory. This location will be created if it does not exist.
+   * @param maxEntries number of entries in the cache, at most
+   * @param maxBloatFactor max number of times the cache size can increase
+   * @param averageValueSizeName a name of one of the {@link AverageValueSize} constants or null if the default should
+   *        be used
+   * @throws IOException
+   */
+  public static void init(Path cacheDir, int maxEntries, int maxBloatFactor, String averageValueSizeName)
+      throws IOException {
+    final int averageValueSize = averageValueSizeName == null ? AverageValueSize.defaultSize.size
+        : AverageValueSize.valueOf(averageValueSizeName.toLowerCase(Locale.ROOT)).size;
+    init(cacheDir, maxEntries, maxBloatFactor, averageValueSize);
+  }
+
+  /**
+   * Initialize the inventory cache
+   *
+   * @param cacheDir Path to the cache directory. This location will be created if it does not exist.
+   * @param maxEntries number of entries in the cache, at most
+   * @param maxBloatFactor max number of times the cache size can increase
+   * @param averageValueSize the average size of a value (a grid dataset inventory) in bytes
+   * @throws IOException
+   */
+  private static void init(Path cacheDir, int maxEntries, int maxBloatFactor, int averageValueSize) throws IOException {
     if (!Files.exists(cacheDir)) {
       logger.info("Creating cache directory at {}", cacheDir.toString());
       Files.createDirectories(cacheDir);
@@ -61,8 +101,11 @@ public class GridInventoryCacheChronicle implements InventoryCacheProvider {
       logger.info("Creating new grid inventory cache file at {}", dbFile.toString());
     }
     if (cache == null) {
+      logger.info("Grid inventory cache built with: maxEntries={}, maxBloatFactor={}, averageValueSize={}", maxEntries,
+          maxBloatFactor, averageValueSize);
+
       cache = ChronicleMapBuilder.of(String.class, byte[].class).name("GridDatasetInv")
-          .averageKey("/data/project/analysis/file.ext").averageValueSize(4096).entries(maxEntries)
+          .averageKey("/data/project/analysis/file.ext").averageValueSize(averageValueSize).entries(maxEntries)
           .maxBloatFactor(maxBloatFactor).createOrRecoverPersistedTo(dbFile.toFile());
     }
   }

--- a/tds/src/main/java/thredds/server/admin/DebugCommands.java
+++ b/tds/src/main/java/thredds/server/admin/DebugCommands.java
@@ -8,6 +8,7 @@ package thredds.server.admin;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+import thredds.featurecollection.cache.GridInventoryCacheChronicle;
 import thredds.server.config.TdsContext;
 import thredds.servlet.ServletUtil;
 import ucar.nc2.dataset.NetcdfDataset;
@@ -144,6 +145,9 @@ public class DebugCommands {
           f.format("%n%n");
           fc.showCache(f);
         }
+
+        f.format("%n%n");
+        GridInventoryCacheChronicle.showCache(f);
 
         e.pw.flush();
       }

--- a/tds/src/main/java/thredds/server/config/TdsInit.java
+++ b/tds/src/main/java/thredds/server/config/TdsInit.java
@@ -380,10 +380,11 @@ public class TdsInit implements ApplicationListener<ContextRefreshedEvent>, Disp
           tdsContext.getThreddsDirectory().getPath() + "/cache/collection/"); // cacheDirectory is old way
     int maxEntries = ThreddsConfig.getInt("FeatureCollection.maxEntries", 1000);
     int maxBloatFactor = ThreddsConfig.getInt("FeatureCollection.maxBloatFactor", 1);
+    String averageValueSize = ThreddsConfig.get("FeatureCollection.averageValueSize", null);
 
     Path fcCacheDir = Paths.get(fcCache);
     try {
-      GridInventoryCacheChronicle.init(fcCacheDir, maxEntries, maxBloatFactor);
+      GridInventoryCacheChronicle.init(fcCacheDir, maxEntries, maxBloatFactor, averageValueSize);
       startupLog.info("TdsInit: GridDatasetInv cache= {}", fcCache);
     } catch (Exception e) {
       startupLog.error("TdsInit: Failed initialize GridDatasetInv cache= {}", fcCache, e);

--- a/tds/src/test/content/thredds/threddsConfig.xml
+++ b/tds/src/test/content/thredds/threddsConfig.xml
@@ -106,6 +106,7 @@
   <FeatureCollection>
     <maxEntries>1024</maxEntries>
     <maxBloatFactor>2</maxBloatFactor>
+    <averageValueSize>medium</averageValueSize>
   </FeatureCollection>
 
   <ConfigCatalog>

--- a/tds/src/test/java/thredds/featurecollection/cache/TestGridInventoryCacheChronicle.java
+++ b/tds/src/test/java/thredds/featurecollection/cache/TestGridInventoryCacheChronicle.java
@@ -1,0 +1,165 @@
+package thredds.featurecollection.cache;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.base.Charsets;
+import java.io.File;
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import java.util.Date;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.TemporaryFolder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import thredds.filesystem.MFileOS;
+import thredds.inventory.MFile;
+import ucar.nc2.dt.grid.GridDataset;
+import ucar.nc2.ft.fmrc.GridDatasetInv;
+import ucar.nc2.time.CalendarDate;
+import ucar.unidata.util.test.TestDir;
+import ucar.unidata.util.test.category.NeedsCdmUnitTest;
+
+public class TestGridInventoryCacheChronicle {
+  private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+  // takes up 316 bytes in the cache
+  private static final String SMALL_FILE = "src/test/content/thredds/public/testdata/testData.nc";
+  // takes up 15661 bytes in the cache
+  private static final String LARGE_FILE =
+      TestDir.cdmUnitTestDir + "ft/fmrc/cache/SILAM-AQ-glob06_v5_8_2022090900_002.nc4";
+
+  @Rule
+  public final TemporaryFolder tempFolder = new TemporaryFolder();
+
+  @After
+  public void reset() {
+    GridInventoryCacheChronicle.resetCache();
+  }
+
+  @Test
+  public void shouldInitializeDefaultCache() throws IOException {
+    GridInventoryCacheChronicle.init(tempFolder.getRoot().toPath());
+    final File[] files = tempFolder.getRoot().listFiles();
+    assertThat(files).isNotNull();
+    assertThat(files.length).isEqualTo(1);
+    assertThat(files[0].getName()).endsWith("GridDatasetInv.dat");
+  }
+
+  @Test
+  public void shouldRetrieveFromCache() throws IOException {
+    GridInventoryCacheChronicle.init(tempFolder.getRoot().toPath());
+    final GridInventoryCacheChronicle cache = new GridInventoryCacheChronicle();
+
+    final MFile mFile = new MFileOS(SMALL_FILE);
+    final CalendarDate date = CalendarDate.of(0);
+    final GridDatasetInv gridDatasetInv = new GridDatasetInv(GridDataset.openIfce(mFile.getPath()), date);
+    cache.put(mFile, gridDatasetInv);
+
+    final GridDatasetInv retrievedGridDatasetInv = cache.get(mFile);
+    assertThat(retrievedGridDatasetInv).isNotNull();
+    assertThat(retrievedGridDatasetInv.getRunDate()).isEqualTo(date);
+    assertThat(retrievedGridDatasetInv.getTimeCoords().size()).isEqualTo(gridDatasetInv.getTimeCoords().size());
+    assertThat(retrievedGridDatasetInv.getVertCoords().size()).isEqualTo(gridDatasetInv.getVertCoords().size());
+    assertThat(retrievedGridDatasetInv.findGrid("Z_sfc")).isNotNull();
+  }
+
+  @Test
+  public void shouldFitMaxEntriesInCacheWithDefaultAverageValueSize() throws IOException {
+    final int maxEntries = 10;
+    GridInventoryCacheChronicle.init(tempFolder.getRoot().toPath(), maxEntries, 1);
+    assertThat(GridInventoryCacheChronicle.getRemainingAutoResizes()).isEqualTo(1);
+
+    putInCache(maxEntries, SMALL_FILE);
+    assertThat(GridInventoryCacheChronicle.getRemainingAutoResizes()).isEqualTo(1);
+    assertThat(GridInventoryCacheChronicle.getNumberOfEntries()).isEqualTo(maxEntries);
+  }
+
+  @Test
+  public void shouldFitMaxEntriesInCacheWithMediumAverageValueSize() throws IOException {
+    final int maxEntries = 10;
+    GridInventoryCacheChronicle.init(tempFolder.getRoot().toPath(), maxEntries, 1, "MEDIUM");
+    assertThat(GridInventoryCacheChronicle.getRemainingAutoResizes()).isEqualTo(1);
+
+    putInCache(maxEntries, SMALL_FILE);
+    assertThat(GridInventoryCacheChronicle.getRemainingAutoResizes()).isEqualTo(1);
+    assertThat(GridInventoryCacheChronicle.getNumberOfEntries()).isEqualTo(maxEntries);
+  }
+
+  @Category(NeedsCdmUnitTest.class)
+  @Test
+  public void shouldFitLessThanMaxEntriesInCacheForLargeFileWithSmallAverageValueSize() throws IOException {
+    final int maxEntries = 10;
+    GridInventoryCacheChronicle.init(tempFolder.getRoot().toPath(), maxEntries, 1, "Small");
+    assertThat(GridInventoryCacheChronicle.getRemainingAutoResizes()).isEqualTo(1);
+
+    putInCache(6, LARGE_FILE);
+    assertThat(GridInventoryCacheChronicle.getRemainingAutoResizes()).isEqualTo(0);
+    assertThat(GridInventoryCacheChronicle.getNumberOfEntries()).isEqualTo(6);
+  }
+
+  @Category(NeedsCdmUnitTest.class)
+  @Test
+  public void shouldFitMaxEntriesInCacheForLargeFileWithLargeAverageValueSize() throws IOException {
+    final int maxEntries = 10;
+    GridInventoryCacheChronicle.init(tempFolder.getRoot().toPath(), maxEntries, 1, "large");
+    assertThat(GridInventoryCacheChronicle.getRemainingAutoResizes()).isEqualTo(1);
+
+    putInCache(maxEntries, LARGE_FILE);
+    assertThat(GridInventoryCacheChronicle.getRemainingAutoResizes()).isEqualTo(1);
+    assertThat(GridInventoryCacheChronicle.getNumberOfEntries()).isEqualTo(10);
+  }
+
+  @Category(NeedsCdmUnitTest.class)
+  @Test
+  public void shouldResizeCacheWithDefaultAverageValueSize() throws IOException {
+    final int maxEntries = 10;
+    final int maxBloatFactor = 5;
+    GridInventoryCacheChronicle.init(tempFolder.getRoot().toPath(), maxEntries, maxBloatFactor);
+
+    try {
+      putInCache(100, LARGE_FILE);
+    } catch (IllegalStateException e) {
+      assertThat(GridInventoryCacheChronicle.getRemainingAutoResizes()).isEqualTo(0);
+      assertThat(GridInventoryCacheChronicle.getNumberOfEntries()).isAtLeast(18);
+    }
+  }
+
+  @Category(NeedsCdmUnitTest.class)
+  @Test
+  public void shouldResizeCacheWithLargeAverageValueSize() throws IOException {
+    final int maxEntries = 10;
+    final int maxBloatFactor = 5;
+    GridInventoryCacheChronicle.init(tempFolder.getRoot().toPath(), maxEntries, maxBloatFactor, "LARGE");
+
+    try {
+      putInCache(400, LARGE_FILE);
+    } catch (IllegalStateException e) {
+      assertThat(GridInventoryCacheChronicle.getRemainingAutoResizes()).isEqualTo(0);
+      assertThat(GridInventoryCacheChronicle.getNumberOfEntries()).isAtLeast(300);
+    }
+  }
+
+  private void putInCache(int numberOfTimes, String filename) throws IOException {
+    final GridInventoryCacheChronicle cache = new GridInventoryCacheChronicle();
+    final GridDatasetInv gridDatasetInv = new GridDatasetInv(GridDataset.open(filename), CalendarDate.of(0));
+    logger.debug("Value size (bytes): " + calculateValueSize(filename));
+
+    for (int i = 0; i < numberOfTimes; i++) {
+      final MFile mFile = new MFileOS("key" + i);
+      cache.put(mFile, gridDatasetInv);
+      logger.debug("Number of entries = {}, Remaining auto resizes = {}, % free space = {}",
+          GridInventoryCacheChronicle.getNumberOfEntries(), GridInventoryCacheChronicle.getRemainingAutoResizes(),
+          GridInventoryCacheChronicle.getPercentageFreeSpace());
+    }
+  }
+
+  private static int calculateValueSize(String file) throws IOException {
+    try (final GridDataset gridDataset = GridDataset.open(file)) {
+      final GridDatasetInv inv = new GridDatasetInv(gridDataset, CalendarDate.of(0));
+      return inv.writeCompactXML(new Date()).getBytes(Charsets.UTF_8).length;
+    }
+  }
+}

--- a/tds/src/test/java/thredds/featurecollection/cache/TestGridInventoryCacheChronicle.java
+++ b/tds/src/test/java/thredds/featurecollection/cache/TestGridInventoryCacheChronicle.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.util.Date;
 import org.junit.After;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -34,8 +35,13 @@ public class TestGridInventoryCacheChronicle {
   @Rule
   public final TemporaryFolder tempFolder = new TemporaryFolder();
 
+  @BeforeClass
+  public static void resetBeforeClass() {
+    GridInventoryCacheChronicle.resetCache();
+  }
+
   @After
-  public void reset() {
+  public void resetAfterEachTest() {
     GridInventoryCacheChronicle.resetCache();
   }
 

--- a/tds/src/test/java/thredds/server/config/ThreddsConfigTest.java
+++ b/tds/src/test/java/thredds/server/config/ThreddsConfigTest.java
@@ -40,6 +40,7 @@ public class ThreddsConfigTest {
     assertEquals(52428800, ThreddsConfig.getBytes("NetcdfSubsetService.maxFileDownloadSize", -1L));
     assertEquals(1024, ThreddsConfig.getInt("FeatureCollection.maxEntries", 1000));
     assertEquals(2, ThreddsConfig.getInt("FeatureCollection.maxBloatFactor", 1));
+    assertEquals("medium", ThreddsConfig.get("FeatureCollection.averageValueSize", null));
   }
 
   // Tests the "cachePathPolicy" element, added in response to this message on the thredds mailing list:


### PR DESCRIPTION
Related to https://github.com/Unidata/tds/issues/317.

- Add `averageValueSize` parameter to the FMRC cache settings in `threddsConfig.xml`, with values: small (default), medium, or large.
- Use compact xml in the cache instead of pretty printed xml
- Update documentation
- Add tests (added a file to thredds-test-data that has a large cache value size)
- Add extra logging info to the admin debug service

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unidata/tds/327)
<!-- Reviewable:end -->
