### PR TITLE
Fix wms epsg database not loading

### DIFF
--- a/tds/src/integrationTests/java/thredds/server/wms/TestWmsServer.java
+++ b/tds/src/integrationTests/java/thredds/server/wms/TestWmsServer.java
@@ -67,6 +67,20 @@ public class TestWmsServer {
         TestOnLocalServer.withHttpPath("/wms/scanCdmUnitTests/conventions/cf/ipcc/tas_A1.nc?service=WMS&version=1.3.0"
             + "&request=GetMap&CRS=CRS:84&WIDTH=512&HEIGHT=512&LAYERS=tas&BBOX=0,-90,360,90&format="
             + ContentType.png.toString() + "&time=1850-01-16T12:00:00Z");
+    testGetPng(endpoint);
+  }
+
+  @Test
+  @Category(NeedsCdmUnitTest.class)
+  public void testGetPngInAnotherProjection() {
+    String endpoint =
+        TestOnLocalServer.withHttpPath("/wms/scanCdmUnitTests/conventions/cf/ipcc/tas_A1.nc?service=WMS&version=1.3.0"
+            + "&request=GetMap&CRS=EPSG:3857&WIDTH=512&HEIGHT=512&LAYERS=tas&BBOX=0,-90,360,90&format="
+            + ContentType.png.toString() + "&time=1850-01-16T12:00:00Z");
+    testGetPng(endpoint);
+  }
+
+  private static void testGetPng(String endpoint) {
     byte[] result = TestOnLocalServer.getContent(endpoint, HttpServletResponse.SC_OK, ContentType.png.toString());
     // make sure we get a png back
     // first byte (unsigned) should equal 137 (decimal)

--- a/tds/src/main/java/thredds/server/config/TdsInit.java
+++ b/tds/src/main/java/thredds/server/config/TdsInit.java
@@ -149,8 +149,8 @@ public class TdsInit implements ApplicationListener<ContextRefreshedEvent>, Disp
           configCatalogInitializer.init(readMode, (PreferencesExt) mainPrefs.node("configCatalog"));
 
           // set epsg database location for edal-java (comes from apache-sis)
-          EpsgDatabasePath.DB_PATH =
-              (new File(tdsContext.getThreddsDirectory(), "/cache/edal-java/epsg/").toURI().toString());
+          EpsgDatabasePath.DB_PATH = (new File(tdsContext.getThreddsDirectory(), "/cache/edal-java/epsg/").getPath());
+          startupLog.info("EPSG database path: " + EpsgDatabasePath.DB_PATH);
           startupLog.info("TdsInit complete");
         }
       }


### PR DESCRIPTION
Fix wms epsg database not loading issue (should fix https://github.com/Unidata/tds/issues/455)
- Add wms get map test that uses EPSG:3857 which requires the epsg database. This did not reproduce the issue for me locally, but I thought it was still useful to have as a test.
- Remove `toURI()` from epsg database path. This is because edal-java now expects a file path, not a URI path.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Unidata/tds/457)
<!-- Reviewable:end -->
