### PR TITLE
Use last edal-java release

### DIFF
--- a/tds-platform/build.gradle
+++ b/tds-platform/build.gradle
@@ -99,7 +99,7 @@ dependencies {
     api 'org.n52.sensorweb:52n-xml-om-v20'
 
     // edal-java (ncwms)
-    def edalVersion = '1.5.2.1-SNAPSHOT'
+    def edalVersion = '1.5.2.0'
     api "uk.ac.rdg.resc:edal-common:${edalVersion}"
     api "uk.ac.rdg.resc:edal-cdm:${edalVersion}"
     api "uk.ac.rdg.resc:edal-wms:${edalVersion}"


### PR DESCRIPTION
Switch back to last edal-java release instead of snapshot so things don't break when I do edal-java jakarta servlet upgrades.