### PR TITLE
Use ncml in dataset scans opened through ncss

### DIFF
--- a/tds/src/main/java/thredds/core/DatasetManager.java
+++ b/tds/src/main/java/thredds/core/DatasetManager.java
@@ -439,12 +439,8 @@ public class DatasetManager implements InitializingBean {
         // and pass that to CoverageDataset
         DtCoverageDataset gds = new DtCoverageDataset(NetcdfDatasets.openDataset(location));
         if (!gds.getGrids().isEmpty()) {
-          Formatter errlog = new Formatter();
-          FeatureDatasetCoverage result = DtCoverageAdapter.factory(gds, errlog);
-          if (result != null)
-            opt = Optional.of(result);
-          else
-            opt = Optional.empty(errlog.toString());
+          FeatureDatasetCoverage result = DtCoverageAdapter.factory(gds, new Formatter());
+          opt = Optional.of(result);
         }
       }
 

--- a/tds/src/test/content/thredds/catalog.xml
+++ b/tds/src/test/content/thredds/catalog.xml
@@ -173,9 +173,8 @@
 
   <dataset name="Ncml Tests">
 
-    <!-- UNTESTED test NcML in dataset LOOK doesnt work -->
-    <dataset name="Example NcML Modified - DODS" ID="ExampleNcMLModified" urlPath="ExampleNcML/Modified.nc">
-      <serviceName>odap</serviceName>
+    <dataset name="Example NcML Modified" ID="ExampleNcMLModified" urlPath="ExampleNcML/Modified.nc">
+      <serviceName>all</serviceName>
       <dataType>Grid</dataType>
       <ncml:netcdf xmlns="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2" location="${cdmUnitTest}/tds/example1.nc" addRecords="true">
         <attribute name="name" value="value"/>
@@ -184,6 +183,9 @@
           <attribute name="long_name" value="relatively humid"/>
           <attribute name="units" value="percent (%)"/>
           <remove type="attribute" name="description"/>
+        </variable>
+        <variable name="time">
+          <attribute name="units" value="hours since 2000-01-01 00:00:00"/>
         </variable>
       </ncml:netcdf>
     </dataset>
@@ -245,6 +247,9 @@
           <attribute name="long_name" value="relatively humid"/>
           <attribute name="units" value="percent (%)"/>
           <remove type="attribute" name="description"/>
+        </variable>
+        <variable name="time">
+          <attribute name="units" value="hours since 2000-01-01 00:00:00"/>
         </variable>
       </ncml:netcdf>
 

--- a/tds/src/test/java/thredds/server/ncss/controller/grid/NcmlTest.java
+++ b/tds/src/test/java/thredds/server/ncss/controller/grid/NcmlTest.java
@@ -6,6 +6,7 @@ import org.jdom2.Document;
 import org.jdom2.Element;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
@@ -25,10 +26,12 @@ import ucar.nc2.NetcdfFile;
 import ucar.nc2.NetcdfFiles;
 import ucar.nc2.Variable;
 import java.io.IOException;
+import ucar.unidata.util.test.category.NeedsCdmUnitTest;
 
 import static com.google.common.truth.Truth.assertThat;
 
 @RunWith(SpringJUnit4ClassRunner.class)
+@Category(NeedsCdmUnitTest.class)
 @WebAppConfiguration
 @ContextConfiguration(locations = {"/WEB-INF/applicationContext.xml", "/WEB-INF/spring-servlet.xml"},
     loader = MockTdsContextLoader.class)

