### PR TITLE
Palette support

### DIFF
--- a/tds/src/main/java/thredds/server/wcs/Request.java
+++ b/tds/src/main/java/thredds/server/wcs/Request.java
@@ -22,7 +22,11 @@ public interface Request {
   }
 
   enum Format {
-    NONE(""), GeoTIFF("image/tiff"), GeoTIFF_Float("image/tiff"), NetCDF3("application/x-netcdf"), GeoTIFF_Palette("image/tiff");
+    NONE(""),
+    GeoTIFF("image/tiff"),
+    GeoTIFF_Float("image/tiff"),
+    NetCDF3("application/x-netcdf"),
+    GeoTIFF_Palette("image/tiff");
 
     private String mimeType;
 

--- a/tds/src/main/java/thredds/server/wcs/Request.java
+++ b/tds/src/main/java/thredds/server/wcs/Request.java
@@ -22,7 +22,7 @@ public interface Request {
   }
 
   enum Format {
-    NONE(""), GeoTIFF("image/tiff"), GeoTIFF_Float("image/tiff"), NetCDF3("application/x-netcdf");
+    NONE(""), GeoTIFF("image/tiff"), GeoTIFF_Float("image/tiff"), NetCDF3("application/x-netcdf"), GeoTIFF_Palette("image/tiff");
 
     private String mimeType;
 

--- a/tds/src/main/java/thredds/server/wcs/v1_0_0_1/WcsCoverage.java
+++ b/tds/src/main/java/thredds/server/wcs/v1_0_0_1/WcsCoverage.java
@@ -20,6 +20,7 @@ import ucar.unidata.geoloc.LatLonRect;
 import ucar.unidata.geoloc.Projection;
 import ucar.unidata.geoloc.ogc.EPSG_OGC_CF_Helper;
 import javax.annotation.Nonnull;
+import java.awt.Color;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -176,7 +177,7 @@ public class WcsCoverage {
             }
             String[] flag_colors = flag_colors_attr.getStringValue().split("\\s+");
             log.info("flag_values count:" + flag_values.length + " flag_colors count:" + flag_colors.length);
-            writer.setColorTable(GeotiffWriter.createColorMap(flag_values, flag_colors));
+            writer.setColorTable(GeotiffWriter.createColorMap(flag_values, flag_colors), Color.white);
           }
           writer.writeGrid(array, format == Request.Format.GeoTIFF,
                            format == Request.Format.GeoTIFF_Palette ? DataType.UBYTE : null);

--- a/tds/src/main/java/thredds/server/wcs/v1_0_0_1/WcsCoverage.java
+++ b/tds/src/main/java/thredds/server/wcs/v1_0_0_1/WcsCoverage.java
@@ -143,7 +143,8 @@ public class WcsCoverage {
 
     /////////
     try {
-      if (format == Request.Format.GeoTIFF || format == Request.Format.GeoTIFF_Float || format == Request.Format.GeoTIFF_Palette) {
+      if (format == Request.Format.GeoTIFF || format == Request.Format.GeoTIFF_Float
+          || format == Request.Format.GeoTIFF_Palette) {
         File dir = new File(getDiskCache().getRootDirectory());
         File tifFile = File.createTempFile("WCS", ".tif", dir);
         if (log.isDebugEnabled())
@@ -166,8 +167,8 @@ public class WcsCoverage {
             }
             if (!flag_colors_attr.isString()) {
               log.error("Invalid flag_colors attribute");
-              throw new WcsException(WcsException.Code.UNKNOWN, "",
-                  "Invalid flag_colors attribute for coverage [" + this.coverage.getName() + "] for format GeoTIFF_Palette.");
+              throw new WcsException(WcsException.Code.UNKNOWN, "", "Invalid flag_colors attribute for coverage ["
+                  + this.coverage.getName() + "] for format GeoTIFF_Palette.");
             }
 
             int[] flag_values = new int[flag_values_attr.getLength()];
@@ -180,7 +181,7 @@ public class WcsCoverage {
             writer.setColorTable(GeotiffWriter.createColorMap(flag_values, flag_colors), Color.white);
           }
           writer.writeGrid(array, format == Request.Format.GeoTIFF,
-                           format == Request.Format.GeoTIFF_Palette ? DataType.UBYTE : null);
+              format == Request.Format.GeoTIFF_Palette ? DataType.UBYTE : null);
 
         } catch (Throwable e) {
           log.error("writeCoverageDataToFile(): Failed to write file for requested coverage <" + this.coverage.getName()


### PR DESCRIPTION
Make it possible to request a geotiff from WCS with a color palette, using the dataset's attributes for flag colors and values, much like it does for the WMS service.

Depends on the recently merged https://github.com/Unidata/netcdf-java/pull/1066