### PR TITLE
Update docs about wms palettes

### DIFF
--- a/docs/userguide/src/site/pages/thredds/ThreddsConfigRef.md
+++ b/docs/userguide/src/site/pages/thredds/ThreddsConfigRef.md
@@ -235,7 +235,7 @@ The following shows all the configuration options available in the WMS section o
 <WMS>
   <allow>true</allow>
   <allowRemote>false</allowRemote>
-  <paletteLocationDir>/path/to/custom/palettes</paletteLocationDir>
+  <paletteLocationDir>wmsPalettes</paletteLocationDir>
   <maxImageWidth>2048</maxImageWidth>
   <maxImageHeight>2048</maxImageHeight>
 </WMS>
@@ -248,7 +248,8 @@ Here is the description of the various options:
 * `allowRemote`: a value of `true` enables the WMS service for datasets available from a remote server.
 * `paletteLocationDir`: optionally specify the location of the directory containing your own palette files, by specifying the directory
 where they are contained.
-  If the directory location starts with a `/`, the path is absolute, otherwise it is relative to `${tds.content.root.path}/thredds/`.
+  The directory is relative to `${tds.content.root.path}/thredds/`.
+  The default directory for custom palette files is `${tds.content.root.path}/thredds/wmsPalettes`.
   If you don't specify it, or specify it incorrectly, the default palettes will be used, which are described
   [here](https://reading-escience-centre.gitbooks.io/ncwms-user-guide/content/04-usage.html#getmap).
 * `maxImageWidth`: the maximum image width in pixels that this WMS service will return.

--- a/docs/userguide/src/site/pages/thredds/ThreddsConfigRef.md
+++ b/docs/userguide/src/site/pages/thredds/ThreddsConfigRef.md
@@ -235,7 +235,7 @@ The following shows all the configuration options available in the WMS section o
 <WMS>
   <allow>true</allow>
   <allowRemote>false</allowRemote>
-  <paletteLocationDir>/WEB-INF/palettes</paletteLocationDir>
+  <paletteLocationDir>/path/to/custom/palettes</paletteLocationDir>
   <maxImageWidth>2048</maxImageWidth>
   <maxImageHeight>2048</maxImageHeight>
 </WMS>
@@ -249,7 +249,8 @@ Here is the description of the various options:
 * `paletteLocationDir`: optionally specify the location of the directory containing your own palette files, by specifying the directory
 where they are contained.
   If the directory location starts with a `/`, the path is absolute, otherwise it is relative to `${tds.content.root.path}/thredds/`.
-  If you don't specify it, or specify it incorrectly, the default palettes will be used, which are in the war file under `WEB-INF/palettes`.
+  If you don't specify it, or specify it incorrectly, the default palettes will be used, which are described
+  [here](https://reading-escience-centre.gitbooks.io/ncwms-user-guide/content/04-usage.html#getmap).
 * `maxImageWidth`: the maximum image width in pixels that this WMS service will return.
 * `maxImageHeight`: the maximum image height in pixels that this WMS service will return.
 


### PR DESCRIPTION
Remove documentation references to /WEB-INF/palettes which no longer exist in TDS 5.

See https://github.com/Unidata/tds/issues/173#issuecomment-956943943 or commit 3335c3632bfc416672c21bd0a2c1c332e5978273

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Unidata/tds/342)
<!-- Reviewable:end -->
