### PR TITLE
Test Opendap and WMS are applying enhancements correctly

### DIFF
--- a/tds/src/integrationTests/java/thredds/server/services/TestEnhancements.java
+++ b/tds/src/integrationTests/java/thredds/server/services/TestEnhancements.java
@@ -11,6 +11,7 @@ import ucar.nc2.Variable;
 import javax.servlet.http.HttpServletResponse;
 
 import java.io.IOException;
+import ucar.nc2.dataset.NetcdfDatasets;
 
 import static com.google.common.truth.Truth.assertThat;
 
@@ -42,6 +43,24 @@ public class TestEnhancements {
     final byte[] content = TestOnLocalServer.getContent(endpoint, HttpServletResponse.SC_OK, ContentType.netcdf);
 
     try (NetcdfFile netcdfFile = NetcdfFiles.openInMemory("test_data.nc", content)) {
+      checkResultWithEnhancements(netcdfFile, 100);
+    }
+  }
+
+  @Test
+  public void testOpendapWithEnhancements() throws IOException {
+    final String endpoint = TestOnLocalServer.withHttpPath("/dodsC/" + ENHANCED_FILE);
+
+    try (NetcdfFile netcdfFile = NetcdfDatasets.openFile(endpoint, null)) {
+      checkResultWithEnhancements(netcdfFile, 0);
+    }
+  }
+
+  @Test
+  public void testOpendapWithEnhancementsNcML() throws IOException {
+    final String endpoint = TestOnLocalServer.withHttpPath("/dodsC/" + NCML_ENHANCED_FILE);
+
+    try (NetcdfFile netcdfFile = NetcdfDatasets.openFile(endpoint, null)) {
       checkResultWithEnhancements(netcdfFile, 100);
     }
   }

--- a/tds/src/integrationTests/java/thredds/server/wms/TestWmsServer.java
+++ b/tds/src/integrationTests/java/thredds/server/wms/TestWmsServer.java
@@ -142,6 +142,17 @@ public class TestWmsServer {
     checkValue(withoutOffsetEndpoint, 7.5);
   }
 
