### PR TITLE
Upgrade chronicle

### DIFF
--- a/tds-platform/build.gradle
+++ b/tds-platform/build.gradle
@@ -16,7 +16,7 @@ dependencies {
   api enforcedPlatform("edu.ucar:netcdf-java-bom:${depVersion.netcdfJava}")
   api enforcedPlatform('org.springframework:spring-framework-bom:5.3.34')
   api enforcedPlatform('org.springframework.security:spring-security-bom:5.7.12')
-  api platform('net.openhft:chronicle-bom:2.23.136')
+  api platform('net.openhft:chronicle-bom:2.25ea62')
   api enforcedPlatform("org.apache.logging.log4j:log4j-bom:2.17.1")
   api enforcedPlatform("jakarta.platform:jakarta.jakartaee-bom:8.0.0")
 


### PR DESCRIPTION
Upgrade to chronicle-bom 2.25ea62 (release versions no longer published on maven). This contains chronicle-map version 3.25ea6, which has fix needed in https://github.com/Unidata/tds/issues/484. Passes tests on Jenkins: https://jenkins-aws.unidata.ucar.edu/view/Users/job/tara-tds/37/