### PR TITLE
Update to JDK 17

### DIFF
--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -6,10 +6,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v2
         with:
           distribution: 'adopt'
-          java-version: '11'
+          java-version: '17'
       - name: Build with Gradle (refresh dependencies)
         run: ./gradlew clean classes testClasses assemble --refresh-dependencies

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,11 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Setup Java 11
+      - name: Setup Java 17
         uses: actions/setup-java@v2
         with:
           distribution: 'zulu'
-          java-version: '11'
+          java-version: '17'
       - name: Cache Gradle packages
         uses: actions/cache@v1
         with:

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -6,11 +6,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v2
         with:
           distribution: 'adopt'
-          java-version: '11'
+          java-version: '17'
       - name: Cache Gradle packages
         uses: actions/cache@v1
         with:

--- a/.github/workflows/tds.yml
+++ b/.github/workflows/tds.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java-version: [ 11 ]
+        java-version: [ 17 ]
         java-vendor: [ 'zulu', 'temurin' ]
         # test against tomcat 8.5.x and tomcat 9.x
         servletcontainer: [ 'tomcat85', 'tomcat9' ]

--- a/.github/workflows/tds.yml
+++ b/.github/workflows/tds.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         java-version: [ 17 ]
-        java-vendor: [ 'zulu', 'temurin' ]
+        java-vendor: [ 'temurin' ]
         # test against tomcat 8.5.x and tomcat 9.x
         servletcontainer: [ 'tomcat85', 'tomcat9' ]
     steps:

