### PR TITLE
Improve code with asserts

### DIFF
--- a/opendap/server/src/main/java/opendap/servers/parsers/AST.java
+++ b/opendap/server/src/main/java/opendap/servers/parsers/AST.java
@@ -406,8 +406,9 @@ class ASTvalue extends AST {
       subclause = getClauseFactory().newValueClause((BaseType) components.pop(), false);
     } else if (fcn != null) {
       subclause = fcn.translate();
-    } else
-      assert (false);
+    } else {
+      throw new IllegalStateException("Unexpected state in AST::translate");
+    }
     return subclause;
   }
 }
@@ -473,7 +474,7 @@ class ASTconstant extends ASTvalue {
       }
         break;
       default:
-        assert (false);
+        throw new IllegalStateException("Unexpected tag = " + tag);
     }
     return subclause;
   }

--- a/opendap/server/src/main/java/opendap/servers/parsers/Ceparse.java
+++ b/opendap/server/src/main/java/opendap/servers/parsers/Ceparse.java
@@ -331,7 +331,7 @@ public abstract class Ceparse implements ExprParserConstants {
         }
         break;
       default:
-        assert (false);
+        throw new IllegalStateException("Unexpected tag = " + tag);
     }
     return value;
   }


### PR DESCRIPTION
We have removed the enable asserts option from our TDS servers. So asserts should not be used for error handling. This PR:
- Changes assert(false) to an exception
- Removes some null checks/asserts where the variable actually can't be null (this change may be clearer if you hide whitespace differences)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Unidata/tds/380)
<!-- Reviewable:end -->
