### PR TITLE
Add radar server tests

### DIFF
--- a/tds/src/integrationTests/java/thredds/server/radar/TestRadarServerQuery.java
+++ b/tds/src/integrationTests/java/thredds/server/radar/TestRadarServerQuery.java
@@ -1,0 +1,116 @@
+package thredds.server.radar;
+
+import jakarta.servlet.http.HttpServletResponse;
+import org.jdom2.Document;
+import org.jdom2.Element;
+import org.jdom2.JDOMException;
+import org.jdom2.Namespace;
+import org.jdom2.filter.Filters;
+import org.jdom2.xpath.XPathExpression;
+import org.jdom2.xpath.XPathFactory;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import thredds.test.util.TestOnLocalServer;
+import thredds.util.xml.XmlUtil;
+import ucar.unidata.util.test.category.NeedsCdmUnitTest;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static com.google.common.truth.Truth.assertThat;
+
+@Category(NeedsCdmUnitTest.class)
+public class TestRadarServerQuery {
+  private static final Namespace NS =
+      Namespace.getNamespace("ns", "http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0");
+  private static final String L2_URL = "/radarServer/nexrad/level2/IDD";
+  private static final String L3_URL = "/radarServer/nexrad/level3/IDD";
+
+  @Test
+  public void shouldReturnAllDatasetsForStation() throws IOException, JDOMException {
+    String endpoint = L2_URL + "?stn=KDGX&temporal=all";
+    verifyNumberOfDatasets(endpoint, 3);
+  }
+
+  @Test
+  public void shouldReturnZeroDatasetsForNonOverlappingTimeRange() throws IOException, JDOMException {
+    String endpoint = L2_URL + "?stn=KDGX&time_start=2000-01-01T12:00:00&time_end=2001-01-01T12:00:00";
+    verifyNumberOfDatasets(endpoint, 0);
+  }
+
+  @Test
+  public void shouldReturnOneDatasetForOverlappingTimeRange() throws IOException, JDOMException {
+    String endpoint = L2_URL + "?stn=KDGX&time_start=2014-06-02T23:52:00&time_end=2014-06-02T23:53:00";
+    verifyNumberOfDatasets(endpoint, 1);
+  }
+
+  @Test
+  public void shouldReturnOneDatasetForOverlappingTimeDuration() throws IOException, JDOMException {
+    String endpoint = L2_URL + "?stn=KDGX&time_start=2014-06-02T23:52:00&time_duration=PT1M";
+    verifyNumberOfDatasets(endpoint, 1);
+  }
+
+  @Test
+  public void shouldReturnOneDatasetForTime() throws IOException, JDOMException {
+    String endpoint = L2_URL + "?stn=KDGX&time=2014-06-02T23:52:00";
+    verifyNumberOfDatasets(endpoint, 1);
+  }
+
+  @Test
+  public void shouldReturnZeroDatasetsForNonExistentStation() throws IOException, JDOMException {
+    String endpoint = L2_URL + "?stn=ABCD&temporal=all";
+    verifyNumberOfDatasets(endpoint, 0);
+  }
+
+  @Test
+  public void shouldReturnErrorForNonOverlappingBox() throws IOException, JDOMException {
+    String endpoint = L2_URL + "?north=10&south=0&west=-100&east=-80&temporal=all";
+    byte[] result = TestOnLocalServer.getContent(TestOnLocalServer.withHttpPath(endpoint), HttpServletResponse.SC_OK,
+        "text/plain;charset=iso-8859-1");
+    assertThat(new String(result, StandardCharsets.UTF_8)).isEqualTo("No stations found for specified coordinates.");
+  }
+
+  @Test
+  public void shouldReturnAllDatasetsForOverlappingBox() throws IOException, JDOMException {
+    String endpoint = L2_URL + "?north=50&south=30&west=-100&east=-80&temporal=all";
+    verifyNumberOfDatasets(endpoint, 3);
+  }
+
+  @Test
+  public void shouldReturnAllDatasetsForLonLat() throws IOException, JDOMException {
+    String endpoint = L2_URL + "?latitude=30&longitude=-90&temporal=all";
+    verifyNumberOfDatasets(endpoint, 3);
+  }
+
+  @Test
+  public void shouldReturnAllLevel3Datasets() throws IOException, JDOMException {
+    String endpoint = L3_URL + "?temporal=all&var=N0R&stn=UDX";
+    verifyNumberOfDatasets(endpoint, 329);
+  }
+
+  @Test
+  public void shouldReturnErrorWithoutVar() throws IOException, JDOMException {
+    String endpoint = L3_URL + "?temporal=all&stn=UDX";
+    byte[] result = TestOnLocalServer.getContent(TestOnLocalServer.withHttpPath(endpoint), HttpServletResponse.SC_OK,
+        "text/plain;charset=iso-8859-1");
+    assertThat(new String(result, StandardCharsets.UTF_8)).isEqualTo("One or more variables required.");
+  }
+
+  private static void verifyNumberOfDatasets(String endpoint, int expectedNumber) throws IOException, JDOMException {
+    byte[] result = TestOnLocalServer.getContent(TestOnLocalServer.withHttpPath(endpoint), HttpServletResponse.SC_OK,
+        "application/xml");
+
+    Document doc = XmlUtil.getStringResponseAsDoc(result);
+
+    XPathExpression<Element> xpathDoc = XPathFactory.instance()
+        .compile("ns:catalog/ns:dataset/ns:metadata/ns:documentation", Filters.element(), null, NS);
+    Element documentation = xpathDoc.evaluateFirst(doc);
+    assertThat(documentation.getTextTrim()).isEqualTo(expectedNumber + " datasets found for query");
+
+    XPathExpression<Element> xpathDatasets =
+        XPathFactory.instance().compile("ns:catalog/ns:dataset/ns:dataset", Filters.element(), null, NS);
+    List<Element> datasets = xpathDatasets.evaluate(doc);
+    assertThat(datasets.size()).isEqualTo(expectedNumber);
+  }
+}

