### PR TITLE
Update zarr s3 test

### DIFF
--- a/tds/src/integrationTests/java/thredds/tds/TestZarr.java
+++ b/tds/src/integrationTests/java/thredds/tds/TestZarr.java
@@ -4,14 +4,13 @@ import static com.google.common.truth.Truth.assertThat;
 
 import java.nio.charset.StandardCharsets;
 import javax.servlet.http.HttpServletResponse;
-import org.junit.Ignore;
 import org.junit.Test;
 import thredds.test.util.TestOnLocalServer;
 
 public class TestZarr {
   final private static String ZARR_DIR_PATH = "localContent/zarr/zarr_test_data.zarr";
   final private static String ZARR_ZIP_PATH = "localContent/zarr/zarr_test_data.zip";
-  final private static String ZARR_S3_PATH = "s3-zarr/zarr_test_data.zarr";
+  final private static String ZARR_S3_PATH = "s3-zarr/zarr_test_data.zarr/";
 
   @Test
   public void shouldOpenZarrDirectory() {
@@ -23,7 +22,6 @@ public class TestZarr {
     checkWithOpendap(ZARR_ZIP_PATH);
   }
 
-  @Ignore("Still working on S3 Zarr")
   @Test
   public void shouldOpenObjectStoreZarrFile() {
     checkWithOpendap(ZARR_S3_PATH);


### PR DESCRIPTION
Closes https://github.com/Unidata/tds/issues/444. Depends on changes in https://github.com/Unidata/netcdf-java/pull/1285.

Unignore zarr s3 test and add trailing delimiter to path.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Unidata/tds/447)
<!-- Reviewable:end -->