--- a/tds/src/test/java/thredds/server/ncss/controller/grid/NcmlTest.java
+++ b/tds/src/test/java/thredds/server/ncss/controller/grid/NcmlTest.java
@@ -1,0 +1,108 @@
+package thredds.server.ncss.controller.grid;
+
+import java.util.List;
+import java.util.Optional;
+import org.jdom2.Document;
+import org.jdom2.Element;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.RequestBuilder;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import thredds.mock.web.MockTdsContextLoader;
+import thredds.util.xml.XmlUtil;
+import ucar.nc2.Attribute;
+import ucar.nc2.NetcdfFile;
+import ucar.nc2.NetcdfFiles;
+import ucar.nc2.Variable;
+import java.io.IOException;
+
+import static com.google.common.truth.Truth.assertThat;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@WebAppConfiguration
+@ContextConfiguration(locations = {"/WEB-INF/applicationContext.xml", "/WEB-INF/spring-servlet.xml"},
+    loader = MockTdsContextLoader.class)
+public class NcmlTest {
+  private static final String NCML_DATASET = "/ncss/grid/ExampleNcML/Modified.nc";
+  private static final String NCML_DATASET_SCAN = "/ncss/grid/ModifyDatasetScan/example1.nc";
+
+  @Autowired
+  private WebApplicationContext wac;
+
+  private MockMvc mockMvc;
+
+  @Before
+  public void setUp() throws IOException {
+    mockMvc = MockMvcBuilders.webAppContextSetup(this.wac).build();
+  }
+
+  @Test
+  public void shouldShowNcmlModifiedVariableOnDatasetPage() throws Exception {
+    assertShowsNcmlModifiedVariableOnDatasetPage(NCML_DATASET + "/dataset.xml");
+  }
+
+  @Test
+  public void shouldShowNcmlModifiedVariableOnDatasetPageForDatasetScan() throws Exception {
+    assertShowsNcmlModifiedVariableOnDatasetPage(NCML_DATASET_SCAN + "/dataset.xml");
+  }
+
+  @Test
+  public void shouldReturnNcmlModifiedVariable() throws Exception {
+    assertReturnsNcmlModifiedVariable(NCML_DATASET);
+  }
+
+  @Test
+  public void shouldReturnNcmlModifiedVariableForDatasetScan() throws Exception {
+    assertReturnsNcmlModifiedVariable(NCML_DATASET_SCAN);
+  }
+
+  private void assertShowsNcmlModifiedVariableOnDatasetPage(String servletPath) throws Exception {
+    final RequestBuilder requestBuilder = MockMvcRequestBuilders.get(servletPath).servletPath(servletPath);
+    final MvcResult mvcResult =
+        mockMvc.perform(requestBuilder).andExpect(MockMvcResultMatchers.status().isOk()).andReturn();
+
+    final Document doc = XmlUtil.getStringResponseAsDoc(mvcResult.getResponse());
+    final List<Element> grids = XmlUtil.evaluateXPath(doc, "//grid");
+    assertThat(grids).isNotNull();
+
+    final Optional<Element> orgiVar =
+        grids.stream().filter(e -> e.getAttribute("name").getValue().equals("rh")).findFirst();
+    assertThat(orgiVar.isPresent()).isFalse();
+
+    final Optional<Element> modifiedVar =
+        grids.stream().filter(e -> e.getAttribute("name").getValue().equals("ReletiveHumidity")).findFirst();
+    assertThat(modifiedVar.isPresent()).isTrue();
+    assertThat(modifiedVar.get().getAttribute("name").getValue()).isEqualTo("ReletiveHumidity");
+    assertThat(modifiedVar.get().getAttribute("desc").getValue()).isEqualTo("relatively humid");
+  }
+
+  private void assertReturnsNcmlModifiedVariable(String servletPath) throws Exception {
+    final RequestBuilder requestBuilder =
+        MockMvcRequestBuilders.get(servletPath).servletPath(servletPath).param("var", "all");
+    final MvcResult mvcResult =
+        mockMvc.perform(requestBuilder).andExpect(MockMvcResultMatchers.status().isOk()).andReturn();
+
+    try (NetcdfFile ncf = NetcdfFiles.openInMemory("ncmlTest.nc", mvcResult.getResponse().getContentAsByteArray())) {
+      final Variable origVar = ncf.findVariable("rh");
+      assertThat((Object) origVar).isNull();
+
+      final Variable modifiedVar = ncf.findVariable("ReletiveHumidity");
+      assertThat((Object) modifiedVar).isNotNull();
+
+      final Attribute att = modifiedVar.findAttribute("long_name");
+      assertThat(att).isNotNull();
+      assertThat(att.getStringValue()).isEqualTo("relatively humid");
+    }
+  }
+}
+

--- a/tds/src/test/java/thredds/server/ncss/controller/grid/NcmlTest.java
+++ b/tds/src/test/java/thredds/server/ncss/controller/grid/NcmlTest.java
@@ -78,9 +78,9 @@ public class NcmlTest {
     final List<Element> grids = XmlUtil.evaluateXPath(doc, "//grid");
     assertThat(grids).isNotNull();
 
-    final Optional<Element> orgiVar =
+    final Optional<Element> origVar =
         grids.stream().filter(e -> e.getAttribute("name").getValue().equals("rh")).findFirst();
-    assertThat(orgiVar.isPresent()).isFalse();
+    assertThat(origVar.isPresent()).isFalse();
 
     final Optional<Element> modifiedVar =
         grids.stream().filter(e -> e.getAttribute("name").getValue().equals("ReletiveHumidity")).findFirst();


### PR DESCRIPTION
Resolves https://github.com/Unidata/tds/issues/398.

- refactor dataset scans with ncml code in `openNetcdfFile` to helper function
- Handle dataset scans with ncml in `openCoverageDataset` (used by NCSS)
- Small fix for `openCoverageDataset` code-- don't perform null check when function returns `@NonNull`
- Add tests. Update catalog ncml to work for NCSS.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Unidata/tds/434)
<!-- Reviewable:end -->
