### PR TITLE
Add apache dependency

### DIFF
--- a/tds-platform/build.gradle
+++ b/tds-platform/build.gradle
@@ -88,6 +88,7 @@ dependencies {
     api "org.hibernate.validator:hibernate-validator:${depVersion.hibernateValidator}"
     api "org.hibernate.validator:hibernate-validator-annotation-processor:${depVersion.hibernateValidator}"
     api 'jakarta.el:jakarta.el-api'
+    api'org.apache.commons:commons-lang3:3.4'
     runtime 'org.glassfish:javax.el:3.0.0'
     runtime "jaxen:jaxen:${depVersion.jaxen}"
 

--- a/tds-testing-platform/build.gradle
+++ b/tds-testing-platform/build.gradle
@@ -39,7 +39,6 @@ dependencies {
     api 'org.hamcrest:hamcrest-core:2.2'
 
     // only needed for it subproject
-    api 'org.apache.commons:commons-lang3:3.4' // replace?
     api 'org.xmlunit:xmlunit-core:2.7.0'  // For comparing catalog XML.
 
   }

--- a/tds/build.gradle
+++ b/tds/build.gradle
@@ -50,6 +50,7 @@ dependencies {
   compile 'com.google.code.findbugs:jsr305'
   compile 'com.google.guava:guava'
   compile 'joda-time:joda-time'
+  compile 'org.apache.commons:commons-lang3'
 
   // WaterML
   compile 'org.apache.xmlbeans:xmlbeans'

--- a/tds/src/main/java/thredds/server/catalogservice/CatalogViewContextParser.java
+++ b/tds/src/main/java/thredds/server/catalogservice/CatalogViewContextParser.java
@@ -1,6 +1,6 @@
 package thredds.server.catalogservice;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Autowired;


### PR DESCRIPTION
TDS is not compiling due to missing apache commons-lang 2.0 dependency used in `CatalogViewContextParser`. I _think_ what happened is this used to be pulled in by edal-java but they updated to 3.x. So here I update TDS to use `org.apache.commons:commons-lang3` but also to explicitly declare it as a dependency.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Unidata/tds/452)
<!-- Reviewable:end -->
