### PR TITLE
Improve error message when test fails

### DIFF
--- a/tds/src/test/java/thredds/server/ncss/controller/grid/GridDatasetControllerTest.java
+++ b/tds/src/test/java/thredds/server/ncss/controller/grid/GridDatasetControllerTest.java
@@ -5,6 +5,7 @@
 package thredds.server.ncss.controller.grid;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
 import static org.junit.Assume.assumeTrue;
 
 import java.io.FileNotFoundException;
@@ -142,10 +143,11 @@ public class GridDatasetControllerTest {
 
     final FileCacheIF rafCache = RandomAccessFile.getGlobalFileCache();
     rafCache.clearCache(true);
-    assertThat(rafCache.showCache()).isEmpty();
+    assertWithMessage(rafCache.showCache().toString()).that(rafCache.showCache()).isEmpty();
     mockMvc.perform(rb);
-    assertThat(rafCache.showCache().size()).isEqualTo(1);
-    assertThat(rafCache.showCache().get(0)).startsWith("false"); // file should not be locked
+    assertWithMessage(rafCache.showCache().toString()).that(rafCache.showCache().size()).isEqualTo(1);
+    // file should not be locked
+    assertWithMessage(rafCache.showCache().toString()).that(rafCache.showCache().get(0)).startsWith("false");
   }
 
   private class FilenameMatcher extends BaseMatcher<String> {


### PR DESCRIPTION
Use `assertWithMessage` to give more info when the test fails.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Unidata/tds/425)
<!-- Reviewable:end -->
