### PR TITLE
Add extra test for zarr and caching

### DIFF
--- a/tds/src/integrationTests/java/thredds/tds/TestZarr.java
+++ b/tds/src/integrationTests/java/thredds/tds/TestZarr.java
@@ -27,6 +27,13 @@ public class TestZarr {
     checkWithOpendap(ZARR_S3_PATH);
   }
 
+  @Test
+  public void shouldOpenZarrTwice() {
+    // Test it works correctly with the netcdf file cache
+    checkWithOpendap(ZARR_DIR_PATH);
+    checkWithOpendap(ZARR_DIR_PATH);
+  }
+
   private static void checkWithOpendap(String path) {
     final String endpoint = TestOnLocalServer.withHttpPath("dodsC/" + path + ".dds");
     final byte[] content = TestOnLocalServer.getContent(endpoint, HttpServletResponse.SC_OK);


### PR DESCRIPTION
Add test hitting the same zarr file twice to ensure it works correctly with the netcdf file cache. This test depends on fix in https://github.com/Unidata/netcdf-java/pull/1288

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Unidata/tds/450)
<!-- Reviewable:end -->
