### PR TITLE
Revert change to database path

### DIFF
--- a/tds/src/main/java/thredds/server/config/TdsInit.java
+++ b/tds/src/main/java/thredds/server/config/TdsInit.java
@@ -149,7 +149,8 @@ public class TdsInit implements ApplicationListener<ContextRefreshedEvent>, Disp
           configCatalogInitializer.init(readMode, (PreferencesExt) mainPrefs.node("configCatalog"));
 
           // set epsg database location for edal-java (comes from apache-sis)
-          EpsgDatabasePath.DB_PATH = (new File(tdsContext.getThreddsDirectory(), "/cache/edal-java/epsg/").getPath());
+          EpsgDatabasePath.DB_PATH =
+              (new File(tdsContext.getThreddsDirectory(), "/cache/edal-java/epsg/").toURI().toString());
           startupLog.info("EPSG database path: " + EpsgDatabasePath.DB_PATH);
           startupLog.info("TdsInit complete");
         }


### PR DESCRIPTION
Address https://github.com/Unidata/tds/issues/455. Revert change (https://github.com/Unidata/tds/pull/457) in path for loading the EPSG database. The change was needed due to a change in edal-java, which has now been reverted: https://github.com/Unidata/edal-java/pull/13. 