### PR TITLE
Improve exception messages

### DIFF
--- a/tds/src/main/java/thredds/server/opendap/OpendapServlet.java
+++ b/tds/src/main/java/thredds/server/opendap/OpendapServlet.java
@@ -203,7 +203,7 @@ public class OpendapServlet extends AbstractServlet implements InitializingBean 
       // plain ol' 404
     } catch (FileNotFoundException e) {
       // e.printStackTrace();
-      sendErrorResponse(response, HttpServletResponse.SC_NOT_FOUND, e.getMessage());
+      sendErrorResponse(response, HttpServletResponse.SC_NOT_FOUND, "FileNotFound: No such file or directory");
 
       // DAP2Exception bad url
     } catch (BadURLException e) {

--- a/tds/src/main/java/thredds/server/wfs/WFSController.java
+++ b/tds/src/main/java/thredds/server/wfs/WFSController.java
@@ -261,8 +261,8 @@ public class WFSController extends HttpServlet {
         // Last check to see if typenames is specified, must be for GetFeature, DescribeFeatureType
         if (typeName == null) {
           return new WFSExceptionWriter(
-              "WFS server error. For the specifed request, parameter typename or typenames must be specified.", request,
-              "MissingParameterValue");
+              "WFS server error. For the specifed request, parameter typename or typenames must be specified.",
+              "request", "MissingParameterValue");
         }
       }
 


### PR DESCRIPTION
- Do not include file paths in open dap's 404 exception messages 
- Fix Coverity flagged issue on WFS exception containing query parameters