### PR TITLE
Fix test file that renames dimension

### DIFF
--- a/tds-ugrid/src/test/resources/cases/fvcom/fvcom_delt.ncml
+++ b/tds-ugrid/src/test/resources/cases/fvcom/fvcom_delt.ncml
@@ -2,9 +2,6 @@
 <netcdf xmlns="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2"
     location="UCF_FVCOM_DEMO.nc">
     
-    <dimension name="face" orgName="nele"/>
-    <dimension name="node" orgName="node"/>
-    
     <!-- X and Y Coordinates -->
     <variable name="face_x" orgName="xc">
         <attribute name="long_name" value="Characteristics longitude of 2D mesh triangle (e.g. circumcenter coordinate)"/>


### PR DESCRIPTION
Fix [failing test](https://jenkins-aws.unidata.ucar.edu/job/tds/255/testReport/junit/ucar.nc2.dataset/UGridConventionIntegrationTest/classMethod/) after https://github.com/Unidata/netcdf-java/pull/1209. The test ncml file renames the dimension but does not update the name of the dimension in the variables that use it, which causes an error since those variables use a non-existent dimension. The tests don't use the renamed dimension, so I just removed the rename here.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Unidata/tds/393)
<!-- Reviewable:end -->
