### PR TITLE
Make averageValueSize configurable for DatasetTrackerChronicle

### DIFF
--- a/tdcommon/src/main/java/thredds/server/catalog/tracker/DatasetTrackerChronicle.java
+++ b/tdcommon/src/main/java/thredds/server/catalog/tracker/DatasetTrackerChronicle.java
@@ -27,7 +27,7 @@ public class DatasetTrackerChronicle implements DatasetTracker {
   // average size (bytes) of key for database, which is the path to a given dataset.
   // LOOK: is 512 a good average size? There is no length on file path, so hard to set a maximum.
   private static final int averagePathLength = 512;
-  private static final int averageValueSize = 2000;
+  private static final int averageValueSize = 200;
 
   // delete old databases
   public static void cleanupBefore(String pathname, long trackerNumber) {

--- a/tdcommon/src/test/java/thredds/server/catalog/tracker/TestDatasetTrackerChronicle.java
+++ b/tdcommon/src/test/java/thredds/server/catalog/tracker/TestDatasetTrackerChronicle.java
@@ -48,10 +48,10 @@ public class TestDatasetTrackerChronicle {
   @Test
   public void shouldTrackDatasetWithLongNcml() throws IOException {
     try (DatasetTrackerChronicle datasetTracker =
-        new DatasetTrackerChronicle(tempFolder.getRoot().getAbsolutePath(), 1, 1)) {
+        new DatasetTrackerChronicle(tempFolder.getRoot().getAbsolutePath(), 1, 1, "Large")) {
       assertThat(datasetTracker.getCount()).isEqualTo(0);
 
-      datasetTracker.trackDataset(1, mockDataset(1_000, "path"), null);
+      datasetTracker.trackDataset(1, mockDataset(10_000, "path"), null);
       assertThat(datasetTracker.getCount()).isEqualTo(1);
     }
   }
@@ -59,7 +59,7 @@ public class TestDatasetTrackerChronicle {
   @Test
   public void shouldTrackMultipleDatasetsWithNcml() throws IOException {
     try (DatasetTrackerChronicle datasetTracker =
-        new DatasetTrackerChronicle(tempFolder.getRoot().getAbsolutePath(), 10, 1)) {
+        new DatasetTrackerChronicle(tempFolder.getRoot().getAbsolutePath(), 10, 1, "medium")) {
       assertThat(datasetTracker.getCount()).isEqualTo(0);
 
       datasetTracker.trackDataset(1, mockDataset(100, "path1"), null);

--- a/tds/src/main/java/thredds/core/ConfigCatalogInitialization.java
+++ b/tds/src/main/java/thredds/core/ConfigCatalogInitialization.java
@@ -86,6 +86,7 @@ public class ConfigCatalogInitialization {
   private String contextPath; // thredds
   private String trackerDir; // the tracker "databases" are kept in this directory
   private long maxDatasets; // chronicle limit
+  private String averageValueSize;
 
   // on reread, construct new objects, so cant be spring beans
   private DataRootPathMatcher dataRootPathMatcher;
@@ -108,6 +109,10 @@ public class ConfigCatalogInitialization {
 
   public void setMaxDatasetToTrack(long maxDatasets) {
     this.maxDatasets = maxDatasets;
+  }
+
+  public void setDatasetTrackerAverageValueSize(String averageValueSize) {
+    this.averageValueSize = averageValueSize;
   }
 
   // called from TdsInit on spring-managed auto-wired bean
@@ -141,7 +146,7 @@ public class ConfigCatalogInitialization {
     if (!isStartup && readMode == ReadMode.always)
       trackerNumber++; // must write a new database if TDS is already running and rereading all
     if (!isDebugMode || this.datasetTracker == null)
-      this.datasetTracker = new DatasetTrackerChronicle(trackerDir, maxDatasets, trackerNumber);
+      this.datasetTracker = new DatasetTrackerChronicle(trackerDir, maxDatasets, trackerNumber, averageValueSize);
 
     boolean databaseAlreadyExists = datasetTracker.exists(); // detect if tracker database exists
     if (!databaseAlreadyExists) {

--- a/tds/src/main/java/thredds/server/config/TdsInit.java
+++ b/tds/src/main/java/thredds/server/config/TdsInit.java
@@ -436,6 +436,7 @@ public class TdsInit implements ApplicationListener<ContextRefreshedEvent>, Disp
     String trackerDir = ThreddsConfig.get("ConfigCatalog.dir",
         new File(tdsContext.getThreddsDirectory().getPath(), "/cache/catalog/").getPath());
     int trackerMax = ThreddsConfig.getInt("ConfigCatalog.maxDatasets", 10 * 1000);
+    String datasetTrackerAverageValueSize = ThreddsConfig.get("ConfigCatalog.averageValueSize", null);
     File trackerDirFile = new File(trackerDir);
     if (!trackerDirFile.exists()) {
       boolean ok = trackerDirFile.mkdirs();
@@ -443,6 +444,7 @@ public class TdsInit implements ApplicationListener<ContextRefreshedEvent>, Disp
     }
     configCatalogInitializer.setTrackerDir(trackerDir);
     configCatalogInitializer.setMaxDatasetToTrack(trackerMax);
+    configCatalogInitializer.setDatasetTrackerAverageValueSize(datasetTrackerAverageValueSize);
 
     // Jupyter notebook service cache
     if (allowedServices.isAllowed(StandardService.jupyterNotebook)) {


### PR DESCRIPTION
In this [issue](https://github.com/Unidata/tds/issues/368), a few datasets with very large NcML caused the ChronicleMap cache to fail. This PR would allow the `averageValueSize` to be configurable (`small`, `medium`, or `large` with `small` as the default). For example:

```
  <ConfigCatalog>
    <averageValueSize>large</averageValueSize>
  </ConfigCatalog>
  ```