### PR TITLE
Ignore tests

### DIFF
--- a/tds/src/integrationTests/java/thredds/server/cdmr/TestCdmRemoteCompareDataP.java
+++ b/tds/src/integrationTests/java/thredds/server/cdmr/TestCdmRemoteCompareDataP.java
@@ -75,9 +75,15 @@ public class TestCdmRemoteCompareDataP {
   }
 
   static void addFromScan(final List<Object[]> list, String dirName, FileFilter ff) {
+    // TODO vlens in structures do not currently work
+    String skipStructuresWithVlens = "vlen/IntTimSciSamp.nc";
+
     try {
       TestDir.actOnAll(dirName, ff, new TestDir.Act() {
         public int doAct(String filename) throws IOException {
+          if (filename.endsWith(skipStructuresWithVlens)) {
+            return 0;
+          }
           File file = new File(filename);
           if (file.length() < 100 * 1000) { // 100K
             list.add(new Object[] {filename});

--- a/tds/src/integrationTests/java/thredds/server/cdmr/TestCdmRemoteMisc.java
+++ b/tds/src/integrationTests/java/thredds/server/cdmr/TestCdmRemoteMisc.java
@@ -6,6 +6,7 @@
 package thredds.server.cdmr;
 
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.slf4j.Logger;
@@ -159,6 +160,7 @@ public class TestCdmRemoteMisc {
 
   }
 
+  @Ignore("TODO vlens in structures do not currently work")
   @Test
   public void testVlenInStructure() {
     try {

--- a/tds/src/integrationTests/java/thredds/server/dap4/TestDap4.java
+++ b/tds/src/integrationTests/java/thredds/server/dap4/TestDap4.java
@@ -2,6 +2,7 @@
 package thredds.server.dap4;
 
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.slf4j.Logger;
@@ -20,6 +21,7 @@ import ucar.unidata.util.test.category.NeedsCdmUnitTest;
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 
+@Ignore("TODO unignore when dap4 is working!")
 @Category(NeedsCdmUnitTest.class)
 public class TestDap4 {
   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());


### PR DESCRIPTION
Currently four tests are failing on Jenkins (and have been for a long time). This PR would ignore three of them.

- `testSimpleDap4GridDataset` since DAP4 is still a work in progress in the TDS
- `testVlenInStructure` and `TestCdmRemoteCompareDataP ::doOne` with file `IntTimSciSamp.nc`-- both involve the same file that has a vlen structure member. I encountered issues with this same file while working on the gCDM and discovered that netcdf-java simply does not work for structures with vlens, so I had to ignore this file in the gCDM tests as well.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Unidata/tds/381)
<!-- Reviewable:end -->
