### PR TITLE
URL Scheme fixes

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 1998-2018, University Corporation for Atmospheric Research/Unidata
+Copyright (c) 1998-2025, University Corporation for Atmospheric Research/Unidata
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/tds/src/integrationTests/java/thredds/server/cdmr/TestCdmRemoteCompareHeadersP.java
+++ b/tds/src/integrationTests/java/thredds/server/cdmr/TestCdmRemoteCompareHeadersP.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998-2021 University Corporation for Atmospheric Research/Unidata
+ * Copyright (c) 1998-2025 University Corporation for Atmospheric Research/Unidata
  * See LICENSE for license information.
  */
 
@@ -76,7 +76,7 @@ public class TestCdmRemoteCompareHeadersP {
     addFromScan(result, contentRoot + "/grib2/", new FileFilter() {
       public boolean accept(File pathname) {
         String name = pathname.getName();
-        return !name.contains(".gbx") && !name.contains(".ncx");
+        return !name.contains(".gbx") && !name.contains(".ncx") && !name.endsWith("README");
       }
     });
     addFromScan(result, contentRoot + "/gini/", new SuffixFileFilter(".gini"));

--- a/tds/src/main/webapp/WEB-INF/applicationContext.xml
+++ b/tds/src/main/webapp/WEB-INF/applicationContext.xml
@@ -110,10 +110,18 @@
         <constructor-arg type="int" value="1"/>
     </bean>
 
-    <!-- Restricted Access (using container managed security, eg Tomcat, or CAMS) -->
+    <!-- Restricted Access (using container managed security, eg Tomcat, or CAMS)
+    Changes as of 5.7:
+    By default, the TDS will use the incoming request to determine whether SSL
+    is in use. However, if you need to override this behavior, you may change
+    these values. Note, useSSL is only considered if sslPort is not -1. That is,
+    if you want useSSL to be false, you need to change the value of sslPort to
+    a value other than -1 even though it will not be used in constructing the
+    authentication endpoint used by the redirect.
+    -->
     <bean id="restrictedDatasetAuthorizer" class="thredds.servlet.restrict.TomcatAuthorizer">
         <property name="useSSL" value="false"/>
-        <property name="sslPort" value="8443"/>
+        <property name="sslPort" value="-1"/>
     </bean>
 
     <!-- ESGF


### PR DESCRIPTION
Use incoming request to determine the dap4 and tomcat authentication URL scheme (allowing an override for the latter). Also, fix an integration test such that it does not try to read a README file as a GRIB2 file, and update year in license.