### PR TITLE
Fix opendap error code

### DIFF
--- a/tds/src/main/java/thredds/server/opendap/OpendapServlet.java
+++ b/tds/src/main/java/thredds/server/opendap/OpendapServlet.java
@@ -226,6 +226,10 @@ public class OpendapServlet extends AbstractServlet implements InitializingBean 
       response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
       parseExceptionHandler(pe, response);
 
+    } catch (IllegalArgumentException e) {
+      log.info("request= " + rs, e);
+      sendErrorResponse(response, HttpServletResponse.SC_BAD_REQUEST, e.getMessage());
+
       // 403 - request too big
     } catch (RequestTooLargeException e) {
       // handled at the Spring level by TdsErrorHandling, so

--- a/tds/src/test/java/thredds/server/opendap/OpendapServletTest.java
+++ b/tds/src/test/java/thredds/server/opendap/OpendapServletTest.java
@@ -127,4 +127,20 @@ public class OpendapServletTest {
     System.out.printf("%s%n", strResponse);
   }
 
+  @Test
+  public void shouldReturnBadRequestForMalformedTime() {
+    final String path = "/testGFSfmrc/runs/GFS_CONUS_80km_nc_RUN_2012-19T00:00:00Z.html";
+    final MockHttpServletResponse response = mockGetRequest(path);
+    assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_BAD_REQUEST);
+  }
+
+  private MockHttpServletResponse mockGetRequest(String path) {
+    final String mockURI = "/thredds/dodsC" + path;
+    MockHttpServletRequest request = new MockHttpServletRequest("GET", mockURI);
+    request.setContextPath("/thredds");
+    request.setPathInfo(path);
+    final MockHttpServletResponse response = new MockHttpServletResponse();
+    opendapServlet.doGet(request, response);
+    return response;
+  }
 }

