### PR TITLE
Fix WMS netcdf file locking issue

### DIFF
--- a/tds/src/integrationTests/java/thredds/server/wms/TestUpdateWmsServer.java
+++ b/tds/src/integrationTests/java/thredds/server/wms/TestUpdateWmsServer.java
@@ -33,7 +33,6 @@ import thredds.util.ContentType;
 
 import static com.google.common.truth.Truth.assertThat;
 
-@Ignore("TODO: fix locked files issue")
 public class TestUpdateWmsServer {
   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 

--- a/tds/src/integrationTests/java/thredds/server/wms/TestUpdateWmsServer.java
+++ b/tds/src/integrationTests/java/thredds/server/wms/TestUpdateWmsServer.java
@@ -42,7 +42,7 @@ public class TestUpdateWmsServer {
   private static final String DIR = "src/test/content/thredds/public/testdata/";
   private static final Path SRC_FILE_1 = Paths.get(DIR, "testGridAsPoint.nc");
   private static final Path SRC_FILE_2 = Paths.get(DIR, "testData.nc");
-  private static String FILENAME = "testUpdate.nc";
+  private static final String FILENAME = "testUpdate.nc";
 
   @Rule
   public TemporaryFolder temporaryFolder = new TemporaryFolder(new File(DIR));

--- a/tds/src/integrationTests/java/thredds/server/wms/TestUpdateWmsServer.java
+++ b/tds/src/integrationTests/java/thredds/server/wms/TestUpdateWmsServer.java
@@ -5,6 +5,7 @@
 
 package thredds.server.wms;
 
+import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -19,9 +20,9 @@ import org.jdom2.filter.Filters;
 import org.jdom2.input.SAXBuilder;
 import org.jdom2.xpath.XPathExpression;
 import org.jdom2.xpath.XPathFactory;
-import org.junit.After;
-import org.junit.Ignore;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import java.io.IOException;
@@ -39,27 +40,32 @@ public class TestUpdateWmsServer {
   private static final Namespace NS_WMS = Namespace.getNamespace("wms", "http://www.opengis.net/wms");
 
   private static final String DIR = "src/test/content/thredds/public/testdata/";
-  private static final Path TEST_FILE = Paths.get(DIR, "testUpdate.nc");
+  private static final Path SRC_FILE_1 = Paths.get(DIR, "testGridAsPoint.nc");
+  private static final Path SRC_FILE_2 = Paths.get(DIR, "testData.nc");
+  private static String FILENAME = "testUpdate.nc";
 
-  @After
-  public void cleanupTestFile() throws IOException {
-    Files.delete(TEST_FILE);
-  }
+  @Rule
+  public TemporaryFolder temporaryFolder = new TemporaryFolder(new File(DIR));
 
   @Test
   public void testUpdateFile() throws IOException, JDOMException {
-    final String path = "/wms/localContent/testUpdate.nc?service=WMS&version=1.3.0&request=GetCapabilities";
+    final String filePath = temporaryFolder.getRoot().getName() + "/" + FILENAME;
+    final String path = "/wms/localContent/" + filePath + "?service=WMS&version=1.3.0&request=GetCapabilities";
     final String endpoint = TestOnLocalServer.withHttpPath(path);
 
     // Check initial WMS output
-    Files.copy(Paths.get(DIR, "testGridAsPoint.nc"), TEST_FILE);
+    createTestFile(SRC_FILE_1, FILENAME);
     final byte[] result = TestOnLocalServer.getContent(endpoint, HttpServletResponse.SC_OK, ContentType.xmlwms);
     checkLayerNameInXml(result, "withT1Z1");
 
     // Update test file and check that WMS output is updated
-    Files.copy(Paths.get(DIR, "testData.nc"), TEST_FILE, StandardCopyOption.REPLACE_EXISTING);
+    createTestFile(SRC_FILE_2, FILENAME);
     final byte[] updatedResult = TestOnLocalServer.getContent(endpoint, HttpServletResponse.SC_OK, ContentType.xmlwms);
     checkLayerNameInXml(updatedResult, "Z_sfc");
+  }
+
+  private void createTestFile(Path srcFile, String filename) throws IOException {
+    Files.copy(srcFile, Paths.get(temporaryFolder.getRoot().toString(), filename), StandardCopyOption.REPLACE_EXISTING);
   }
 
   private void checkLayerNameInXml(byte[] result, String expectedLayerName) throws IOException, JDOMException {

--- a/tds/src/main/java/thredds/server/admin/DebugCommands.java
+++ b/tds/src/main/java/thredds/server/admin/DebugCommands.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import thredds.featurecollection.cache.GridInventoryCacheChronicle;
 import thredds.server.config.TdsContext;
+import thredds.server.wms.ThreddsWmsServlet;
 import thredds.servlet.ServletUtil;
 import ucar.nc2.dataset.NetcdfDataset;
 import java.io.ByteArrayOutputStream;
@@ -148,6 +149,9 @@ public class DebugCommands {
 
         f.format("%n%n");
         GridInventoryCacheChronicle.showCache(f);
+
+        f.format("%n%n");
+        ThreddsWmsServlet.showCache(f);
 
         e.pw.flush();
       }

--- a/tds/src/main/java/thredds/server/admin/DebugCommands.java
+++ b/tds/src/main/java/thredds/server/admin/DebugCommands.java
@@ -166,6 +166,7 @@ public class DebugCommands {
         FileCacheIF fc = GribCdmIndex.gribCollectionCache;
         if (fc != null)
           fc.clearCache(false);
+        ThreddsWmsServlet.resetCache();
         e.pw.println("  ClearCache ok");
       }
     };
@@ -224,6 +225,13 @@ public class DebugCommands {
     };
     debugHandler.addAction(act);
 
+    act = new Action("forceWMSCache", "Force clear WMS Cache") {
+      public void doAction(Event e) {
+        ThreddsWmsServlet.resetCache();
+        e.pw.println("  WMS force clearCache done");
+      }
+    };
+    debugHandler.addAction(act);
   }
 
   protected void makeDebugActions() {

--- a/tds/src/main/java/thredds/server/wms/TdsWmsDatasetFactory.java
+++ b/tds/src/main/java/thredds/server/wms/TdsWmsDatasetFactory.java
@@ -23,15 +23,6 @@ public class TdsWmsDatasetFactory extends CdmGridDatasetFactory {
   }
 
   /**
-   * Get time of last modification of the underlying netcdfDataset
-   *
-   * @return time of last modification in Unix time (msecs since reference), or 0 if unknown
-   */
-  long getLastModified() {
-    return netcdfDataset.getLastModified();
-  }
-
-  /**
    *
    * None of this matters really. For NcML datasets, we cannot rely on a location, as the
    * ncml is modifying the dataset in memory. So, we are ignoring location and force reset

--- a/tds/src/main/java/thredds/server/wms/ThreddsWmsCatalogue.java
+++ b/tds/src/main/java/thredds/server/wms/ThreddsWmsCatalogue.java
@@ -423,7 +423,7 @@ public class ThreddsWmsCatalogue implements WmsCatalogue {
     return new TdsEnhancedVariableMetadata(this, metadata);
   }
 
-  public void setNetcdfDataset(NetcdfDataset ncd) {
+  void setNetcdfDataset(NetcdfDataset ncd) {
     datasetFactory.setNetcdfDataset(ncd);
   }
 }

--- a/tds/src/main/java/thredds/server/wms/ThreddsWmsCatalogue.java
+++ b/tds/src/main/java/thredds/server/wms/ThreddsWmsCatalogue.java
@@ -147,15 +147,6 @@ public class ThreddsWmsCatalogue implements WmsCatalogue {
     return tdsDatasetPath;
   }
 
-  /**
-   * Get time of last modification of the underlying netcdfDataset
-   *
-   * @return time of last modification in Unix time (msecs since reference), or 0 if unknown
-   */
-  long getLastModified() {
-    return datasetFactory.getLastModified();
-  }
-
   @Override
   public FeaturesAndMemberName getFeaturesForLayer(String layerName, PlottingDomainParams params) throws EdalException {
     /*
@@ -430,5 +421,9 @@ public class ThreddsWmsCatalogue implements WmsCatalogue {
      * variable being plotted.
      */
     return new TdsEnhancedVariableMetadata(this, metadata);
+  }
+
+  public void setNetcdfDataset(NetcdfDataset ncd) {
+    datasetFactory.setNetcdfDataset(ncd);
   }
 }

--- a/tds/src/main/java/thredds/server/wms/ThreddsWmsServlet.java
+++ b/tds/src/main/java/thredds/server/wms/ThreddsWmsServlet.java
@@ -112,15 +112,7 @@ public class ThreddsWmsServlet extends WmsServlet {
     if (useCachedCatalogue(tdsDataset.getPath())) {
       catalogue = catalogueCache.get(tdsDataset.getPath()).wmsCatalogue;
     } else {
-      NetcdfFile ncf = TdsRequestedDataset.getNetcdfFile(httpServletRequest, httpServletResponse, tdsDataset.getPath());
-      NetcdfDataset ncd;
-      if (TdsRequestedDataset.useNetcdfJavaBuilders()) {
-        ncd = NetcdfDatasets.enhance(ncf, NetcdfDataset.getDefaultEnhanceMode(), null);
-      } else {
-        ncd = NetcdfDataset.wrap(ncf, NetcdfDataset.getDefaultEnhanceMode());
-      }
-
-      String netcdfFilePath = ncf.getLocation();
+      NetcdfDataset ncd = acquireNetcdfDataset(httpServletRequest, httpServletResponse, tdsDataset);
 
       /*
        * Generate a new catalogue for the given dataset
@@ -134,7 +126,7 @@ public class ThreddsWmsServlet extends WmsServlet {
        * upon construction (i.e. HERE). That's a TDS implementation detail
        * though, hence not in this example.
        */
-      if (netcdfFilePath == null) {
+      if (ncd.getLocation() == null) {
         throw new EdalLayerNotFoundException("The requested dataset is not available on this server");
       }
       catalogue = new ThreddsWmsCatalogue(ncd, tdsDataset.getPath());
@@ -143,6 +135,16 @@ public class ThreddsWmsServlet extends WmsServlet {
     }
 
     return catalogue;
+  }
+
+  private NetcdfDataset acquireNetcdfDataset(HttpServletRequest httpServletRequest,
+      HttpServletResponse httpServletResponse, TdsRequestedDataset tdsDataset) throws IOException {
+    NetcdfFile ncf = TdsRequestedDataset.getNetcdfFile(httpServletRequest, httpServletResponse, tdsDataset.getPath());
+    if (TdsRequestedDataset.useNetcdfJavaBuilders()) {
+      return NetcdfDatasets.enhance(ncf, NetcdfDataset.getDefaultEnhanceMode(), null);
+    } else {
+      return NetcdfDataset.wrap(ncf, NetcdfDataset.getDefaultEnhanceMode());
+    }
   }
 
   // package private for testing

--- a/tds/src/main/java/thredds/server/wms/ThreddsWmsServlet.java
+++ b/tds/src/main/java/thredds/server/wms/ThreddsWmsServlet.java
@@ -150,12 +150,12 @@ public class ThreddsWmsServlet extends WmsServlet {
     }
   }
 
-  // package private for testing
-  static void resetCache() {
+  public static void resetCache() {
     catalogueCache.invalidateAll();
     cacheLoads = 0;
   }
 
+  // package private for testing
   static boolean containsCachedCatalogue(String tdsDatasetPath) {
     return catalogueCache.asMap().containsKey(tdsDatasetPath);
   }

--- a/tds/src/test/java/thredds/server/wms/TestWmsCache.java
+++ b/tds/src/test/java/thredds/server/wms/TestWmsCache.java
@@ -13,6 +13,7 @@ import java.util.List;
 import javax.servlet.ServletException;
 
 import org.junit.*;
+import org.junit.experimental.categories.Category;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.slf4j.Logger;
@@ -25,6 +26,7 @@ import org.springframework.test.context.web.WebAppConfiguration;
 import java.lang.invoke.MethodHandles;
 import ucar.nc2.dataset.NetcdfDatasets;
 import ucar.nc2.util.cache.FileCacheIF;
+import ucar.unidata.util.test.category.NeedsCdmUnitTest;
 
 @RunWith(SpringJUnit4ClassRunner.class)
 @WebAppConfiguration
@@ -116,6 +118,7 @@ public class TestWmsCache {
   }
 
   @Test
+  @Category(NeedsCdmUnitTest.class)
   public void shouldNotLockAggregationInCache() throws IOException, ServletException {
     final String testPath = "ExampleNcML/Agg.nc";
     getCapabilities(testPath);


### PR DESCRIPTION
Currently, when a dataset is opened through WMS, it stays locked in the netcdf file cache. This means the file will never be cleaned up in the cache, since the soft limit does not apply to locked files and the hard limit is set to -1 (no limit) by default.

This PR:
- Use try with resources in wms to ensure netcdf file gets closed and does not stay locked.
- Use guava cache instead of map for WMS cache
- Update tests and add tests ro check if file is locked in the netcdf file cache after a wms request

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Unidata/tds/461)
<!-- Reviewable:end -->
