### PR TITLE
Fix compiler warnings

### DIFF
--- a/dap4/d4servlet/src/main/java/dap4/servlet/CDMWrap.java
+++ b/dap4/d4servlet/src/main/java/dap4/servlet/CDMWrap.java
@@ -394,8 +394,8 @@ public class CDMWrap {
     for (Map.Entry<Integer, String> entry : ecvalues.entrySet()) {
       String name = entry.getValue();
       assert (name != null);
-      int value = (int) entry.getKey();
-      dapenum.addEnumConst(dmrfactory.newEnumConst(name, new Long(value)));
+      long value = entry.getKey();
+      dapenum.addEnumConst(dmrfactory.newEnumConst(name, value));
     }
     return dapenum;
   }

--- a/opendap/dtswar/src/main/java/opendap/dts/Getopts.java
+++ b/opendap/dtswar/src/main/java/opendap/dts/Getopts.java
@@ -119,7 +119,7 @@ public class Getopts {
    * @param sw int value switch whose option is requested
    */
   public String getOption(int sw) {
-    Character opt = new Character((char) sw);
+    Character opt = (char) sw;
     return getOption(opt);
   }
 
@@ -192,7 +192,7 @@ public class Getopts {
     for (int i = 0; i < flags.length(); i++) {
       boolean found;
       int cc = flags.charAt(i);
-      Character c = new Character((char) cc);
+      Character c = (char) cc;
       char alpha[] = {'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's',
           't', 'u', 'v', 'w', 'x', 'y', 'z'};
 
@@ -205,7 +205,7 @@ public class Getopts {
 
       found = false;
       for (int j = 0; j < alpha.length; j++) {
-        Character ch = new Character(alpha[j]);
+        Character ch = alpha[j];
         char uc = Character.toUpperCase(ch.charValue());
         if (alpha[j] == cc || uc == cc) {
           found = true;
@@ -228,7 +228,7 @@ public class Getopts {
           if (prv == ':') {
             throw new InvalidSwitch(throwstring + "Can't have consecutive ':'\n" + usage + "\n");
           } else {
-            Character cp = new Character((char) prv);
+            Character cp = (char) prv;
             OptSwitch sw = (OptSwitch) switchtab.get(cp);
             sw.SetHasValue(OptSwitch.VAL);
           }
@@ -259,7 +259,7 @@ public class Getopts {
       // more options, iterate them
       for (int j = 1; j < args[i].length(); j++) {
         cc = args[i].charAt(j);
-        Character fc = new Character(cc);
+        Character fc = cc;
         OptSwitch cs = (OptSwitch) switchtab.get(fc);
         if (cs == null) {
           // The supplied switch wasn't recognised.

--- a/opendap/dtswar/src/main/java/opendap/dts/SDTest.java
+++ b/opendap/dtswar/src/main/java/opendap/dts/SDTest.java
@@ -162,13 +162,13 @@ public class SDTest {
     String arg = null;
     try {
       opts = new Getopts("f:c:", args);
-      if (opts.getSwitch(new Character('f')).set) {
-        arg = opts.getSwitch(new Character('f')).val;
+      if (opts.getSwitch('f').set) {
+        arg = opts.getSwitch('f').val;
         if (Debug)
           // System.out.print("DDS File: " + ((arg != null) ? arg : "null") + "\n");
           DDSFile = arg;
       }
-      if (opts.getSwitch(new Character('c')).set) {
+      if (opts.getSwitch('c').set) {
         arg = g.getOptarg();
         if (Debug)
           // System.out.print("Constraint Expression: \"" + ((arg != null) ? arg : "null") + "\"\n");

--- a/opendap/server/src/main/java/opendap/servlet/AsciiWriter.java
+++ b/opendap/server/src/main/java/opendap/servlet/AsciiWriter.java
@@ -105,19 +105,19 @@ public class AsciiWriter {
     if (data instanceof DString) // covers DURL case
       showString(pw, ((DString) data).getValue());
     else if (data instanceof DFloat32)
-      pw.print((new Float(((DFloat32) data).getValue())).toString());
+      pw.print((Float.valueOf(((DFloat32) data).getValue())).toString());
     else if (data instanceof DFloat64)
-      pw.print((new Double(((DFloat64) data).getValue())).toString());
+      pw.print((Double.valueOf(((DFloat64) data).getValue())).toString());
     else if (data instanceof DUInt32)
-      pw.print((new Long(((DUInt32) data).getValue() & ((long) 0xFFFFFFFF))).toString());
+      pw.print((Long.valueOf(((DUInt32) data).getValue() & ((long) 0xFFFFFFFF))).toString());
     else if (data instanceof DUInt16)
-      pw.print((new Integer(((DUInt16) data).getValue() & 0xFFFF)).toString());
+      pw.print((Integer.valueOf(((DUInt16) data).getValue() & 0xFFFF)).toString());
     else if (data instanceof DInt32)
-      pw.print((new Integer(((DInt32) data).getValue())).toString());
+      pw.print((Integer.valueOf(((DInt32) data).getValue())).toString());
     else if (data instanceof DInt16)
-      pw.print((new Short(((DInt16) data).getValue())).toString());
+      pw.print((Short.valueOf(((DInt16) data).getValue())).toString());
     else if (data instanceof DByte)
-      pw.print((new Integer(((DByte) data).getValue() & 0xFF)).toString());
+      pw.print((Integer.valueOf(((DByte) data).getValue() & 0xFF)).toString());
     else
       pw.print("Not implemented type = " + data.getTypeName() + " " + data.getEncodedName() + "\n");
 

--- a/opendap/server/src/main/java/opendap/servlet/ascii/asciiByte.java
+++ b/opendap/server/src/main/java/opendap/servlet/ascii/asciiByte.java
@@ -84,7 +84,7 @@ public class asciiByte extends DByte implements toASCII {
     if (addName)
       pw.print(", ");
 
-    pw.print((new Byte(getValue())).toString());
+    pw.print((Byte.valueOf(getValue())).toString());
 
     if (newLine)
       pw.print("\n");

--- a/opendap/server/src/main/java/opendap/servlet/ascii/asciiF32.java
+++ b/opendap/server/src/main/java/opendap/servlet/ascii/asciiF32.java
@@ -83,7 +83,7 @@ public class asciiF32 extends DFloat32 implements toASCII {
       pw.print(", ");
 
 
-    pw.print((new Float(getValue())).toString());
+    pw.print((Float.valueOf(getValue())).toString());
 
     if (newLine)
       pw.print("\n");

--- a/opendap/server/src/main/java/opendap/servlet/ascii/asciiF64.java
+++ b/opendap/server/src/main/java/opendap/servlet/ascii/asciiF64.java
@@ -83,7 +83,7 @@ public class asciiF64 extends DFloat64 implements toASCII {
     if (addName)
       pw.print(", ");
 
-    pw.print((new Double(getValue())).toString());
+    pw.print((Double.valueOf(getValue())).toString());
 
     if (newLine)
       pw.print("\n");

--- a/opendap/server/src/main/java/opendap/servlet/ascii/asciiI16.java
+++ b/opendap/server/src/main/java/opendap/servlet/ascii/asciiI16.java
@@ -83,7 +83,7 @@ public class asciiI16 extends DInt16 implements toASCII {
     if (addName)
       pw.print(", ");
 
-    pw.print((new Short(getValue())).toString());
+    pw.print((Short.valueOf(getValue())).toString());
 
     if (newLine)
       pw.print("\n");

--- a/opendap/server/src/main/java/opendap/servlet/ascii/asciiI32.java
+++ b/opendap/server/src/main/java/opendap/servlet/ascii/asciiI32.java
@@ -84,7 +84,7 @@ public class asciiI32 extends DInt32 implements toASCII {
     if (addName)
       pw.print(", ");
 
-    pw.print((new Long(getValue())).toString());
+    pw.print((Long.valueOf(getValue())).toString());
 
     if (newLine)
       pw.print("\n");

--- a/opendap/server/src/main/java/opendap/servlet/ascii/asciiUI16.java
+++ b/opendap/server/src/main/java/opendap/servlet/ascii/asciiUI16.java
@@ -83,7 +83,7 @@ public class asciiUI16 extends DUInt16 implements toASCII {
     if (addName)
       pw.print(", ");
 
-    pw.print((new Integer(getValue() & 0xFFFF)).toString());
+    pw.print((Integer.valueOf(getValue() & 0xFFFF)).toString());
 
     if (newLine)
       pw.print("\n");

--- a/opendap/server/src/main/java/opendap/servlet/ascii/asciiUI32.java
+++ b/opendap/server/src/main/java/opendap/servlet/ascii/asciiUI32.java
@@ -83,7 +83,7 @@ public class asciiUI32 extends DUInt32 implements toASCII {
     if (addName)
       pw.print(", ");
 
-    pw.print((new Long(getValue() & ((long) 0xFFFFFFFF))).toString());
+    pw.print((Long.valueOf(getValue() & ((long) 0xFFFFFFFF))).toString());
 
     if (newLine)
       pw.print("\n");


### PR DESCRIPTION
Fix compiler warnings about using deprecated boxing constructors. Instead use the static `valueOf` or let the primitives be auto boxed.