### PR TITLE
Remove JDK 14 from github workflows

### DIFF
--- a/.github/workflows/tds.yml
+++ b/.github/workflows/tds.yml
@@ -6,18 +6,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        # test against latest 11, 14 of zulu and 11 of temurin java
         java-version: [ 11 ]
         java-vendor: [ 'zulu', 'temurin' ]
         # test against tomcat 8.5.x and tomcat 9.x
         servletcontainer: [ 'tomcat85', 'tomcat9' ]
-        include:
-          - java-version: 14
-            java-vendor: 'zulu'
-            servletcontainer: 'tomcat85'
-          - java-version: 14
-            java-vendor: 'zulu'
-            servletcontainer: 'tomcat9'
     steps:
       - uses: actions/checkout@v4
       - name: Build and test with Gradle (${{ matrix.java-vendor }} ${{ matrix.java-version }})


### PR DESCRIPTION
Remove JDK 14 from GitHub workflows as this was removed from thredds-test-actions in anticipation of the upcoming JDK 17 update.