### PR TITLE
Switch order of dependency repos

### DIFF
--- a/gradle/any/dependencies.gradle
+++ b/gradle/any/dependencies.gradle
@@ -35,9 +35,12 @@ repositories {
     }
   }
 
-  // chronicle-bom needs access to chronicle snapshots
   maven {
     url 'https://oss.sonatype.org/content/repositories/snapshots/'
+    content {
+      // this repository *only* used for chronicle-map snapshot artifacts that are sometimes specified in the chronicle-bom
+      includeGroup 'net.openhft'
+    }
   }
 }
 

--- a/gradle/any/dependencies.gradle
+++ b/gradle/any/dependencies.gradle
@@ -15,11 +15,6 @@ repositories {
   // uncomment for release process
 //  mavenLocal()
 
-  // chronicle-bom needs access to chronicle snapshots
-  maven {
-    url 'https://oss.sonatype.org/content/repositories/snapshots/'
-  }
-
   // All of the hosted repositories below could be replaced with:
   //     url "https://artifacts.unidata.ucar.edu/repository/unidata-all/"
   // which is a group repository that contains all other repositories. However, I prefer to list all source
@@ -38,6 +33,11 @@ repositories {
       // this repository *only* used for artifacts with group "org.bounce" (NcML editor in toolsUI)
       includeGroup 'org.bounce'
     }
+  }
+
+  // chronicle-bom needs access to chronicle snapshots
+  maven {
+    url 'https://oss.sonatype.org/content/repositories/snapshots/'
   }
 }
 


### PR DESCRIPTION
Sonatype is getting tried for Unidata's artifacts, and is now suddenly returning a 502 error which prevents netcdf-java artifacts from getting downloaded. This PR:
- switches order of repos so our artifacts can be found on nexus and sonatype is used last
- limited use of sonatype to chronicle artifacts