### PR TITLE
S3 radar server

### DIFF
--- a/tds/src/integrationTests/java/thredds/server/radar/TestRadarServer.java
+++ b/tds/src/integrationTests/java/thredds/server/radar/TestRadarServer.java
@@ -31,7 +31,15 @@ public class TestRadarServer {
         // {"/radar/radarCollections.xml"},
         {"/radarServer/nexrad/level2/IDD/dataset.xml"}, {"/radarServer/nexrad/level2/IDD/stations.xml"},
         {"/radarServer/nexrad/level2/IDD?stn=KDGX&time_start=2014-06-05T12:47:17&time_end=2014-06-05T16:07:17"},
-        {"/radarServer/nexrad/level3/IDD/stations.xml"}, {"/radarServer/terminal/level3/IDD/stations.xml"},});
+        {"/radarServer/nexrad/level3/IDD/stations.xml"}, {"/radarServer/terminal/level3/IDD/stations.xml"},
+
+
+        // s3 tests
+        {"/radarServer/s3/nexrad/level2/IDD/dataset.xml"}, {"/radarServer/s3/nexrad/level2/IDD/stations.xml"},
+        {"/radarServer/s3/nexrad/level2/IDD?stn=KDGX&time_start=2014-06-05T12:47:17&time_end=2014-06-05T16:07:17"},
+        {"/radarServer/s3/nexrad/level3/IDD/stations.xml"},
+
+    });
   }
 
   private static final String expectedContentType = "application/xml";

--- a/tds/src/integrationTests/java/thredds/server/radar/TestRadarServerQuery.java
+++ b/tds/src/integrationTests/java/thredds/server/radar/TestRadarServerQuery.java
@@ -10,62 +10,77 @@ import org.jdom2.xpath.XPathExpression;
 import org.jdom2.xpath.XPathFactory;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 import thredds.test.util.TestOnLocalServer;
 import thredds.util.xml.XmlUtil;
 import ucar.unidata.util.test.category.NeedsCdmUnitTest;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.List;
 
 import static com.google.common.truth.Truth.assertThat;
 
 @Category(NeedsCdmUnitTest.class)
