### PR TITLE
Allow two periods in file paths

### DIFF
--- a/tds/src/main/java/thredds/util/TdsPathUtils.java
+++ b/tds/src/main/java/thredds/util/TdsPathUtils.java
@@ -42,8 +42,8 @@ public class TdsPathUtils {
     if (dataPath.startsWith("/"))
       dataPath = dataPath.substring(1);
 
-    if (dataPath.contains("..")) // LOOK what about escapes ??
-      throw new IllegalArgumentException("path cannot contain '..'");
+    if (dataPath.contains("../")) // LOOK what about escapes ??
+      throw new IllegalArgumentException("path cannot contain '../'");
 
     return dataPath;
   }


### PR DESCRIPTION
Allow file names with two periods like "my..file.nc". To ensure no traversal to parent directory, we will disallow "../".