### PR TITLE
Update enhancements test 

### DIFF
--- a/tds/src/integrationTests/java/thredds/server/services/TestEnhancements.java
+++ b/tds/src/integrationTests/java/thredds/server/services/TestEnhancements.java
@@ -42,7 +42,6 @@ public class TestEnhancements {
     }
   }
 
-  @Ignore("TODO: fix services to be consistent in how they apply ncml and enhancements")
   @Test
   public void testNCSSWithEnhancementsNcML() throws IOException {
     // scale-offset set as variable attribute

--- a/tds/src/test/content/thredds/catalog.xml
+++ b/tds/src/test/content/thredds/catalog.xml
@@ -56,7 +56,7 @@
       <ncml:netcdf xmlns="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2" enhance="all"
       location="content/testdata/testOffset.nc">
         <variable name="variableWithoutOffset">
-          <attribute name="add_offset" value="-100"/>
+          <attribute name="add_offset" type="float" value="-100"/>
         </variable>
       </ncml:netcdf>
     </dataset>


### PR DESCRIPTION
Enhancements seem to be working in NCSS for NcML datasets if you give a numeric type (other [PR ](https://github.com/Unidata/tds/pull/434) to fix datasetScans). Unignore test and make NcML offset type float instead of string so the offset is recognized.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Unidata/tds/435)
<!-- Reviewable:end -->
