### PR TITLE
Allow regExp in notebook lookup by datasetID

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,7 +47,7 @@ opendap/src/test/data/test.*.*
 tds/src/test/content/thredds/logs
 tds/src/test/content/thredds/cache
 tds/src/test/content/thredds/state
-tds/src/test/content/thredds/notebooks/
+tds/src/test/content/thredds/notebooks/default_viewer.ipynb
 tds/src/test/content/thredds/templates/
 tds/src/test/content/README.txt
 tds/src/test/content/thredds/README.txt

--- a/docs/userguide/src/site/pages/tds_tutorial/tds_configuration/CustomizingTdsLookAndFeel.md
+++ b/docs/userguide/src/site/pages/tds_tutorial/tds_configuration/CustomizingTdsLookAndFeel.md
@@ -361,8 +361,22 @@ A Notebook configured for all gridded datasets and a dataset called `almostGridd
     "viewer_info": {
         "description": "This Notebook displays gridded data.",
         "accepts": {
-          "accept_datasetIDs": ["almostGridded],
+          "accept_datasetIDs": ["almostGridded"],
           "accept_dataset_types": ["Grid"]
+        }
+    }
+  }
+~~~
+
+The `accept_datasetIDs` can also include regular expressions. This can be useful, for instance, when configuring a
+notebook for all datasets in a `datasetScan`:
+~~~
+  "metadata": {
+  ...
+    "viewer_info": {
+        "description": "Notebook that displays all datasets in a dataset scan.",
+        "accepts": {
+          "accept_datasetIDs": ["myDatasetScanID/.*"],
         }
     }
   }

--- a/tds/src/integrationTests/java/thredds/server/notebook/TestNotebookServices.java
+++ b/tds/src/integrationTests/java/thredds/server/notebook/TestNotebookServices.java
@@ -1,0 +1,75 @@
+package thredds.server.notebook;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import javax.servlet.http.HttpServletResponse;
+import org.junit.Test;
+import thredds.test.util.TestOnLocalServer;
+import thredds.util.ContentType;
+
+public class TestNotebookServices {
+  private static final String defaultViewer =
+      "{\"filename\":\"default_viewer.ipynb\",\"description\":\"The TDS default viewer attempts to plot any Variable contained in the Dataset.\"}";
+  private static final String testViewer =
+      "{\"filename\":\"testNotebookMetadata.ipynb\",\"description\":\"Test notebook viewer accepts\"}";
+
+  private static final String onlyDefaultViewer = "[" + defaultViewer + "]";
+  private static final String defaultAndTestViewer = "[" + defaultViewer + "," + testViewer + "]";
+  private static final String testAndDefaultViewer = "[" + testViewer + "," + defaultViewer + "]";
+
+  private static final String topCatalog = "?catalog=catalog.xml";
+  private static final String enhancedCatalog = "?catalog=testEnhanced/catalog.xml";
+
+  @Test
+  public void shouldHaveDefaultNotebook() {
+    final String path = "/notebook/testDataset" + topCatalog;
+    final String response = getStringContent(path);
+    assertThat(response).isEqualTo(onlyDefaultViewer);
+  }
+
+  @Test
+  public void shouldReturnNotFound() {
+    final String path = "/notebook/notADatasetId" + topCatalog;
+    final String endpoint = TestOnLocalServer.withHttpPath(path);
+    TestOnLocalServer.getContent(endpoint, HttpServletResponse.SC_NOT_FOUND);
+  }
+
+  @Test
+  public void shouldMatchByDatasetId() {
+    final String path = "/notebook/testGAP" + topCatalog;
+    final String response = getStringContent(path);
+    assertThat(response).isAnyOf(defaultAndTestViewer, testAndDefaultViewer);
+  }
+
+  @Test
+  public void shouldMatchDatasetScanByDatasetIdRegExp() {
+    final String path = "/notebook/testEnhanced/2004050412_eta_211.nc" + enhancedCatalog;
+    final String response = getStringContent(path);
+    assertThat(response).isAnyOf(defaultAndTestViewer, testAndDefaultViewer);
+  }
+
+  @Test
+  public void shouldMatchFeatureCollectionDatasetByDatasetIdRegExp() {
+    final String gribPath = "gribCollection/GFS_CONUS_80km/GFS_CONUS_80km_20120227_0000.grib1";
+    final String gribCatalog = "?catalog=" + gribPath + "/catalog.xml";
+    final String path = "/notebook/" + gribPath;
+    final String response = getStringContent(path + gribCatalog);
+    assertThat(response).isAnyOf(defaultAndTestViewer, testAndDefaultViewer);
+  }
+
+  @Test
+  public void shouldMatchFeatureCollectionBestByDatasetIdRegExp() {
+    final String gribPath = "gribCollection/GFS_CONUS_80km/";
+    final String gribCatalog = "?catalog=" + gribPath + "catalog.xml";
+    final String path = "/notebook/" + gribPath + "Best";
+    final String response = getStringContent(path + gribCatalog);
+    assertThat(response).isAnyOf(defaultAndTestViewer, testAndDefaultViewer);
+  }
+
+  private static String getStringContent(String path) {
+    final String endpoint = TestOnLocalServer.withHttpPath(path);
+    final byte[] content = TestOnLocalServer.getContent(endpoint, HttpServletResponse.SC_OK, ContentType.json);
+    return new String(content, StandardCharsets.UTF_8);
+  }
+}

--- a/tds/src/integrationTests/java/thredds/server/notebook/TestNotebookServices.java
+++ b/tds/src/integrationTests/java/thredds/server/notebook/TestNotebookServices.java
@@ -5,8 +5,10 @@ import static com.google.common.truth.Truth.assertThat;
 import java.nio.charset.StandardCharsets;
 import javax.servlet.http.HttpServletResponse;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import thredds.test.util.TestOnLocalServer;
 import thredds.util.ContentType;
+import ucar.unidata.util.test.category.NeedsCdmUnitTest;
 
 public class TestNotebookServices {
   private static final String defaultViewer =
@@ -50,6 +52,7 @@ public class TestNotebookServices {
   }
 
   @Test
+  @Category(NeedsCdmUnitTest.class)
   public void shouldMatchFeatureCollectionDatasetByDatasetIdRegExp() {
     final String gribPath = "gribCollection/GFS_CONUS_80km/GFS_CONUS_80km_20120227_0000.grib1";
     final String gribCatalog = "?catalog=" + gribPath + "/catalog.xml";
@@ -59,6 +62,7 @@ public class TestNotebookServices {
   }
 
   @Test
+  @Category(NeedsCdmUnitTest.class)
   public void shouldMatchFeatureCollectionBestByDatasetIdRegExp() {
     final String gribPath = "gribCollection/GFS_CONUS_80km/";
     final String gribCatalog = "?catalog=" + gribPath + "catalog.xml";

--- a/tds/src/main/java/thredds/server/notebook/NotebookController.java
+++ b/tds/src/main/java/thredds/server/notebook/NotebookController.java
@@ -112,6 +112,11 @@ public class NotebookController {
     String catalogName = params.catalog;
     Dataset dataset = getDataset(catalogName, req);
 
+    if (dataset == null) {
+      throw new FileNotFoundException("Dataset with ID '" + new TdsRequestedDataset(req, getBase()).getPath()
+          + "' not found in catalog '" + catalogName + "'.");
+    }
+
     JSONArray notebooks = getNotebookParams(dataset);
 
     // Set content...

--- a/tds/src/main/java/thredds/server/notebook/NotebookMetadata.java
+++ b/tds/src/main/java/thredds/server/notebook/NotebookMetadata.java
@@ -113,13 +113,13 @@ public class NotebookMetadata {
 
   private class AcceptedDatasetTypes {
 
-    private boolean accept_all;
+    private final boolean accept_all;
 
-    private Set<String> accept_datasetIDs;
+    private final Set<String> accept_datasetIDs;
 
-    private Set<String> accept_catalogs;
+    private final Set<String> accept_catalogs;
 
-    private Set<String> accept_dataset_types;
+    private final Set<String> accept_dataset_types;
 
     public AcceptedDatasetTypes(JSONObject nb) {
       JSONObject jobj = tryGetJSONObjectFromJSON(NotebookMetadataKeys.acceptObject.key, nb);

--- a/tds/src/main/java/thredds/server/notebook/NotebookMetadata.java
+++ b/tds/src/main/java/thredds/server/notebook/NotebookMetadata.java
@@ -1,5 +1,7 @@
 package thredds.server.notebook;
 
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import org.json.*;
 import thredds.client.catalog.Catalog;
 import thredds.client.catalog.Dataset;
@@ -111,11 +113,15 @@ public class NotebookMetadata {
     }
   }
 
+  private static Set<Pattern> compilePatterns(Set<String> set) {
+    return set.stream().map(Pattern::compile).collect(Collectors.toSet());
+  }
+
   private class AcceptedDatasetTypes {
 
     private final boolean accept_all;
 
-    private final Set<String> accept_datasetIDs;
+    private final Set<Pattern> accept_datasetIDs;
 
     private final Set<String> accept_catalogs;
 
@@ -125,7 +131,7 @@ public class NotebookMetadata {
       JSONObject jobj = tryGetJSONObjectFromJSON(NotebookMetadataKeys.acceptObject.key, nb);
 
       this.accept_all = jobj.isEmpty() ? true : tryGetBoolFromJSON(NotebookMetadataKeys.acceptAll.key, jobj);
-      this.accept_datasetIDs = tryGetSetFromJSON(NotebookMetadataKeys.acceptDatasetIDs.key, jobj);
+      this.accept_datasetIDs = compilePatterns(tryGetSetFromJSON(NotebookMetadataKeys.acceptDatasetIDs.key, jobj));
       this.accept_catalogs = tryGetSetFromJSON(NotebookMetadataKeys.acceptCatalogs.key, jobj);
       this.accept_dataset_types = tryGetSetFromJSON(NotebookMetadataKeys.acceptDatasetTypes.key, jobj);
     }
@@ -134,7 +140,7 @@ public class NotebookMetadata {
       if (this.accept_all) {
         return true;
       }
-      if (this.accept_datasetIDs.contains(ds.getID())) {
+      if (ds.getID() != null && accept_datasetIDs.stream().anyMatch(p -> p.matcher(ds.getID()).matches())) {
         return true;
       }
       if (this.accept_dataset_types.contains(ds.getFeatureTypeName())) {

--- a/tds/src/test/content/thredds/notebooks/testNotebookMetadata.ipynb
+++ b/tds/src/test/content/thredds/notebooks/testNotebookMetadata.ipynb
@@ -1,0 +1,10 @@
+{
+  "metadata": {
+    "viewer_info": {
+      "description": "Test notebook viewer accepts",
+      "accepts": {
+        "accept_datasetIDs": ["testGAP", "testEnhanced/.*", "gribCollection/GFS_CONUS_80km/.*"]
+      }
+    }
+  }
+}

--- a/tds/src/test/data/testNotebookMetadata.json
+++ b/tds/src/test/data/testNotebookMetadata.json
@@ -2,7 +2,7 @@
   "metadata": {
     "viewer_info": {
       "accepts": {
-        "accept_datasetIDs": ["matchById"],
+        "accept_datasetIDs": ["matchById", "matchByIdRegExp/.*"],
         "accept_dataset_types": ["GRID"],
         "accept_catalogs": ["Parent catalog by name", "/parent/catalog/by/URI"]
       }

--- a/tds/src/test/java/thredds/server/notebook/TestNotebookService.java
+++ b/tds/src/test/java/thredds/server/notebook/TestNotebookService.java
@@ -55,4 +55,23 @@ public class TestNotebookService {
     Dataset noMatch = new Dataset(otherParent, "Not a match", fldsNoMatch, null, null);
     assertThat(nbData.isValidForDataset(noMatch)).isFalse();
   }
+
+  @Test
+  public void testMatchByDatasetIdWithRegExp()
+      throws NotebookMetadata.InvalidJupyterNotebookException, FileNotFoundException {
+    final String test_file = "src/test/data/testNotebookMetadata.json";
+    NotebookMetadata nbData = new NotebookMetadata(new File(test_file));
+
+    // dataset that matches by ID
+    Map<String, Object> fldsWithId = new HashMap<>();
+    fldsWithId.put(Dataset.Id, "matchByIdRegExp/foo");
+    Dataset matchById = new Dataset(null, "match by Id with reg exp", fldsWithId, null, null);
+    assertThat(nbData.isValidForDataset(matchById)).isTrue();
+
+    // dataset that does not match
+    Map<String, Object> fldsWithNotMatchingId = new HashMap<>();
+    fldsWithNotMatchingId.put(Dataset.Id, "notMatching/matchByIdRegExp/foo");
+    Dataset notAMatch = new Dataset(null, "not a match", fldsWithNotMatchingId, null, null);
+    assertThat(nbData.isValidForDataset(notAMatch)).isFalse();
+  }
 }


### PR DESCRIPTION
The motivation for this change is to configure notebooks for specific datasetScans or featureCollections. For instance, a datasetScan with ID of `myDatasetScanId` contains datasets with IDs of `myDatasetScanId/filename.nc` so an exact match on ID doesn't help you for that case.

This PR includes:
- Allow regular expressions in the `accept_datasetIDs` strings
- integrations tests for the notebook service
- unit tests for regular expressions
- add example to documentation
- return a 404 error for dataset not found

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Unidata/tds/401)
<!-- Reviewable:end -->
