### PR TITLE
Encode Godiva and Jupyter urls

### DIFF
--- a/tds/src/main/java/thredds/server/wms/Godiva3Viewer.java
+++ b/tds/src/main/java/thredds/server/wms/Godiva3Viewer.java
@@ -28,8 +28,10 @@
 
 package thredds.server.wms;
 
+import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URLEncoder;
 import javax.servlet.http.HttpServletRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -39,6 +41,7 @@ import thredds.client.catalog.ServiceType;
 import thredds.server.config.ThreddsConfig;
 import thredds.server.viewer.Viewer;
 import thredds.server.viewer.ViewerLinkProvider;
+import thredds.util.StringValidateEncodeUtils;
 
 /**
  * A Viewer for viewing datasets using the built-in Godiva3 client. The viewer
@@ -89,7 +92,15 @@ public class Godiva3Viewer implements Viewer {
       logger.warn("Godiva3Viewer URL=" + req.getRequestURL().toString(), e);
       return null;
     }
-    String url = req.getContextPath() + "/Godiva.html?server=" + dataURI.toString();
+    String url;
+    try {
+      url = req.getContextPath() + "/Godiva.html?server="
+          + URLEncoder.encode(dataURI.toString(), StringValidateEncodeUtils.CHARACTER_ENCODING_UTF_8);
+    } catch (UnsupportedEncodingException e) {
+      logger.warn("Godiva3Viewer URL=" + req.getRequestURL().toString(), e);
+      return null;
+
+    }
     return new ViewerLinkProvider.ViewerLink(Godiva3Viewer.title, url, "",
         ViewerLinkProvider.ViewerLink.ViewerType.Browser);
   }

--- a/tds/src/test/java/thredds/server/notebook/TestNotebookService.java
+++ b/tds/src/test/java/thredds/server/notebook/TestNotebookService.java
@@ -84,35 +84,34 @@ public class TestNotebookService {
     assertThat(nbData.isValidForDataset(notAMatch)).isFalse();
   }
 
-
-  private static final String DIR = "src/test/content/thredds/public/testdata/";
-
   @Rule
-  public TemporaryFolder temporaryFolder = new TemporaryFolder(new File(DIR));
+  public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
   @Test
   public void testNotebookUrlEncode()
       throws URISyntaxException, NotebookMetadata.InvalidJupyterNotebookException, IOException {
     String parentUri = "/parent/catalog/by/URI";
-    final String catalogUri = "/thredds/catalog/catalog.html";
-    String filename = "file+name.json";
-    File tempFile = temporaryFolder.newFile(filename);
+    String catalogName = "my+catalog.xml";
+    String catalogUri = "/thredds/catalog/" + catalogName;
+    String fileName = "file+name.json";
+
+    File tempFile = temporaryFolder.newFile(fileName);
     Files.copy(Paths.get(test_file), tempFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
-    NotebookMetadata nmd = new NotebookMetadata(tempFile);
+    NotebookMetadata metadata = new NotebookMetadata(tempFile);
 
     Map<String, Object> fldsWithId = new HashMap<>();
     fldsWithId.put(Dataset.Id, "matchById");
     Catalog parentCatalog = new Catalog(new URI(catalogUri), "Other parent name", new HashMap<>(), null);
     Dataset dataset = new Dataset(parentCatalog, "match by parent catalog", fldsWithId, null, null);
-
-    final MockHttpServletRequest request = new MockHttpServletRequest("GET", catalogUri);
+    MockHttpServletRequest request = new MockHttpServletRequest("GET", catalogUri);
 
     JupyterNotebookViewerService.JupyterNotebookViewer viewer =
-        new JupyterNotebookViewerService.JupyterNotebookViewer(nmd, parentUri);
+        new JupyterNotebookViewerService.JupyterNotebookViewer(metadata, parentUri);
     ViewerLinkProvider.ViewerLink link = viewer.getViewerLink(dataset, request);
     String decodedUrl = URLDecoder.decode(link.getUrl(), StringValidateEncodeUtils.CHARACTER_ENCODING_UTF_8);
 
-    assertThat(decodedUrl).contains("filename=" + filename);
+    assertThat(decodedUrl).contains("filename=" + fileName);
+    assertThat(decodedUrl).contains("catalog=" + catalogName);
 
   }
 }

--- a/tds/src/test/java/thredds/server/notebook/TestNotebookService.java
+++ b/tds/src/test/java/thredds/server/notebook/TestNotebookService.java
@@ -2,25 +2,35 @@ package thredds.server.notebook;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.springframework.mock.web.MockHttpServletRequest;
 import thredds.client.catalog.Catalog;
 import thredds.client.catalog.Dataset;
+import thredds.server.viewer.ViewerLinkProvider;
+import thredds.util.StringValidateEncodeUtils;
 import ucar.nc2.constants.FeatureType;
 
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URLDecoder;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.util.HashMap;
 import java.util.Map;
 
 public class TestNotebookService {
+  private final String test_file = "src/test/data/testNotebookMetadata.json";
 
   @Test
   public void testNotebookRegistration()
       throws NotebookMetadata.InvalidJupyterNotebookException, FileNotFoundException, URISyntaxException {
 
-    final String test_file = "src/test/data/testNotebookMetadata.json";
     NotebookMetadata nbData = new NotebookMetadata(new File(test_file));
 
     // dataset that matches by ID
@@ -59,7 +69,6 @@ public class TestNotebookService {
   @Test
   public void testMatchByDatasetIdWithRegExp()
       throws NotebookMetadata.InvalidJupyterNotebookException, FileNotFoundException {
-    final String test_file = "src/test/data/testNotebookMetadata.json";
     NotebookMetadata nbData = new NotebookMetadata(new File(test_file));
 
     // dataset that matches by ID
@@ -73,5 +82,37 @@ public class TestNotebookService {
     fldsWithNotMatchingId.put(Dataset.Id, "notMatching/matchByIdRegExp/foo");
     Dataset notAMatch = new Dataset(null, "not a match", fldsWithNotMatchingId, null, null);
     assertThat(nbData.isValidForDataset(notAMatch)).isFalse();
+  }
+
+
+  private static final String DIR = "src/test/content/thredds/public/testdata/";
+
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder(new File(DIR));
+
+  @Test
+  public void testNotebookUrlEncode()
+      throws URISyntaxException, NotebookMetadata.InvalidJupyterNotebookException, IOException {
+    String parentUri = "/parent/catalog/by/URI";
+    final String catalogUri = "/thredds/catalog/catalog.html";
+    String filename = "file+name.json";
+    File tempFile = temporaryFolder.newFile(filename);
+    Files.copy(Paths.get(test_file), tempFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+    NotebookMetadata nmd = new NotebookMetadata(tempFile);
+
+    Map<String, Object> fldsWithId = new HashMap<>();
+    fldsWithId.put(Dataset.Id, "matchById");
+    Catalog parentCatalog = new Catalog(new URI(catalogUri), "Other parent name", new HashMap<>(), null);
+    Dataset dataset = new Dataset(parentCatalog, "match by parent catalog", fldsWithId, null, null);
+
+    final MockHttpServletRequest request = new MockHttpServletRequest("GET", catalogUri);
+
+    JupyterNotebookViewerService.JupyterNotebookViewer viewer =
+        new JupyterNotebookViewerService.JupyterNotebookViewer(nmd, parentUri);
+    ViewerLinkProvider.ViewerLink link = viewer.getViewerLink(dataset, request);
+    String decodedUrl = URLDecoder.decode(link.getUrl(), StringValidateEncodeUtils.CHARACTER_ENCODING_UTF_8);
+
+    assertThat(decodedUrl).contains("filename=" + filename);
+
   }
 }

--- a/tds/src/test/java/thredds/server/wms/TestGodiva3Viewer.java
+++ b/tds/src/test/java/thredds/server/wms/TestGodiva3Viewer.java
@@ -1,0 +1,40 @@
+package thredds.server.wms;
+
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.mock.web.MockHttpServletRequest;
+import thredds.client.catalog.Dataset;
+import thredds.client.catalog.ServiceType;
+import thredds.server.viewer.ViewerLinkProvider;
+import thredds.util.StringValidateEncodeUtils;
+
+import java.io.UnsupportedEncodingException;
+import java.lang.invoke.MethodHandles;
+import java.net.URLDecoder;
+
+import static thredds.client.catalog.Dataset.makeStandalone;
+import static com.google.common.truth.Truth.assertThat;
+
+public class TestGodiva3Viewer {
+  private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+  @Test
+  public void testGodivaUrlEncode() throws UnsupportedEncodingException {
+    String filePath = "test/filenameWith+sign.nc";
+
+    Dataset ds = makeStandalone(filePath, "", "", ServiceType.WMS.name());
+
+    final String uri = "/thredds/catalog/catalog.html";
+    final MockHttpServletRequest request = new MockHttpServletRequest("GET", uri);
+
+    Godiva3Viewer viewer = new Godiva3Viewer();
+    ViewerLinkProvider.ViewerLink link = viewer.getViewerLink(ds, request);
+
+    String decodedUrl = URLDecoder.decode(link.getUrl(), StringValidateEncodeUtils.CHARACTER_ENCODING_UTF_8);
+
+    assertThat(decodedUrl).endsWith(filePath);
+
+  }
+
+}

--- a/tds/src/test/java/thredds/server/wms/TestGodiva3Viewer.java
+++ b/tds/src/test/java/thredds/server/wms/TestGodiva3Viewer.java
@@ -33,7 +33,7 @@ public class TestGodiva3Viewer {
 
     String decodedUrl = URLDecoder.decode(link.getUrl(), StringValidateEncodeUtils.CHARACTER_ENCODING_UTF_8);
 
-    assertThat(decodedUrl).endsWith(filePath);
+    assertThat(decodedUrl).contains(filePath);
 
   }
 


### PR DESCRIPTION
Need to encode Godiva and Jupyter URLs to handle special characters in the file names.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Unidata/tds/417)
<!-- Reviewable:end -->