--- a/docs/userguide/src/site/pages/tds_tutorial/faq/faq.md
+++ b/docs/userguide/src/site/pages/tds_tutorial/faq/faq.md
@@ -301,6 +301,17 @@ com.google.common.util.concurrent.UncheckedExecutionException: java.lang.Illegal
 
 then you may need to adjust your [FMRC cache settings](https://docs.unidata.ucar.edu/tds/current/userguide/tds_config_ref.html#featurecollection-cache).
 
+### Failed to start up with JDK 17
+
+If you are upgrading to JDK 17 and your serverStartup.log contains an error like
+~~~
+ERROR org.springframework.web.context.ContextLoader: Context initialization failed
+java.lang.ExceptionInInitializerError: null
+    at net.openhft.chronicle.core.internal.ClassUtil.getSetAccessible0Method(ClassUtil.java:32) ~[chronicle-core-2.25ea15.jar:?]
+    ...
+~~~
+You may be missing the JVM arguments need by the chronicle library. Please see `$CHRONICLE_CACHE` in [`${tomcat_home}/bin/setenv.sh`](running_tomcat.html#setting-java_home-java_opts-catalina_home-catalina_base-and-content_root)
+
 ## Caching
 
 ### We use compressed netCDF files, and the very first access to them are quite slow, although subsequent accesses are much faster, then become slow again after a while. 

--- a/docs/userguide/src/site/pages/tds_tutorial/getting_started/InstallJavaTomcat.md
+++ b/docs/userguide/src/site/pages/tds_tutorial/getting_started/InstallJavaTomcat.md
@@ -29,7 +29,7 @@ The installation is being performed as the `root` user.
 For installation of the JDK on Windows or Mac OS, see the [JDK Installation Guide](https://adoptium.net/installation.html){:target='_blank'}.
 " %}
 
-1.  [Download](https://adoptium.net/){:target="_blank"} current OpenJDK 11 (LTS) JDK version from the AdoptOpenJDK site. 
+1.  [Download](https://adoptium.net/){:target="_blank"} the required OpenJDK version from the AdoptOpenJDK site. 
 
 2.  Install the JDK.
 
@@ -39,17 +39,17 @@ For installation of the JDK on Windows or Mac OS, see the [JDK Installation Guid
     # pwd
     /usr/local
     
-    # cp /tmp/jdk-8u192-linux-x64.tar.gz .
+    # cp /tmp/jdk-xx.tar.gz .
 
     # ls -l
     total 187268
-    -rw-r--r-- 1 root root 191757099 Oct 24 13:19 jdk-11.0.11.tar.gz
+    -rw-r--r-- 1 root root 191757099 Oct 24 13:19 jdk-xx.tar.gz
     ~~~
 
     Unpack the archive file:
 
     ~~~bash
-    # tar xvfz jdk-11.0.11.tar.gz 
+    # tar xvfz jdk-xx.tar.gz 
     ~~~
 
     This will extract the JDK in the installation directory:
@@ -57,17 +57,17 @@ For installation of the JDK on Windows or Mac OS, see the [JDK Installation Guid
     ~~~bash
     # ls -l
     total 187272
-    drwxr-xr-x 7 root root      4096 Oct  6 07:58 jdk-11.0.11
-    -rw-r--r-- 1 root root 191757099 Oct 24 13:19 jdk-11.0.11.tar.gz
+    drwxr-xr-x 7 root root      4096 Oct  6 07:58 jdk-xx
+    -rw-r--r-- 1 root root 191757099 Oct 24 13:19 jdk-xx.tar.gz
     ~~~
 
     Remove the remaining binary `tar.gz` file when the installation is complete.
    
     ~~~bash
-    # rm jdk-11.0.11.tar.gz
+    # rm jdk-xx.tar.gz
     # ls -l
     total 187279
-    drwxr-xr-x 7 root root      4096 Oct  6 07:58 jdk-11.0.11
+    drwxr-xr-x 7 root root      4096 Oct  6 07:58 jdk-xx
     ~~~
 
     {% include important.html content="
@@ -101,7 +101,7 @@ For installation of Tomcat on Windows, see the [Tomcat Setup Guide](http://tomca
     # ls -l
     total 196676
     -rw-r--r-- 1 root root   9625824 Oct 24 13:27 apache-tomcat-8.5.34.tar.gz
-    drwxr-xr-x 7 root root      4096 Oct  6 07:58 jdk-11.0.11
+    drwxr-xr-x 7 root root      4096 Oct  6 07:58 jdk-xx
     ~~~
 
     Unpack the archive file:
@@ -117,7 +117,7 @@ For installation of Tomcat on Windows, see the [Tomcat Setup Guide](http://tomca
     total 196680
     drwxr-xr-x 9 root root      4096 Oct 24 13:29 apache-tomcat-8.5.34
     -rw-r--r-- 1 root root   9625824 Oct 24 13:27 apache-tomcat-8.5.34.tar.gz
-    drwxr-xr-x 7 root root      4096 Oct  6 07:58 jdk-11.0.11
+    drwxr-xr-x 7 root root      4096 Oct  6 07:58 jdk-xx
     ~~~
 
     Remove the remaining binary `tar.gz` file when the installation is complete.
@@ -127,7 +127,7 @@ For installation of Tomcat on Windows, see the [Tomcat Setup Guide](http://tomca
     # ls -l
     total 187282
     drwxr-xr-x 9 root root      4096 Oct 24 13:29 apache-tomcat-8.5.34
-    drwxr-xr-x 7 root root      4096 Oct  6 07:58 jdk-11.0.11
+    drwxr-xr-x 7 root root      4096 Oct  6 07:58 jdk-xx
     ~~~
 
 ## Create Symbolic Links
@@ -149,13 +149,13 @@ Windows users can consult the [Microsoft Documentation](https://docs.microsoft.c
     /usr/local
     
     # ln -s apache-tomcat-8.5.34 tomcat 
-    # ln -s jdk-11.0.11 jdk
+    # ln -s jdk-xx jdk
     # ls -l 
     total 196684
     drwxr-xr-x 9 root root      4096 Oct 24 13:29 tomcat -> apache-tomcat-8.5.34
     drwxr-xr-x 9 root root      4096 Oct 24 13:29 apache-tomcat-8.5.34
-    lrwxrwxrwx 1 root root        12 Oct 24 13:59 jdk -> jdk-11.0.11
-    drwxr-xr-x 7 root root      4096 Oct  6 07:58 jdk-11.0.11
+    lrwxrwxrwx 1 root root        12 Oct 24 13:59 jdk -> jdk-xx
+    drwxr-xr-x 7 root root      4096 Oct  6 07:58 jdk-xx
     ~~~
 
 ## Next Step

--- a/docs/userguide/src/site/pages/tds_tutorial/getting_started/InstallJavaTomcat.md
+++ b/docs/userguide/src/site/pages/tds_tutorial/getting_started/InstallJavaTomcat.md
@@ -14,7 +14,7 @@ Users of OS-provided packages via package management systems for Java and/or Tom
 
 ## System Requirements
 
-* OpenJDK Java 11
+* OpenJDK Java 17
 * Apache Tomcat 8.x or 9.x
 
 While there are different distributors of Java and servlet containers, Unidata develops, uses and tests the THREDDS Data Server using _OpenJDK Java_ and the _Apache Tomcat_ servlet container.

--- a/docs/userguide/src/site/pages/tds_tutorial/getting_started/RunningTomcat.md
+++ b/docs/userguide/src/site/pages/tds_tutorial/getting_started/RunningTomcat.md
@@ -128,11 +128,12 @@ Download an {% include link_file.html file="tds_tutorial/getting_started/setenv.
    NORMAL="-d64 -Xmx4096m -Xms512m -server"
    HEAP_DUMP="-XX:+HeapDumpOnOutOfMemoryError"
    HEADLESS="-Djava.awt.headless=true"
+   CHRONICLE_CACHE="--add-exports java.base/jdk.internal.ref=ALL-UNNAMED --add-exports java.base/sun.nio.ch=ALL-UNNAMED --add-exports jdk.unsupported/sun.misc=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-opens jdk.compiler/com.sun.tools.javac=ALL-UNNAMED --add-opens java.base/java.lang=ALL-UNNAMED --add-opens java.base/java.lang.reflect=ALL-UNNAMED --add-opens java.base/java.io=ALL-UNNAMED --add-opens java.base/java.util=ALL-UNNAMED"
 
    #
    # Standard setup.
    #
-   JAVA_OPTS="$CONTENT_ROOT $NORMAL $HEAP_DUMP $HEADLESS $JAVA_PREFS_ROOTS"
+   JAVA_OPTS="$CONTENT_ROOT $NORMAL $HEAP_DUMP $HEADLESS $JAVA_PREFS_ROOTS $CHRONICLE_CACHE"
 
    export JAVA_OPTS
    ~~~
@@ -153,6 +154,7 @@ Download an {% include link_file.html file="tds_tutorial/getting_started/setenv.
     * `-Djava.awt.headless=true` is needed to prevent graphics rendering code from assuming a graphics console exists.
     Without this, WMS code will crash the server in some circumstances.
     * `-Djava.util.prefs.systemRoot=$CONTENT_ROOT/thredds/javaUtilPrefs -Djava.util.prefs.userRoot=$CONTENT_ROOT/thredds/javaUtilPrefs` allows the java.util.prefs of the TDS WMS to write system preferences to a location that is writable by the Tomcat user.
+    * The parameters in `$CHRONICLE_CACHE` are required by the [chronicle libraries](https://chronicle.software/chronicle-support-java-17/) to run with JDK 17
 
     {%include note.html content="
     For more information about the possible options/arguments available for `$JAVA_OPTS`, please consult the [Oracle Documentation](https://docs.oracle.com/javase/8/docs/technotes/tools/unix/java.html#BABDJJFI){:target='_blank'}.

--- a/gradle/any/java-internal.gradle
+++ b/gradle/any/java-internal.gradle
@@ -2,8 +2,8 @@ apply plugin: 'java'
 apply from: "$rootDir/gradle/any/spotless.gradle"
 
 java {
-  sourceCompatibility = JavaVersion.VERSION_11
-  targetCompatibility = JavaVersion.VERSION_11
+  sourceCompatibility = JavaVersion.VERSION_17
+  targetCompatibility = JavaVersion.VERSION_17
 }
 
 // Will apply to "compileJava", "compileTestJava", "compileSourceSetJava", etc.

--- a/gradle/any/properties.gradle
+++ b/gradle/any/properties.gradle
@@ -52,3 +52,17 @@ ext {
   getPropertyOrFailBuild = this.&getPropertyOrFailBuild
   addFilteredSysProps = this.&addFilteredSysProps
 }
+
+ext {
+  jvmArguments = [
+          '--add-exports', 'java.base/jdk.internal.ref=ALL-UNNAMED',
+          '--add-exports', 'java.base/sun.nio.ch=ALL-UNNAMED',
+          '--add-exports', 'jdk.unsupported/sun.misc=ALL-UNNAMED',
+          '--add-exports', 'jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED',
+          '--add-opens', 'jdk.compiler/com.sun.tools.javac=ALL-UNNAMED',
+          '--add-opens', 'java.base/java.lang=ALL-UNNAMED',
+          '--add-opens', 'java.base/java.lang.reflect=ALL-UNNAMED',
+          '--add-opens', 'java.base/java.io=ALL-UNNAMED',
+          '--add-opens', 'java.base/java.util=ALL-UNNAMED',
+  ]
+}

--- a/tdcommon/build.gradle
+++ b/tdcommon/build.gradle
@@ -48,3 +48,7 @@ spotless {
 tasks.named('sourceJar').configure {
   dependsOn('generateProto')
 }
+
+test {
+  jvmArgs = jvmArguments
+}

--- a/tds/build.gradle
+++ b/tds/build.gradle
@@ -254,10 +254,14 @@ import org.akhikhl.gretty.AppAfterIntegrationTestTask
 
 import java.nio.file.Paths
 
+test {
+  jvmArgs = jvmArguments
+}
+
 gretty {
   httpPort = 8081
   contextPath = '/thredds'
-  jvmArgs = ['--add-exports', 'java.base/jdk.internal.ref=ALL-UNNAMED']
+  jvmArgs = jvmArguments
 }
 
 def testInfomation = [[name: 'freshInstallTest',

--- a/tds/build.gradle
+++ b/tds/build.gradle
@@ -257,7 +257,7 @@ import java.nio.file.Paths
 gretty {
   httpPort = 8081
   contextPath = '/thredds'
-  jvmArgs = ['--illegal-access=permit', '--add-exports', 'java.base/jdk.internal.ref=ALL-UNNAMED']
+  jvmArgs = ['--add-exports', 'java.base/jdk.internal.ref=ALL-UNNAMED']
 }
 
 def testInfomation = [[name: 'freshInstallTest',


### PR DESCRIPTION
- Update JDK from 11 to 17.
- Update GitHub workflows-- note Zulu 17 is present but not currently working in the thredds-test-environment
- Add JVM arguments needed by chronicle to tests and gretty: https://chronicle.software/chronicle-support-java-17/
- Add JVM args to documentation