### PR TITLE
Fix grib collection time interval

### DIFF
--- a/tds/src/integrationTests/java/thredds/featurecollection/TestGribFeatureCollection.java
+++ b/tds/src/integrationTests/java/thredds/featurecollection/TestGribFeatureCollection.java
@@ -1,0 +1,49 @@
+package thredds.featurecollection;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.io.IOException;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import thredds.test.util.TestOnLocalServer;
+import ucar.nc2.NetcdfFile;
+import ucar.nc2.Variable;
+import ucar.nc2.dataset.NetcdfDatasets;
+import ucar.unidata.util.test.category.NeedsCdmUnitTest;
+
+public class TestGribFeatureCollection {
+
+  @Test
+  @Category(NeedsCdmUnitTest.class)
+  public void shouldReturnCorrectTimeRange() throws IOException {
+    final String collection = "HRRR/analysis/";
+    final String topPartition = collection + "TP";
+    final String singleFile = collection + "HRRR_CONUS_2p5km_ana_20150706_2000.grib2";
+
+    assertTimeHasSizeAndRank(topPartition, 4, 1);
+    assertTimeHasSizeAndRank(singleFile, 1, 1);
+  }
+
+  @Test
+  @Category(NeedsCdmUnitTest.class)
+  public void shouldReturnCorrectTimeRangeFor2DTimeCollection() throws IOException {
+    final String collection = "gribCollection/gfsConus80_file/gfsConus80_file-20141024/";
+    final String twoD = collection + "TwoD";
+    final String singleFile = collection + "GFS_CONUS_80km_20141024_0000.grib1";
+    final String best = collection + "Best";
+
+    assertTimeHasSizeAndRank(twoD, 84, 2);
+    assertTimeHasSizeAndRank(singleFile, 1, 1);
+    assertTimeHasSizeAndRank(best, 4, 1);
+  }
+
+  private static void assertTimeHasSizeAndRank(String path, int size, int rank) throws IOException {
+    final String endpoint = TestOnLocalServer.withHttpPath("dodsC/" + path);
+    try (NetcdfFile ncfile = NetcdfDatasets.openFile(endpoint, null)) {
+      final Variable time = ncfile.findVariable("time");
+      assertThat((Object) time).isNotNull();
+      assertThat(time.getSize()).isEqualTo(size);
+      assertThat(time.getRank()).isEqualTo(rank);
+    }
+  }
+}

--- a/tds/src/main/java/thredds/featurecollection/InvDatasetFcGrib.java
+++ b/tds/src/main/java/thredds/featurecollection/InvDatasetFcGrib.java
@@ -704,7 +704,7 @@ public class InvDatasetFcGrib extends InvDatasetFeatureCollection {
 
   // kinda kludgey, but trying not keep URLs stable
   public GribCollectionImmutable.Dataset getSingleDatasetOrByTypeName(GribCollectionImmutable gc, String typeName) {
-    if (gc.getDatasets().size() == 1)
+    if (gc.getDatasets().size() == 1 && typeName.equalsIgnoreCase(PARTITION_DATASET))
       return gc.getDataset(0);
     for (GribCollectionImmutable.Dataset ds : gc.getDatasets())
       if (ds.getType().toString().equalsIgnoreCase(typeName))

--- a/tds/src/main/java/thredds/featurecollection/InvDatasetFcGrib.java
+++ b/tds/src/main/java/thredds/featurecollection/InvDatasetFcGrib.java
@@ -703,6 +703,13 @@ public class InvDatasetFcGrib extends InvDatasetFeatureCollection {
   }
 
   // kinda kludgey, but trying not keep URLs stable
+  /**
+   * @return Dataset if typeName matches the type of one of the collection datasets (e.g. "Best", "TwoD").
+   *         If the requested typeName is "TP" and there is only one dataset, return it (e.g. dataset is type "MRUTP").
+   *         Else return null, e.g. if typeName is the name of a dataset.
+   * @deprecated Should not be public
+   */
+  @Deprecated
   public GribCollectionImmutable.Dataset getSingleDatasetOrByTypeName(GribCollectionImmutable gc, String typeName) {
     if (gc.getDatasets().size() == 1 && typeName.equalsIgnoreCase(PARTITION_DATASET))
       return gc.getDataset(0);


### PR DESCRIPTION
Fixes issue where grib collections with one time dimension always return all times even when a single file is requested.

The function I am fixing in this PR should return the full collection when the "TP" is requested and null if a specific grib file is requested (and then a different code path will find the correct time partition to return instead of the whole thing). Previously, it returned the full dataset in both cases. This bug did not affect forecast datasets that have two time dimensions, because there the number of datasets is two (best and twoD).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Unidata/tds/339)
<!-- Reviewable:end -->
