### PR TITLE
Improve tests

### DIFF
--- a/tds/src/integrationTests/java/ucar/nc2/dt/grid/TestGridSubsetThredds.java
+++ b/tds/src/integrationTests/java/ucar/nc2/dt/grid/TestGridSubsetThredds.java
@@ -210,6 +210,7 @@ public class TestGridSubsetThredds {
     }
   }
 
+  @Ignore("http://esrl.noaa.gov/psd/thredds not available")
   @Test
   @Category(NeedsExternalResource.class)
   public void testScaleOffset() throws Exception {

--- a/tds/src/test/java/thredds/server/wms/TestWmsCache.java
+++ b/tds/src/test/java/thredds/server/wms/TestWmsCache.java
@@ -76,6 +76,13 @@ public class TestWmsCache {
     Files.copy(TEST_FILE, TEMP_FILE, StandardCopyOption.REPLACE_EXISTING);
   }
 
+  @Before
+  public void clearNetcdfFileCache() {
+    final FileCacheIF cache = NetcdfDatasets.getNetcdfFileCache();
+    cache.clearCache(true);
+    assertNoneLockedInNetcdfFileCache();
+  }
+
   @After
   public void clearCache() {
     ThreddsWmsServlet.resetCache();
@@ -174,7 +181,10 @@ public class TestWmsCache {
   }
 
   private void assertNoneLockedInNetcdfFileCache() {
-    assertNotLockedInNetcdfFileCache("");
+    final FileCacheIF cache = NetcdfDatasets.getNetcdfFileCache();
+    final List<String> entries = cache.showCache();
+    final boolean isLocked = entries.stream().anyMatch(e -> e.startsWith("true"));
+    assertWithMessage(cache.showCache().toString()).that(isLocked).isFalse();
   }
 
   private void assertNotLockedInNetcdfFileCache(String path) {


### PR DESCRIPTION
- Ignore test that requires external server that is unavailable
- Improve before/after steps of test that checks NetcdfFile cache. Currently this can fail if run after certain tests that leave files locked in the NetcdfFile cache.