### PR TITLE
Improve support documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,12 @@ respond to the confirmation email. Mailing list archives are available at:
 
 * https://www.unidata.ucar.edu/mailing_lists/archives/thredds/
 
-We appreciate feedback from users of this package. Please send comments,
-suggestions, and bug reports to <support-thredds@unidata.ucar.edu>.
+We appreciate feedback from users of this package.
+Open a GitHub issue or discussion if you have comments,
+suggestions, or bug reports.
 Please identify the version of the package.
+For security or server set up issues that cannot be addressed on GitHub,
+you may send your question with the relevant details to <support-thredds@unidata.ucar.edu>.
 
 ## THREDDS Catalogs
 

--- a/docs/adminguide/src/site/pages/overview/TDSVetted.md
+++ b/docs/adminguide/src/site/pages/overview/TDSVetted.md
@@ -37,7 +37,10 @@ When identified, any security-related issues are addressed immediately and fixed
 ### Providing Feedback
 
 We appreciate feedback from users of the TDS!
-Send comments, suggestions, and bug reports to <{{site.feedback_email}}>. 
+Open a GitHub issue or discussion [here](https://github.com/Unidata/tds) if you have comments,
+suggestions, or bug reports.
 Please identify the version of the package.
+For server set up issues that cannot be addressed on GitHub,
+you may send your question with the relevant details to <support-thredds@unidata.ucar.edu>.
 
 To report a potential security-related issue or bug, contact: <security@unidata.ucar.edu>

--- a/docs/userguide/src/site/_config.yml
+++ b/docs/userguide/src/site/_config.yml
@@ -23,9 +23,8 @@ host: 127.0.0.1
 # the port where the preview is rendered. You can leave this as is unless you have other Jekyll builds using this same port that might cause conflicts. in that case, use another port such as 4006.
 port: 4005
 
-# used as a contact email and subject line for the Feedback link in the top navigation bar
-feedback_email: support-thredds@unidata.ucar.edu
-feedback_subject_line: THREDDS Data Server Documentation Feedback
+# used for the Feedback link in the top navigation bar
+feedback_link: "https://github.com/Unidata/tds/issues/new?title=Documentation%20feedback"
 
 # library used for syntax highlighting
 highlighter: rouge


### PR DESCRIPTION
Emphasize GitHub as primary avenue of support, while eSupport can still be used for security issues.