### PR TITLE
Add test for grib NaN issue

### DIFF
--- a/tds/src/test/content/thredds/catalogGrib.xml
+++ b/tds/src/test/content/thredds/catalogGrib.xml
@@ -91,4 +91,19 @@
     <collection name="gfsConus80_file" spec="${cdmUnitTest}/gribCollections/gfs_conus80/**/.*grib1$" timePartition="file"/>
   </featureCollection>
 
+  <!-- test large grib collection where precipitation variable is missing in one partition -->
+  <featureCollection name="Real Time Mesoscale Analysis 2.5 km" featureType="GRIB2" harvest="true"
+    path="grib/NCEP/RTMA/CONUS_2p5km">
+    <collection name="RTMA-CONUS_2p5km"
+      spec="${cdmUnitTest}/gribCollections/rtma/.*grib2$"
+      dateFormatMark="#RTMA_CONUS_2p5km_#yyyyMMdd_HHmm"
+      timePartition="file"
+      olderThan="5 min"/>
+    <update startup="test" trigger="allow"/>
+    <gribConfig>
+      <pdsHash>
+        <useGenType>true</useGenType>
+      </pdsHash>
+    </gribConfig>
+  </featureCollection>
 </catalog>


### PR DESCRIPTION
Add test for bug that missing variable in one grib partition caused NaNs for all times after. Added one day's worth of RTMA data to thredds-test-data. Test originally failed (on Jenkins, won't run on GitHub), now passes with fix from: https://github.com/Unidata/netcdf-java/pull/1313