### PR TITLE
CVE-2021-28170

### DIFF
--- a/project-files/owasp-dependency-check/dependency-check-suppression.xml
+++ b/project-files/owasp-dependency-check/dependency-check-suppression.xml
@@ -144,5 +144,6 @@
     ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.glassfish/javax\.el@.*$</packageUrl>
     <vulnerabilityName>CVE-2020-15250</vulnerabilityName>
+    <vulnerabilityName>CVE-2021-28170</vulnerabilityName>
   </suppress>
 </suppressions>


### PR DESCRIPTION
to address the outstanding org.glassfish/javax.el@3.0.0 issue. 