--- a/tds/src/test/java/thredds/server/opendap/OpendapServletTest.java
+++ b/tds/src/test/java/thredds/server/opendap/OpendapServletTest.java
@@ -34,7 +34,7 @@ public class OpendapServletTest {
   private ServletConfig servletConfig;
 
   private OpendapServlet opendapServlet;
-  private String path = "/gribCollection/GFS_CONUS_80km/GFS_CONUS_80km_20120229_1200.grib1";
+  private final String path = "/gribCollection/GFS_CONUS_80km/GFS_CONUS_80km_20120229_1200.grib1";
 
   @Before
   public void setUp() throws Exception {

--- a/tds/src/test/java/thredds/server/opendap/OpendapServletTest.java
+++ b/tds/src/test/java/thredds/server/opendap/OpendapServletTest.java
@@ -2,7 +2,6 @@ package thredds.server.opendap;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.lang.invoke.MethodHandles;
@@ -16,7 +15,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
-import org.springframework.mock.web.MockServletConfig;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
@@ -46,7 +44,7 @@ public class OpendapServletTest {
   }
 
   @Test
-  public void asciiDataRequestTest() throws UnsupportedEncodingException {
+  public void asciiDataRequestTest() {
     String mockURI = "/thredds/dodsC" + path + ".ascii";
     String mockQueryString = "Temperature_height_above_ground[0:1:0][0:1:0][41][31]";
     MockHttpServletRequest request = new MockHttpServletRequest("GET", mockURI);
@@ -56,9 +54,6 @@ public class OpendapServletTest {
     MockHttpServletResponse response = new MockHttpServletResponse();
     opendapServlet.doGet(request, response);
     assertEquals(200, response.getStatus());
-
-    // String strResponse = response.getContentAsString();
-    // System.out.printf("%s%n", strResponse);
   }
 
   @Test

--- a/tds/src/test/java/thredds/server/opendap/OpendapServletTest.java
+++ b/tds/src/test/java/thredds/server/opendap/OpendapServletTest.java
@@ -1,7 +1,6 @@
 package thredds.server.opendap;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assert.assertEquals;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.lang.invoke.MethodHandles;
@@ -53,7 +52,7 @@ public class OpendapServletTest {
     request.setPathInfo(path + ".ascii");
     MockHttpServletResponse response = new MockHttpServletResponse();
     opendapServlet.doGet(request, response);
-    assertEquals(200, response.getStatus());
+    assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_OK);
   }
 
   @Test
@@ -66,7 +65,7 @@ public class OpendapServletTest {
     request.setPathInfo(path + ".ascii");
     MockHttpServletResponse response = new MockHttpServletResponse();
     opendapServlet.doGet(request, response);
-    assertEquals(200, response.getStatus());
+    assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_OK);
 
     String strResponse = response.getContentAsString();
     logger.debug(strResponse);
@@ -105,7 +104,7 @@ public class OpendapServletTest {
     request.setPathInfo(path + ".dods");
     MockHttpServletResponse response = new MockHttpServletResponse();
     opendapServlet.doGet(request, response);
-    assertEquals(200, response.getStatus());
+    assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_OK);
     // not set by servlet mocker :: assertEquals("application/octet-stream", response.getContentType());
 
     String strResponse = response.getContentAsString();

--- a/tds/src/test/java/thredds/server/opendap/OpendapServletTest.java
+++ b/tds/src/test/java/thredds/server/opendap/OpendapServletTest.java
@@ -69,7 +69,7 @@ public class OpendapServletTest {
     assertEquals(200, response.getStatus());
 
     String strResponse = response.getContentAsString();
-    System.out.printf("%s%n", strResponse);
+    logger.debug(strResponse);
   }
 
   @Test
@@ -109,7 +109,7 @@ public class OpendapServletTest {
     // not set by servlet mocker :: assertEquals("application/octet-stream", response.getContentType());
 
     String strResponse = response.getContentAsString();
-    System.out.printf("%s%n", strResponse);
+    logger.debug(strResponse);
   }
 
   @Test

--- a/tds/src/test/java/thredds/server/opendap/OpendapServletTest.java
+++ b/tds/src/test/java/thredds/server/opendap/OpendapServletTest.java
@@ -75,12 +75,7 @@ public class OpendapServletTest {
   @Test
   public void shouldReturnAttributesWithEmptyAndNullValues() throws UnsupportedEncodingException {
     final String path = "/scanLocal/testEmptyAndNullAttributes.nc4.html";
-    final String mockURI = "/thredds/dodsC" + path;
-    MockHttpServletRequest request = new MockHttpServletRequest("GET", mockURI);
-    request.setContextPath("/thredds");
-    request.setPathInfo(path);
-    final MockHttpServletResponse response = new MockHttpServletResponse();
-    opendapServlet.doGet(request, response);
+    final MockHttpServletResponse response = mockGetRequest(path);
     assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_OK);
 
     final String stringResponse = response.getContentAsString();
@@ -93,12 +88,7 @@ public class OpendapServletTest {
   @Test
   public void shouldNotContainNCPropertiesAttribute() throws IOException {
     final String path = "/scanLocal/testEmptyAndNullAttributes.nc4.html";
-    final String mockURI = "/thredds/dodsC" + path;
-    MockHttpServletRequest request = new MockHttpServletRequest("GET", mockURI);
-    request.setContextPath("/thredds");
-    request.setPathInfo(path);
-    final MockHttpServletResponse response = new MockHttpServletResponse();
-    opendapServlet.doGet(request, response);
+    final MockHttpServletResponse response = mockGetRequest(path);
     assertThat(response.getStatus()).isEqualTo(HttpServletResponse.SC_OK);
 
     final String stringResponse = response.getContentAsString();


### PR DESCRIPTION
- Fixes https://github.com/Unidata/tds/issues/324. A badly formed time stamp in a FMRC dataset requested through opendap now returns a bad request code instead of an internal server error
- Add test for this
- Small cleanups to test class