### PR TITLE
Wms cache last modified comparison

### DIFF
--- a/tds/src/main/java/thredds/server/wms/ThreddsWmsServlet.java
+++ b/tds/src/main/java/thredds/server/wms/ThreddsWmsServlet.java
@@ -115,7 +115,7 @@ public class ThreddsWmsServlet extends WmsServlet {
     final CachedWmsCatalogue cachedWmsCatalogue = catalogueCache.getIfPresent(tdsDatasetPath);
     final long lastModified = ncd.getLastModified();
 
-    if (cachedWmsCatalogue != null && cachedWmsCatalogue.lastModified >= lastModified) {
+    if (cachedWmsCatalogue != null && cachedWmsCatalogue.lastModified == lastModified) {
       // Must update NetcdfDataset to ensure file resources are reacquired, as this has been closed.
       // But we don't need to recreate the ThreddsWmsCatalogue as it is up-to-date according to the last modified
       cachedWmsCatalogue.wmsCatalogue.setNetcdfDataset(ncd);

--- a/tds/src/test/java/thredds/server/wms/TestWmsCache.java
+++ b/tds/src/test/java/thredds/server/wms/TestWmsCache.java
@@ -82,6 +82,18 @@ public class TestWmsCache {
   }
 
   @Test
+  public void shouldNotUseCacheFileWithNewerModified() throws IOException, ServletException {
+    final File testFile = new File(TEMP_FILE.toUri());
+    final long lastModified = testFile.lastModified();
+    assertAddedToCache(TEST_PATH);
+
+    // Change test file to have older last modified date
+    assertThat(testFile.setLastModified(lastModified - 1)).isTrue();
+
+    assertAddedToCache(TEST_PATH);
+  }
+
+  @Test
   public void shouldUseUnchangedAggregation() throws IOException, ServletException {
     assertAddedToCache(AGGREGATION_RECHECK_MINUTE_PATH);
     assertUsedCache(AGGREGATION_RECHECK_MINUTE_PATH);


### PR DESCRIPTION
Only use cached file if last modified is an exact match. This fixes the case that a file is updated but with an older last modified date than before, and so the cached file continued to be used. This fix also makes the behavior the same for the WMS cache and the NetcdfFile cache, so all the services should behave the same when it comes to checking the last modified.