### PR TITLE
Ncss cache fixes

### DIFF
--- a/docs/userguide/src/site/pages/thredds/ThreddsConfigRef.md
+++ b/docs/userguide/src/site/pages/thredds/ThreddsConfigRef.md
@@ -272,9 +272,9 @@ The following shows all the configuration options available in the `NetcdfSubset
 <NetcdfSubsetService>
   <allow>true</allow>
   <dir>(see the note below)</dir>
-  <scour>15 min</scour>
-  <maxAge>30 min</maxAge>
-  <maxFileDownloadSize>300 MB</maxFileDownloadSize>
+  <scour>10 min</scour>
+  <maxAge>5 min</maxAge>
+  <maxFileDownloadSize>-1</maxFileDownloadSize>
 </NetcdfSubsetService>
 ~~~
 

--- a/docs/userguide/src/site/pages/thredds/ThreddsConfigRef.md
+++ b/docs/userguide/src/site/pages/thredds/ThreddsConfigRef.md
@@ -201,8 +201,8 @@ The following shows all the configuration options available in the WCS section o
 <WCS>
   <allow>true</allow>
   <dir>(see the note below)</dir>
-  <scour>15 min</scour>
-  <maxAge>30 min</maxAge>
+  <scour>10 min</scour>
+  <maxAge>5 min</maxAge>
 </WCS>
 ~~~
 

--- a/tds/src/main/java/thredds/server/ncss/controller/NcssGridController.java
+++ b/tds/src/main/java/thredds/server/ncss/controller/NcssGridController.java
@@ -57,7 +57,7 @@ import ucar.nc2.write.NetcdfFormatWriter;
 @RequestMapping("/ncss/grid")
 public class NcssGridController extends AbstractNcssController {
   // Compression rate used to estimate the filesize of netcdf4 compressed files
-  static private final short ESTIMATED_COMPRESION_RATE = 4;
+  private static final short ESTIMATED_COMPRESION_RATE = 4;
   // pattern for valid WKT lat lon point
   // Two decimal digits separated by whitespace, potentially starting and/or ending with
   // a comma

--- a/tds/src/main/java/thredds/server/ncss/controller/NcssGridController.java
+++ b/tds/src/main/java/thredds/server/ncss/controller/NcssGridController.java
@@ -140,6 +140,8 @@ public class NcssGridController extends AbstractNcssController {
     res.flushBuffer();
     res.getOutputStream().close();
     res.setStatus(HttpServletResponse.SC_OK);
+
+    netcdfResult.delete();
   }
 
   private static NetcdfFileFormat getNetcdfFileFormat(SupportedFormat supportedFormat) {

--- a/tds/src/main/java/thredds/server/ncss/controller/NcssGridController.java
+++ b/tds/src/main/java/thredds/server/ncss/controller/NcssGridController.java
@@ -115,7 +115,7 @@ public class NcssGridController extends AbstractNcssController {
           + "Grid requests with vertCoord must have variables with same vertical levels.");
     }
 
-    String responseFile = getResponseFileName(datasetPath, version);
+    String responseFile = getResponseFileName();
     File netcdfResult = makeCFNetcdfFile(gcd, responseFile, params, version);
 
     // filename download attachment
@@ -178,7 +178,7 @@ public class NcssGridController extends AbstractNcssController {
     return new File(responseFilename);
   }
 
-  private String getResponseFileName(String requestPathInfo, NetcdfFileFormat version) {
+  private String getResponseFileName() {
     File ncFile = ncssDiskCache.getDiskCache().createUniqueFile("ncss-grid", ".nc");
 
     if (ncFile == null)

--- a/tds/src/main/java/thredds/server/ncss/controller/NcssGridController.java
+++ b/tds/src/main/java/thredds/server/ncss/controller/NcssGridController.java
@@ -57,7 +57,7 @@ import ucar.nc2.write.NetcdfFormatWriter;
 @RequestMapping("/ncss/grid")
 public class NcssGridController extends AbstractNcssController {
   // Compression rate used to estimate the filesize of netcdf4 compressed files
-  private static final short ESTIMATED_COMPRESION_RATE = 4;
+  private static final short ESTIMATED_COMPRESSION_RATE = 4;
   // pattern for valid WKT lat lon point
   // Two decimal digits separated by whitespace, potentially starting and/or ending with
   // a comma
@@ -163,7 +163,7 @@ public class NcssGridController extends AbstractNcssController {
     // Test maxFileDownloadSize
     long maxFileDownloadSize = ThreddsConfig.getBytes("NetcdfSubsetService.maxFileDownloadSize", -1L);
     if (version == NetcdfFileFormat.NETCDF4)
-      maxFileDownloadSize *= ESTIMATED_COMPRESION_RATE;
+      maxFileDownloadSize *= ESTIMATED_COMPRESSION_RATE;
 
     // write the file
     // default chunking - let user control at some point


### PR DESCRIPTION
- Delete file from NCSS cache when a request succeeds instead of waiting for scour task to clean it up
- Update NCSS and WCS threddsConfig.xml docs to have correct default values
- Minor cleanups: spelling, delete unused parameters

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Unidata/tds/348)
<!-- Reviewable:end -->
