### PR TITLE
Fix standard services for nested datasets

### DIFF
--- a/tds/src/integrationTests/java/thredds/server/catalog/TestServiceDefaults.java
+++ b/tds/src/integrationTests/java/thredds/server/catalog/TestServiceDefaults.java
@@ -5,6 +5,8 @@
 
 package thredds.server.catalog;
 
+import static com.google.common.truth.Truth.assertThat;
+
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -40,6 +42,18 @@ public class TestServiceDefaults {
     Assert.assertNotNull(s);
     Assert.assertTrue(s.getType() == ServiceType.Compound);
     Assert.assertEquals(7, s.getNestedServices().size());
+  }
+
+  @Test
+  public void testStandardServicesForNestedDataset() {
+    String catalog = "/catalog/catalogs5/testServices.xml";
+    Catalog cat = TdsLocalCatalog.open(catalog);
+    Dataset ds = cat.findDatasetByID("testInnerGridDataset");
+    assertThat(ds.getFeatureType()).isEqualTo(FeatureType.GRID);
+
+    Service service = ds.getServiceDefault();
+    assertThat(service.getType()).isEqualTo(ServiceType.Compound);
+    assertThat(service.getNestedServices().size()).isEqualTo(7);
   }
 
   // Relies on:
@@ -80,6 +94,9 @@ public class TestServiceDefaults {
     Assert.assertEquals(ServiceType.OPENDAP, localServices.getType());
 
     for (Dataset ds : cat.getDatasetsLocal()) {
+      if (ds.getId() != null && ds.getId().equals("testNestedGridDataset")) {
+        continue;
+      }
       if (!(ds instanceof CatalogRef)) {
         Assert.assertTrue(ds.hasAccess());
 

--- a/tds/src/main/java/thredds/core/CatalogManager.java
+++ b/tds/src/main/java/thredds/core/CatalogManager.java
@@ -179,16 +179,23 @@ public class CatalogManager {
 
     // look for datasets that want to use standard services
     for (DatasetBuilder node : cat.getDatasets()) {
-      String sname = (String) node.getFldOrInherited(Dataset.ServiceName);
-      String urlPath = (String) node.get(Dataset.UrlPath);
-      String ftypeS = (String) node.getFldOrInherited(Dataset.FeatureType);
-      if (sname == null && urlPath != null && ftypeS != null) {
-        Service s = globalServices.getStandardServices(ftypeS);
-        if (s != null) {
-          node.put(Dataset.ServiceName, s.getName());
-          cat.addService(s);
-        }
+      addStandardServices(cat, node);
+    }
+  }
+
+  private void addStandardServices(CatalogBuilder cat, DatasetBuilder node) {
+    String sname = (String) node.getFldOrInherited(Dataset.ServiceName);
+    String urlPath = (String) node.get(Dataset.UrlPath);
+    String ftypeS = (String) node.getFldOrInherited(Dataset.FeatureType);
+    if (sname == null && urlPath != null && ftypeS != null) {
+      Service s = globalServices.getStandardServices(ftypeS);
+      if (s != null) {
+        node.put(Dataset.ServiceName, s.getName());
+        cat.addService(s);
       }
+    }
+    for (DatasetBuilder child : node.getDatasets()) {
+      addStandardServices(cat, child);
     }
   }
 

--- a/tds/src/test/content/thredds/catalogs5/testServices.xml
+++ b/tds/src/test/content/thredds/catalogs5/testServices.xml
@@ -7,6 +7,13 @@
   <!--- test using default -->
   <dataset name="Test Single Grid Dataset" ID="testSingleGridDataset" urlPath="cdmUnitTest/ncss/CONUS_80km_nc/GFS_CONUS_80km_20120419_0000.nc" dataType="Grid"/>
 
+  <dataset name="Test Nested Grid Dataset" ID="testNestedGridDataset">
+    <metadata inherited="true">
+      <dataType>Grid</dataType>
+    </metadata>
+    <dataset name="Test Inner Grid Dataset" ID="testInnerGridDataset" urlPath="localContent/testData.nc"/>
+  </dataset>
+
   <!--- test using global -->
   <dataset name="Test sst" ID="TESTsst" serviceName="all" urlPath="cdmUnitTest/conventions/coards/sst.mnmean.nc" dataType="Grid"/>
 


### PR DESCRIPTION
Resolves https://github.com/Unidata/tds/issues/352.

When a dataset catalog entry has a `dataType` set, standard services should get assigned.  Previously only top level datasets would get standard services. This PR also handles child dataset nodes recursively when assigning standard services.