### PR TITLE
Update s3 ncml tests

### DIFF
--- a/tds/src/integrationTests/java/thredds/tds/TestS3Ncml.java
+++ b/tds/src/integrationTests/java/thredds/tds/TestS3Ncml.java
@@ -21,13 +21,21 @@ public class TestS3Ncml {
   }
 
   @Test
-  public void shouldOpenNcmlWithOtherExtensionOnS3() {
-    final String endpoint = TestOnLocalServer.withHttpPath(S3_NCML_PATH + "testStandaloneNcml.otherExt.ascii?time");
+  public void shouldOpenNcmlWithXmlExtensionOnS3() {
+    final String endpoint = TestOnLocalServer.withHttpPath(S3_NCML_PATH + "testStandalone.xml.ascii?time");
     final byte[] content = TestOnLocalServer.getContent(endpoint, HttpServletResponse.SC_OK);
     final String stringContent = new String(content, StandardCharsets.UTF_8);
 
     assertThat(stringContent).contains("time[2]");
     assertThat(stringContent).contains("6, 18");
+  }
+
+  @Test
+  public void shouldOpenNcmlWithOtherExtensionOnS3() {
+    // Can't currently open an S3 NcML file with an extension other than xml or ncml.
+    // Peaking inside the file to check if it's ncml is too slow
+    final String endpoint = TestOnLocalServer.withHttpPath(S3_NCML_PATH + "testStandaloneNcml.otherExt.ascii?time");
+    TestOnLocalServer.getContent(endpoint, HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
   }
 
   @Test


### PR DESCRIPTION
- Add test for opening an ncml file with xml extension
- change expected behavior for file with extension other than xml or ncml (changed in https://github.com/Unidata/netcdf-java/pull/1281)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Unidata/tds/440)
<!-- Reviewable:end -->
