### PR TITLE
github changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,7 +15,7 @@
 # users just like we do for commit author emails.
 # docs/*  docs@example.com
 
-* @tdrwenski
+* @lesserwhirls
 
 #####################
 # top level modules #
@@ -26,16 +26,16 @@
 # classpath / not module specific matches #
 ###########################################
 
-**/thredds/server/radarServer2/** @dopplershift
+**/thredds/server/radarServer2/** @dopplershift @lesserwhirls
 
-**/opendap/** @DennisHeimbigner @tdrwenski
-**/dap4/** @DennisHeimbigner @tdrwenski
+**/opendap/** @DennisHeimbigner @lesserwhirls
+**/dap4/** @DennisHeimbigner @lesserwhirls
 
 ######################
 # general file types #
 ######################
 
-*.py @dopplershift
+*.py @dopplershift @lesserwhirls
 
 ####################
 # individual files #

--- a/.github/workflows/deps.yml
+++ b/.github/workflows/deps.yml
@@ -7,9 +7,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: '17'
       - name: Build with Gradle (refresh dependencies)
         run: ./gradlew clean classes testClasses assemble --refresh-dependencies

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,16 +11,19 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Setup Java 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
-          distribution: 'zulu'
+          distribution: 'temurin'
           java-version: '17'
       - name: Cache Gradle packages
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
-          restore-keys: ${{ runner.os }}-gradle
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
       - name: Build docs using Gradle
         run: './gradlew :docs:build'
       - name: Upload a preview of the rendered html

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -7,15 +7,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: '17'
       - name: Cache Gradle packages
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
-          restore-keys: ${{ runner.os }}-gradle
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
       - name: Code Style Check with Gradle and Spotless
         run: ./gradlew clean spotlessCheck


### PR DESCRIPTION
GitHub is closing down actions/cache v1 and v2, and this PR bumps us to the latest (v4). This also bumps actions/setup-java to the latest version (v4). Additionally, update the CODEOWNERS file.