--- a/tds/src/main/java/thredds/server/radarServer2/RadarServerConfig.java
+++ b/tds/src/main/java/thredds/server/radarServer2/RadarServerConfig.java
@@ -14,6 +14,8 @@ import ucar.nc2.constants.CDM;
 import ucar.nc2.units.DateRange;
 import ucar.nc2.units.DateType;
 import ucar.nc2.units.TimeDuration;
+import ucar.nc2.util.AliasTranslator;
+
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
@@ -59,7 +61,7 @@ public class RadarServerConfig {
         Element meta = dataset.getChild("metadata", catNS);
         conf.name = dataset.getAttributeValue("name");
         conf.urlPath = dataset.getAttributeValue("path");
-        conf.dataPath = getPath(dataset.getAttributeValue("location"));
+        conf.dataPath = getPath(AliasTranslator.translateAlias(dataset.getAttributeValue("location")));
         conf.dataFormat = meta.getChild("dataFormat", catNS).getValue();
         conf.stationFile = meta.getChild("stationFile", catNS).getAttributeValue("path");
         conf.doc = meta.getChild("documentation", catNS).getValue();

--- a/tds/src/test/content/thredds/radar/CS039_L2_stations.xml
+++ b/tds/src/test/content/thredds/radar/CS039_L2_stations.xml
@@ -6,4 +6,7 @@
     <station name="QUAD_CITIES/Davenport" value="KDVN" state="IA" country="US">
         <location3D latitude="41.6" longitude="-90.57" elevation="230" />
     </station>
+    <station name="BRANDON/Jackson" value="KDGX" state="MS" country="US">
+        <location3D latitude="32.17" longitude="-89.59" elevation="186" />
+    </station>
 </stationList>

--- a/tds/src/test/content/thredds/radar/radarCollections.xml
+++ b/tds/src/test/content/thredds/radar/radarCollections.xml
@@ -9,7 +9,7 @@
 
   <dataset name="Radar Data">
     <datasetScan name="NEXRAD Level II Radar from IDD" collectionType="TimeSeries" ID="nexrad/level2/IDD" path="nexrad/level2/IDD" location="${cdmUnitTest}/datasets/radar/level2">
-      <radarCollection layout="STATION/yyyyMMdd" dateRegex="(\d{8}_\d{6})$" dateFormat="yyyyMMdd_HHmmss" />
+      <radarCollection layout="STATION/yyyyMMdd" dateRegex="(\d{8}_\d{4})\.ar2v$" dateFormat="yyyyMMdd_HHmm" />
       <metadata inherited="true">
         <dataType>Radial</dataType>
         <dataFormat>NEXRAD2</dataFormat>

--- a/tds/src/test/java/thredds/util/xml/XmlUtil.java
+++ b/tds/src/test/java/thredds/util/xml/XmlUtil.java
@@ -17,11 +17,13 @@ public class XmlUtil {
   private XmlUtil() {}
 
   public static Document getStringResponseAsDoc(MockHttpServletResponse response) throws JDOMException, IOException {
+    return getStringResponseAsDoc(response.getContentAsByteArray());
+  }
 
+  public static Document getStringResponseAsDoc(byte[] response) throws JDOMException, IOException {
     SAXBuilder sb = new SAXBuilder();
     sb.setExpandEntities(false);
-    String strResponse = response.getContentAsString();
-    return sb.build(new ByteArrayInputStream(strResponse.getBytes(response.getCharacterEncoding())));
+    return sb.build(new ByteArrayInputStream(response));
   }
 
   public static List<Element> evaluateXPath(Document doc, String strXpath) {


### PR DESCRIPTION
- Add tests for radar server queries using existing level2 and level3 data in cdmUnitTest datasets
- Fix level2 test dataset config so it matches current data, by adding a station and fixing date format
- Add xml util test function
- Use the Alias translator in the `RadarServerConfig` so test datasets with `${cdmUnitTest}` path variable get translated to a path