+@RunWith(Parameterized.class)
 public class TestRadarServerQuery {
   private static final Namespace NS =
       Namespace.getNamespace("ns", "http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0");
-  private static final String L2_URL = "/radarServer/nexrad/level2/IDD";
-  private static final String L3_URL = "/radarServer/nexrad/level3/IDD";
+
+  private final String l2Url;
+  private final String l3Url;
+
+  @Parameterized.Parameters(name = "{0}")
+  public static List<String> getTestParameters() {
+    return Arrays.asList("", "s3/");
+  }
+
+  public TestRadarServerQuery(String datasetPathPrefix) {
+    l2Url = "/radarServer/" + datasetPathPrefix + "nexrad/level2/IDD";
+    l3Url = "/radarServer/" + datasetPathPrefix + "nexrad/level3/IDD";
+  }
 
   @Test
   public void shouldReturnAllDatasetsForStation() throws IOException, JDOMException {
-    String endpoint = L2_URL + "?stn=KDGX&temporal=all";
+    String endpoint = l2Url + "?stn=KDGX&temporal=all";
     verifyNumberOfDatasets(endpoint, 3);
   }
 
   @Test
   public void shouldReturnZeroDatasetsForNonOverlappingTimeRange() throws IOException, JDOMException {
-    String endpoint = L2_URL + "?stn=KDGX&time_start=2000-01-01T12:00:00&time_end=2001-01-01T12:00:00";
+    String endpoint = l2Url + "?stn=KDGX&time_start=2000-01-01T12:00:00&time_end=2001-01-01T12:00:00";
     verifyNumberOfDatasets(endpoint, 0);
   }
 
   @Test
   public void shouldReturnOneDatasetForOverlappingTimeRange() throws IOException, JDOMException {
-    String endpoint = L2_URL + "?stn=KDGX&time_start=2014-06-02T23:52:00&time_end=2014-06-02T23:53:00";
+    String endpoint = l2Url + "?stn=KDGX&time_start=2014-06-02T23:52:00&time_end=2014-06-02T23:53:00";
     verifyNumberOfDatasets(endpoint, 1);
   }
 
   @Test
   public void shouldReturnOneDatasetForOverlappingTimeDuration() throws IOException, JDOMException {
-    String endpoint = L2_URL + "?stn=KDGX&time_start=2014-06-02T23:52:00&time_duration=PT1M";
+    String endpoint = l2Url + "?stn=KDGX&time_start=2014-06-02T23:52:00&time_duration=PT1M";
     verifyNumberOfDatasets(endpoint, 1);
   }
 
   @Test
   public void shouldReturnOneDatasetForTime() throws IOException, JDOMException {
-    String endpoint = L2_URL + "?stn=KDGX&time=2014-06-02T23:52:00";
+    String endpoint = l2Url + "?stn=KDGX&time=2014-06-02T23:52:00";
     verifyNumberOfDatasets(endpoint, 1);
   }
 
   @Test
   public void shouldReturnZeroDatasetsForNonExistentStation() throws IOException, JDOMException {
-    String endpoint = L2_URL + "?stn=ABCD&temporal=all";
+    String endpoint = l2Url + "?stn=ABCD&temporal=all";
     verifyNumberOfDatasets(endpoint, 0);
   }
 
   @Test
   public void shouldReturnErrorForNonOverlappingBox() throws IOException, JDOMException {
-    String endpoint = L2_URL + "?north=10&south=0&west=-100&east=-80&temporal=all";
+    String endpoint = l2Url + "?north=10&south=0&west=-100&east=-80&temporal=all";
     byte[] result = TestOnLocalServer.getContent(TestOnLocalServer.withHttpPath(endpoint), HttpServletResponse.SC_OK,
         "text/plain;charset=iso-8859-1");
     assertThat(new String(result, StandardCharsets.UTF_8)).isEqualTo("No stations found for specified coordinates.");
@@ -73,25 +88,25 @@ public class TestRadarServerQuery {
 
   @Test
   public void shouldReturnAllDatasetsForOverlappingBox() throws IOException, JDOMException {
-    String endpoint = L2_URL + "?north=50&south=30&west=-100&east=-80&temporal=all";
+    String endpoint = l2Url + "?north=50&south=30&west=-100&east=-80&temporal=all";
     verifyNumberOfDatasets(endpoint, 3);
   }
 
   @Test
   public void shouldReturnAllDatasetsForLonLat() throws IOException, JDOMException {
-    String endpoint = L2_URL + "?latitude=30&longitude=-90&temporal=all";
+    String endpoint = l2Url + "?latitude=30&longitude=-90&temporal=all";
     verifyNumberOfDatasets(endpoint, 3);
   }
 
   @Test
   public void shouldReturnAllLevel3Datasets() throws IOException, JDOMException {
-    String endpoint = L3_URL + "?temporal=all&var=N0R&stn=UDX";
+    String endpoint = l3Url + "?temporal=all&var=N0R&stn=UDX";
     verifyNumberOfDatasets(endpoint, 329);
   }
 
   @Test
   public void shouldReturnErrorWithoutVar() throws IOException, JDOMException {
-    String endpoint = L3_URL + "?temporal=all&stn=UDX";
+    String endpoint = l3Url + "?temporal=all&stn=UDX";
     byte[] result = TestOnLocalServer.getContent(TestOnLocalServer.withHttpPath(endpoint), HttpServletResponse.SC_OK,
         "text/plain;charset=iso-8859-1");
     assertThat(new String(result, StandardCharsets.UTF_8)).isEqualTo("One or more variables required.");

--- a/tds/src/main/java/thredds/server/radarServer2/RadarServerController.java
+++ b/tds/src/main/java/thredds/server/radarServer2/RadarServerController.java
@@ -148,7 +148,7 @@ public class RadarServerController implements InitializingBean {
       List<RadarServerConfig.RadarConfigEntry> configs =
           RadarServerConfig.readXML(contentPath + "/radar/radarCollections.xml");
       for (RadarServerConfig.RadarConfigEntry conf : configs) {
-        RadarDataInventory di = new RadarDataInventory(conf.dataPath, conf.crawlItems);
+        RadarDataInventory di = new RadarDataInventory(conf.mFile, conf.crawlItems);
         di.setName(conf.name);
         di.setDescription(conf.doc);
 
@@ -495,14 +495,14 @@ public class RadarServerController implements InitializingBean {
 
     for (RadarDataInventory.Query.QueryResultItem i : res) {
       DatasetBuilder fileDB = new DatasetBuilder(mainDB);
-      fileDB.setName(i.file.getFileName().toString());
+      fileDB.setName(i.file.getName());
       fileDB.put(Dataset.Id, String.valueOf(i.file.hashCode()));
 
       fileDB.put(Dataset.Dates, new DateType(i.time.toString(), null, "start of ob", i.time.getCalendar()));
 
       // TODO: Does this need to be converted from the on-disk path
       // to a mapped url path?
-      fileDB.put(Dataset.UrlPath, inv.getCollectionDir().relativize(i.file).toString());
+      fileDB.put(Dataset.UrlPath, inv.getCollectionDir().relativize(i.file));
       mainDB.addDataset(fileDB);
     }
 

--- a/tds/src/test/content/thredds/radar/radarCollections.xml
+++ b/tds/src/test/content/thredds/radar/radarCollections.xml
@@ -47,7 +47,170 @@
       </metadata>
     </datasetScan>
 
+    <datasetScan name="S3 NEXRAD Level II Radar from IDD" collectionType="TimeSeries" ID="s3/nexrad/level2/IDD" path="s3/nexrad/level2/IDD"
+                 location="cdms3:thredds-test-data?radar/level2/#delimiter=/">
+      <radarCollection layout="STATION/yyyyMMdd" dateRegex="(\d{8}_\d{4})\.ar2v$" dateFormat="yyyyMMdd_HHmm" />
+      <metadata inherited="true">
+        <dataType>Radial</dataType>
+        <dataFormat>NEXRAD2</dataFormat>
+        <serviceName>radarServer</serviceName>
+        <documentation type="summary">NEXRAD Level II Radar WSR-88D for Case Study CCS039. </documentation>
+        <timeCoverage>
+          <start>1998-06-29T18:00:00</start>
+          <end>1998-06-29T23:00:00</end>
+        </timeCoverage>
+        <variables vocabulary="DIF">
+          <variable name="Reflectivity" vocabulary_name="EARTH SCIENCE &gt; Spectral/Engineering &gt; Radar &gt; Radar Reflectivity" units="db" />
+          <variable name="Velocity" vocabulary_name="EARTH SCIENCE &gt; Spectral/Engineering &gt; Radar &gt; Doppler Velocity" units="m/s" />
+          <variable name="SpectrumWidth" vocabulary_name="EARTH SCIENCE &gt; Spectral/Engineering &gt; Radar &gt; Doppler Spectrum Width" units="m/s" />
+        </variables>
+        <stationFile path="radar/CS039_L2_stations.xml" />
+        <documentation xlink:title="Available Stations" xlink:href="/thredds/radarServer/nexrad/level2/CCS039/stations.xml"/>
+        <documentation type="path">nexrad/level2/CCS039</documentation>
+        <geospatialCoverage>
+          <northsouth>
+            <start>37.0</start>
+            <size>9.0</size>
+            <units>degrees_north</units>
+          </northsouth>
+          <eastwest>
+            <start>-100.0</start>
+            <size>16.0</size>
+            <units>degrees_east</units>
+          </eastwest>
+          <updown>
+            <start>0.0</start>
+            <size>21.0</size>
+            <units>km</units>
+          </updown>
+        </geospatialCoverage>
+      </metadata>
+    </datasetScan>
+
     <datasetScan name="NEXRAD Level III Radar from IDD" collectionType="TimeSeries" ID="nexrad/level3/IDD" path="nexrad/level3/IDD" location="${cdmUnitTest}/datasets/radar/level3/nexrad/">
+      <radarCollection layout="VARIABLE/STATION/yyyyMMdd" dateRegex="(\d{8}_\d{4})\.nids$" dateFormat="yyyyMMdd_HHmm" />
+      <metadata inherited="true">
+        <dataType>Radial</dataType>
+        <dataFormat>NIDS</dataFormat>
+        <serviceName>radarServer</serviceName>
+        <stationFile path="radar/RadarNexradStations.xml" />
+        <documentation type="summary">The NIDS data feed provides roughly 20 radar products sent every 5-10 minutes from 154 sites over NOAAPORT broadcast. These "derived" products include base reflectivity and velocity, composite reflectivity, precipitation estimates, echo tops and VAD winds</documentation>
+        <documentation xlink:href="http://www.unidata.ucar.edu/data/radar.html" xlink:title="Unidata description of NOAAPORT radar data" />
+        <documentation xlink:href="http://www.ncdc.noaa.gov/oa/radar/radarresources.html" xlink:title="NCDC Radar Resources" />
+        <documentation xlink:href="http://lwf.ncdc.noaa.gov/oa/radar/radarproducts.html" xlink:title="Description of Radar Products (NCDC)" />
+        <creator>
+          <name vocabulary="DIF">DOC/NOAA/NWS</name>
+          <contact url="http://www.roc.noaa.gov/" email="http://www.roc.noaa.gov/Feedback/" />
+        </creator>
+        <geospatialCoverage>
+          <northsouth>
+            <start>20.0</start>
+            <size>40.0</size>
+            <units>degrees_north</units>
+          </northsouth>
+          <eastwest>
+            <start>-135.0</start>
+            <size>70.0</size>
+            <units>degrees_east</units>
+          </eastwest>
+          <updown>
+            <start>0.0</start>
+            <size>0.0</size>
+            <units>km</units>
+          </updown>
+        </geospatialCoverage>
+        <timeCoverage>
+          <end>present</end>
+          <duration>14 days</duration>
+        </timeCoverage>
+        <variables vocabulary="DIF">
+          <variable name="N0R/Base Reflectivity 124nm" vocabulary_name="EARTH SCIENCE &gt; Spectral/Engineering &gt; Radar &gt; Radar Reflectivity" units="dbZ" />
+          <variable name="N0Q/Base Reflectivity DR Tilt 1" vocabulary_name="EARTH SCIENCE &gt; Spectral/Engineering &gt; Radar &gt; Radar Reflectivity" units="dBZ" />
+          <variable name="NAQ/Base Reflectivity DR Tilt 2" vocabulary_name="EARTH SCIENCE &gt; Spectral/Engineering &gt; Radar &gt; Radar Reflectivity" units="dBZ" />
+          <variable name="N1Q/Base Reflectivity DR Tilt 3" vocabulary_name="EARTH SCIENCE &gt; Spectral/Engineering &gt; Radar &gt; Radar Reflectivity" units="dBZ" />
+          <variable name="NBQ/Base Reflectivity DR Tilt 4" vocabulary_name="EARTH SCIENCE &gt; Spectral/Engineering &gt; Radar &gt; Radar Reflectivity" units="dBZ" />
+          <variable name="N2Q/Base Reflectivity DR Tilt 5" vocabulary_name="EARTH SCIENCE &gt; Spectral/Engineering &gt; Radar &gt; Radar Reflectivity" units="dBZ" />
+          <variable name="N3Q/Base Reflectivity DR Tilt 6" vocabulary_name="EARTH SCIENCE &gt; Spectral/Engineering &gt; Radar &gt; Radar Reflectivity" units="dBZ" />
+          <variable name="N0Z/Base Reflecitvity 248nm" vocabulary_name="EARTH SCIENCE &gt; Spectral/Engineering &gt; Radar &gt; Radar Reflectivity" units="dbZ" />
+
+          <variable name="N0V/Radial Velocity 124nm" vocabulary_name="EARTH SCIENCE &gt; Spectral/Engineering &gt; Radar &gt; Doppler Velocity" units="knots" />
+          <variable name="N0U/Radial Velocity DV Tilt 1" vocabulary_name="EARTH SCIENCE &gt; Spectral/Engineering &gt; Radar &gt; Doppler Velocity" units="knots" />
+          <variable name="NAU/Radial Velocity DV Tilt 2" vocabulary_name="EARTH SCIENCE &gt; Spectral/Engineering &gt; Radar &gt; Doppler Velocity" units="knots" />
+          <variable name="N1U/Radial Velocity DV Tilt 3" vocabulary_name="EARTH SCIENCE &gt; Spectral/Engineering &gt; Radar &gt; Doppler Velocity" units="knots" />
+          <variable name="NBU/Radial Velocity DV Tilt 4" vocabulary_name="EARTH SCIENCE &gt; Spectral/Engineering &gt; Radar &gt; Doppler Velocity" units="knots" />
+          <variable name="N2U/Radial Velocity DV Tilt 5" vocabulary_name="EARTH SCIENCE &gt; Spectral/Engineering &gt; Radar &gt; Doppler Velocity" units="knots" />
+          <variable name="N3U/Radial Velocity DV Tilt 6" vocabulary_name="EARTH SCIENCE &gt; Spectral/Engineering &gt; Radar &gt; Doppler Velocity" units="knots" />
+
+          <variable name="DHR/Digital Hybrid Scan Reflectivity" vocabulary_name="EARTH SCIENCE &gt; Spectral/Engineering &gt; Radar &gt; " units="dbZ" />
+          <variable name="NCR/Composite Reflectivity" vocabulary_name="EARTH SCIENCE &gt; Spectral/Engineering &gt; Radar &gt; Radar Reflectivity" units="dbZ" />
+          <variable name="NET/Echo Tops" vocabulary_name="EARTH SCIENCE &gt; Atmosphere &gt; Clouds &gt; Cloud Optical Depth/Thickness" units="1000 feet" />
+          <variable name="EET/Enchanced Echo Tops" vocabulary_name="EARTH SCIENCE &gt; Atmosphere &gt; Clouds &gt; Cloud Optical Depth/Thickness" units="1000 feet" />
+          <variable name="NVW/Velocity Azimuth Display Wind Profile" vocabulary_name="EARTH SCIENCE &gt; Atmosphere &gt; Atmospheric Winds &gt; Wind Profiles" units="knots" />
+          <variable name="N0S/Storm-Rel Mean Vel Tilt 1" vocabulary_name="EARTH SCIENCE &gt; Spectral/Engineering &gt; Radar &gt; Doppler Velocity" units="knots" />
+          <variable name="N1S/Storm-Rel Mean Vel Tilt 2" vocabulary_name="EARTH SCIENCE &gt; Spectral/Engineering &gt; Radar &gt; Doppler Velocity" units="knots" />
+          <variable name="N2S/Storm-Rel Mean Vel Tilt 3" vocabulary_name="EARTH SCIENCE &gt; Spectral/Engineering &gt; Radar &gt; Doppler Velocity" units="knots" />
+          <variable name="N3S/Storm-Rel Mean Vel Tilt 4" vocabulary_name="EARTH SCIENCE &gt; Spectral/Engineering &gt; Radar &gt; Doppler Velocity" units="knots" />
+          <variable name="NVL/Vertically Integrated Liquid" vocabulary_name="EARTH SCIENCE &gt; Atmosphere &gt; Precipitation &gt; Liquid Water Equivalent" units="kg/m2" />
+          <variable name="NST/Storm Tracking Information" vocabulary_name="EARTH SCIENCE &gt; Spectral/Engineering &gt; Radar &gt;" units="" />
+          <variable name="DVL/Digital Vertically Integrated Liquid" vocabulary_name="EARTH SCIENCE &gt; Atmosphere &gt; Precipitation &gt; Liquid Water Equivalent" units="kg/m2" />
+          <variable name="N1P/1-hour Rainfall" vocabulary_name="EARTH SCIENCE &gt; Atmosphere &gt; Precipitation &gt; Precipitation Amount &gt; Hourly Precipitation Amount" units="in" />
+          <variable name="NTP/Storm Total Rainfall" vocabulary_name="EARTH SCIENCE &gt; Atmosphere &gt; Precipitation &gt; Precipitation Amount" units="in" />
+          <variable name="DPA/Digital Precipitation Array" vocabulary_name="EARTH SCIENCE &gt; Atmosphere &gt; Precipitation &gt; Precipitation Amount" units="dBA" />
+          <variable name="DSP/Digital Storm Total Precipitation" vocabulary_name="EARTH SCIENCE &gt; Atmosphere &gt; Precipitation &gt; Precipitation Amount" units="in" />
+          <variable name="NMD/Mesocyclone" vocabulary_name="EARTH SCIENCE &gt; Spectral/Engineering &gt; Radar &gt;" units="" />
+
+          <variable name="N0X/Differential Reflectivity Tilt 1" vocabulary_name="EARTH SCIENCE &gt; Spectral/Engineering &gt; Radar &gt; Radar Reflectivity" units="dB" />
+          <variable name="NAX/Differential Reflectivity Tilt 2" vocabulary_name="EARTH SCIENCE &gt; Spectral/Engineering &gt; Radar &gt; Radar Reflectivity" units="dB" />
+          <variable name="N1X/Differential Reflectivity Tilt 3" vocabulary_name="EARTH SCIENCE &gt; Spectral/Engineering &gt; Radar &gt; Radar Reflectivity" units="dB" />
+          <variable name="NBX/Differential Reflectivity Tilt 4" vocabulary_name="EARTH SCIENCE &gt; Spectral/Engineering &gt; Radar &gt; Radar Reflectivity" units="dB" />
+          <variable name="N2X/Differential Reflectivity Tilt 5" vocabulary_name="EARTH SCIENCE &gt; Spectral/Engineering &gt; Radar &gt; Radar Reflectivity" units="dB" />
+          <variable name="N3X/Differential Reflectivity Tilt 6" vocabulary_name="EARTH SCIENCE &gt; Spectral/Engineering &gt; Radar &gt; Radar Reflectivity" units="dB" />
+
+          <variable name="N0C/Correlation Coefficient Tilt 1" vocabulary_name="EARTH SCIENCE &gt; Spectral/Engineering &gt; Radar &gt;" units="dimensionless" />
+          <variable name="NAC/Correlation Coefficient Tilt 2" vocabulary_name="EARTH SCIENCE &gt; Spectral/Engineering &gt; Radar &gt;" units="dimensionless" />
+          <variable name="N1C/Correlation Coefficient Tilt 3" vocabulary_name="EARTH SCIENCE &gt; Spectral/Engineering &gt; Radar &gt;" units="dimensionless" />
+          <variable name="NBC/Correlation Coefficient Tilt 4" vocabulary_name="EARTH SCIENCE &gt; Spectral/Engineering &gt; Radar &gt;" units="dimensionless" />
+          <variable name="N2C/Correlation Coefficient Tilt 5" vocabulary_name="EARTH SCIENCE &gt; Spectral/Engineering &gt; Radar &gt;" units="dimensionless" />
+          <variable name="N3C/Correlation Coefficient Tilt 6" vocabulary_name="EARTH SCIENCE &gt; Spectral/Engineering &gt; Radar &gt;" units="dimensionless" />
+
+          <variable name="N0K/Specific Differential Phase Tilt 1" vocabulary_name="EARTH SCIENCE &gt; Spectral/Engineering &gt; Radar &gt;" units="deg/km" />
+          <variable name="NAK/Specific Differential Phase Tilt 2" vocabulary_name="EARTH SCIENCE &gt; Spectral/Engineering &gt; Radar &gt;" units="deg/km" />
+          <variable name="N1K/Specific Differential Phase Tilt 3" vocabulary_name="EARTH SCIENCE &gt; Spectral/Engineering &gt; Radar &gt;" units="deg/km" />
+          <variable name="NBK/Specific Differential Phase Tilt 4" vocabulary_name="EARTH SCIENCE &gt; Spectral/Engineering &gt; Radar &gt;" units="deg/km" />
+          <variable name="N2K/Specific Differential Phase Tilt 5" vocabulary_name="EARTH SCIENCE &gt; Spectral/Engineering &gt; Radar &gt;" units="deg/km" />
+          <variable name="N3K/Specific Differential Phase Tilt 6" vocabulary_name="EARTH SCIENCE &gt; Spectral/Engineering &gt; Radar &gt;" units="deg/km" />
+
+          <variable name="N0H/Hydrometeor Classification Tilt 1" vocabulary_name="EARTH SCIENCE &gt; Spectral/Engineering &gt; Radar &gt;" units="" />
+          <variable name="NAH/Hydrometeor Classification Tilt 2" vocabulary_name="EARTH SCIENCE &gt; Spectral/Engineering &gt; Radar &gt;" units="" />
+          <variable name="N1H/Hydrometeor Classification Tilt 3" vocabulary_name="EARTH SCIENCE &gt; Spectral/Engineering &gt; Radar &gt;" units="" />
+          <variable name="NBH/Hydrometeor Classification Tilt 4" vocabulary_name="EARTH SCIENCE &gt; Spectral/Engineering &gt; Radar &gt;" units="" />
+          <variable name="N2H/Hydrometeor Classification Tilt 5" vocabulary_name="EARTH SCIENCE &gt; Spectral/Engineering &gt; Radar &gt;" units="" />
+          <variable name="N3H/Hydrometeor Classification Tilt 6" vocabulary_name="EARTH SCIENCE &gt; Spectral/Engineering &gt; Radar &gt;" units="" />
+
+          <variable name="N0M/Melting Layer Tilt 1" vocabulary_name="EARTH SCIENCE &gt; Atmosphere &gt; Precipitation" units="1000 feet" />
+          <variable name="NAM/Melting Layer Tilt 2" vocabulary_name="EARTH SCIENCE &gt; Atmosphere &gt; Precipitation" units="1000 feet" />
+          <variable name="N1M/Melting Layer Tilt 3" vocabulary_name="EARTH SCIENCE &gt; Atmosphere &gt; Precipitation" units="1000 feet" />
+          <variable name="NBM/Melting Layer Tilt 4" vocabulary_name="EARTH SCIENCE &gt; Atmosphere &gt; Precipitation" units="1000 feet" />
+          <variable name="N2M/Melting Layer Tilt 5" vocabulary_name="EARTH SCIENCE &gt; Atmosphere &gt; Precipitation" units="1000 feet" />
+          <variable name="N3M/Melting Layer Tilt 6" vocabulary_name="EARTH SCIENCE &gt; Atmosphere &gt; Precipitation" units="1000 feet" />
+
+          <variable name="DPR/Digital Instantaneous Precipitation Rate" vocabulary_name="EARTH SCIENCE &gt; Atmosphere &gt; Precipitation &gt; Precipitation Rate" units="in/hr" />
+          <variable name="HHC/Hybrid Hydrometeor Classification" vocabulary_name="EARTH SCIENCE &gt; Spectral/Engineering &gt; Radar &gt;" units="" />
+          <variable name="OHA/One Hour Accumulation" vocabulary_name="EARTH SCIENCE &gt; Atmosphere &gt; Precipitation &gt; Precipitation Amount &gt; Hourly Precipitation Amount" units="in" />
+          <variable name="DAA/Digital Accumulation Array" vocabulary_name="EARTH SCIENCE &gt; Atmosphere &gt; Precipitation &gt; Precipitation Amount" units="in" />
+          <variable name="PTA/Storm Total Accumulation" vocabulary_name="EARTH SCIENCE &gt; Atmosphere &gt; Precipitation &gt; Precipitation Amount" units="in" />
+          <variable name="DTA/Digital Storm Total Accumulation" vocabulary_name="EARTH SCIENCE &gt; Atmosphere &gt; Precipitation &gt; Precipitation Amount" units="in" />
+          <variable name="DU3/Digital 3-hour Accumulation" vocabulary_name="EARTH SCIENCE &gt; Atmosphere &gt; Precipitation &gt; Precipitation Amount &gt; 3 and 6 Hour Precipitation Amount" units="in" />
+          <variable name="DU6/Digital 24-hour Accumulation" vocabulary_name="EARTH SCIENCE &gt; Atmosphere &gt; Precipitation &gt; Precipitation Amount &gt; 24 Hour Precipitation Amount" units="in" />
+          <variable name="DOD/Digital One-Hour Difference Accumulation" vocabulary_name="EARTH SCIENCE &gt; Atmosphere &gt; Precipitation &gt; Precipitation Anomalies" units="in" />
+          <variable name="DSD/Digital Storm Total Difference Accumulation" vocabulary_name="EARTH SCIENCE &gt; Atmosphere &gt; Precipitation &gt; Precipitation Anomalies" units="in" />
+
+        </variables>
+      </metadata>
+    </datasetScan>
+
+    <datasetScan name="S3 NEXRAD Level III Radar from IDD" collectionType="TimeSeries" ID="s3/nexrad/level3/IDD" path="s3/nexrad/level3/IDD"
+                 location="cdms3:thredds-test-data?radar/level3/nexrad/#delimiter=/">
       <radarCollection layout="VARIABLE/STATION/yyyyMMdd" dateRegex="(\d{8}_\d{4})\.nids$" dateFormat="yyyyMMdd_HHmm" />
       <metadata inherited="true">
         <dataType>Radial</dataType>


### PR DESCRIPTION
Resolves https://github.com/Unidata/tds/issues/361 and depends on functionality added in https://github.com/Unidata/netcdf-java/pull/1388.

Make RadarServer code work for S3 datasets by:
- Using `MFile` interface (which has implementations for local and s3 files) instead of a `Path` object
- Using `MController` interface to loop through directories/files (which has implementations for local and S3 files) instead of a `DirectoryStream`

Tests:
- Duplicates test catalog entry for radar data but pointing to s3 version
- Adds s3 test cases to radar server tests

