### PR TITLE
Fix WMS exception messages

### DIFF
--- a/tds/src/main/java/thredds/server/wms/ThreddsWmsServlet.java
+++ b/tds/src/main/java/thredds/server/wms/ThreddsWmsServlet.java
@@ -146,7 +146,7 @@ public class ThreddsWmsServlet extends WmsServlet {
       throw new IOException(e);
     } catch (UncheckedExecutionException e) {
       if (e.getCause() instanceof EdalException) {
-        throw new EdalException("", e.getCause());
+        throw (EdalException) e.getCause();
       } else {
         throw e;
       }


### PR DESCRIPTION
Exceptions are getting wrapped by WMS cache loader as `UncheckedExecutionException`s. For edal-java not to return a 500 error, we want these to be unwrapped back into `EdalException`s. Previously I accidentally was nested these inside a new `EdalException` leading to less helpful error messages. This PR returns original exception instead of wrapping them.