### PR TITLE
Fix NCSS decimal separators

### DIFF
--- a/tds/src/main/webapp/WEB-INF/templates/gridFragments.html
+++ b/tds/src/main/webapp/WEB-INF/templates/gridFragments.html
@@ -27,10 +27,10 @@
       var horizExtentWKT = /*[[${horizExtentWKT}]]*/ 'POLYGON((-90 45, 90 45, 90 -45, -90 -45, -90 45))';
 
       var fullLatLonExt = {
-          north: /*[[${#numbers.formatDecimal(gcd.latlonBoundingBox?.latMax, 0, 3)}]]*/ "45.0000",
-          south: /*[[${#numbers.formatDecimal(gcd.latlonBoundingBox?.latMin, 0, 3)}]]*/ "-45.0000",
-          west:  /*[[${#numbers.formatDecimal(gcd.latlonBoundingBox?.lonMin, 0, 3)}]]*/ "-90.0000",
-          east:  /*[[${#numbers.formatDecimal(gcd.latlonBoundingBox?.lonMax, 0, 3)}]]*/ "90.0000"
+          north: /*[[${#numbers.formatDecimal(gcd.latlonBoundingBox?.latMax, 0, 3, 'POINT')}]]*/ "45.0000",
+          south: /*[[${#numbers.formatDecimal(gcd.latlonBoundingBox?.latMin, 0, 3, 'POINT')}]]*/ "-45.0000",
+          west:  /*[[${#numbers.formatDecimal(gcd.latlonBoundingBox?.lonMin, 0, 3, 'POINT')}]]*/ "-90.0000",
+          east:  /*[[${#numbers.formatDecimal(gcd.latlonBoundingBox?.lonMax, 0, 3, 'POINT')}]]*/ "90.0000"
       };
 
       var fullProjExt = {

--- a/tds/src/main/webapp/WEB-INF/templates/pointFragments.html
+++ b/tds/src/main/webapp/WEB-INF/templates/pointFragments.html
@@ -28,10 +28,10 @@
       var horizExtentWKT = /*[[${horizExtentWKT}]]*/ 'POLYGON((-90 45, 90 45, 90 -45, -90 -45, -90 45))';
 
       var fullLatLonExt = {
-          north: /*[[${#numbers.formatDecimal(boundingBox?.latMax, 0, 3)}]]*/ "45.0000",
-          south: /*[[${#numbers.formatDecimal(boundingBox?.latMin, 0, 3)}]]*/ "-45.0000",
-          west:  /*[[${#numbers.formatDecimal(boundingBox?.lonMin, 0, 3)}]]*/ "-90.0000",
-          east:  /*[[${#numbers.formatDecimal(boundingBox?.lonMax, 0, 3)}]]*/ "90.0000"
+          north: /*[[${#numbers.formatDecimal(boundingBox?.latMax, 0, 3, 'POINT')}]]*/ "45.0000",
+          south: /*[[${#numbers.formatDecimal(boundingBox?.latMin, 0, 3, 'POINT')}]]*/ "-45.0000",
+          west:  /*[[${#numbers.formatDecimal(boundingBox?.lonMin, 0, 3, 'POINT')}]]*/ "-90.0000",
+          east:  /*[[${#numbers.formatDecimal(boundingBox?.lonMax, 0, 3, 'POINT')}]]*/ "90.0000"
       };
 
       var fullTimeExt = {


### PR DESCRIPTION
As in this [issue](https://github.com/Unidata/netcdf-java/pull/1162), NCSS cannot handle commas as decimal separators. Depending on your browser's locale, the default lat/lon range may use commas as the decimal separator which will not work with the bean validation. This PR makes thymeleaf display the default lat/lon bounds using points as the decimal separator regardless of browser settings.