+  @Test
+  public void shouldApplyNcmlOffsetToData() throws IOException, JDOMException {
+    final String datasetPath = "testOffsetWithNcml.nc";
+
+    final String withOffsetEndpoint = createGetFeatureInfoEndpoint(datasetPath, "variableWithOffset");
+    checkValue(withOffsetEndpoint, 7.5);
+
+    final String withoutOffsetEndpoint = createGetFeatureInfoEndpoint(datasetPath, "variableWithoutOffset");
+    checkValue(withoutOffsetEndpoint, -92.5);
+  }
+
   private String createGetFeatureInfoEndpoint(String path, String variableName) {
     return TestOnLocalServer.withHttpPath("/wms/" + path + "?LAYERS=" + variableName
         + "&service=WMS&version=1.3.0&CRS=CRS:84&BBOX=0,0,10,10&WIDTH=100&HEIGHT=100"

--- a/tds/src/integrationTests/java/thredds/server/wms/TestWmsServer.java
+++ b/tds/src/integrationTests/java/thredds/server/wms/TestWmsServer.java
@@ -133,20 +133,30 @@ public class TestWmsServer {
 
   @Test
   public void shouldApplyOffsetToData() throws IOException, JDOMException {
-    final String[] variableNames = {"variableWithOffset", "variableWithoutOffset"};
-    for (String variableName : variableNames) {
-      final String endpoint = TestOnLocalServer.withHttpPath("/wms/scanLocal/testOffset.nc?" + "LAYERS=" + variableName
-          + "&service=WMS&version=1.3.0&CRS=CRS:84&BBOX=0,0,10,10&WIDTH=100&HEIGHT=100"
-          + "&REQUEST=GetFeatureInfo&QUERY_LAYERS=" + variableName + "&i=0&j=0");
-      final byte[] result = TestOnLocalServer.getContent(endpoint, HttpServletResponse.SC_OK, ContentType.xmlwms);
+    final String datasetPath = "scanLocal/testOffset.nc";
 
-      final Reader reader = new StringReader(new String(result, StandardCharsets.UTF_8));
-      final Document doc = new SAXBuilder().build(reader);
-      final XPathExpression<Element> xpath = XPathFactory.instance().compile("//FeatureInfo/value", Filters.element());
-      final Element element = xpath.evaluateFirst(doc);
+    final String withOffsetEndpoint = createGetFeatureInfoEndpoint(datasetPath, "variableWithOffset");
+    checkValue(withOffsetEndpoint, 7.5);
 
-      assertThat(element.getContentSize()).isEqualTo(1);
-      assertThat(Double.valueOf(element.getText())).isWithin(TOLERANCE).of(7.5);
-    }
+    final String withoutOffsetEndpoint = createGetFeatureInfoEndpoint(datasetPath, "variableWithoutOffset");
+    checkValue(withoutOffsetEndpoint, 7.5);
+  }
+
+  private String createGetFeatureInfoEndpoint(String path, String variableName) {
+    return TestOnLocalServer.withHttpPath("/wms/" + path + "?LAYERS=" + variableName
+        + "&service=WMS&version=1.3.0&CRS=CRS:84&BBOX=0,0,10,10&WIDTH=100&HEIGHT=100"
+        + "&REQUEST=GetFeatureInfo&QUERY_LAYERS=" + variableName + "&i=0&j=0");
+  }
+
+  private void checkValue(String endpoint, double expectedValue) throws IOException, JDOMException {
+    final byte[] result = TestOnLocalServer.getContent(endpoint, HttpServletResponse.SC_OK, ContentType.xmlwms);
+
+    final Reader reader = new StringReader(new String(result, StandardCharsets.UTF_8));
+    final Document doc = new SAXBuilder().build(reader);
+    final XPathExpression<Element> xpath = XPathFactory.instance().compile("//FeatureInfo/value", Filters.element());
+    final Element element = xpath.evaluateFirst(doc);
+
+    assertThat(element.getContentSize()).isEqualTo(1);
+    assertThat(Double.valueOf(element.getText())).isWithin(TOLERANCE).of(expectedValue);
   }
 }

--- a/tds/src/test/content/thredds/catalog.xml
+++ b/tds/src/test/content/thredds/catalog.xml
@@ -60,6 +60,15 @@
         </variable>
       </ncml:netcdf>
     </dataset>
+    <dataset name="With NcML enhance=none" ID="withNcMlEnhanceNone" serviceName="all" urlPath="testOffsetWithNcmlEnhanceNone.nc">
+      <serviceName>all</serviceName>
+      <ncml:netcdf xmlns="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2" enhance="none"
+        location="content/testdata/testOffset.nc">
+        <variable name="variableWithoutOffset">
+          <attribute name="add_offset" type="float" value="-100"/>
+        </variable>
+      </ncml:netcdf>
+    </dataset>
   </dataset>
 
   <dataset name="Test Dap4 Dataset" ID="testDap4Dataset" serviceName="dap4"


### PR DESCRIPTION
Ensure both the case of variable enhancement attributes (such as add_offset) in a file and in NcML are tested for NCSS, Opendap, and WMS:

- NCSS: both cases already present in `TestEnhancements`
- Opendap: add both cases to `TestEnhancements` in this PR. Also added NcML `enhance=none` case.
- WMS: enhancement from file already tested in `TestWmsServer`, NcML enhancement test added in this PR

For the situation tested, NCSS and WMS apply enhancements for both inherent attributes and NcML. Opendap applies the enhancements for NcML when `enhance=all` is specified but not if `enhance=none` is specified. Opendap does not apply inherent enhancements to data (so it provides packed binary data).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Unidata/tds/441)
<!-- Reviewable:end -->
