### PR TITLE
Distribute threddsIso with thredds.war

### DIFF
--- a/docs/adminguide/src/site/pages/tds_tutorial/metadata/IsoMetadataRef.md
+++ b/docs/adminguide/src/site/pages/tds_tutorial/metadata/IsoMetadataRef.md
@@ -14,7 +14,7 @@ The TDS distribution includes the [ncISO](https://www.ngdc.noaa.gov/wiki/index.p
 * `ISO`: an ISO 19115 metadata representation of the dataset; and
 * `UDDC`: an evaluation of how well the metadata contained in the dataset conforms to the [NetCDF Attribute Convention for Data Discovery (NACDD)](https://www.unidata.ucar.edu/software/netcdf-java/v4.6/metadata/DataDiscoveryAttConvention.html){:target="_blank"} (see the [NOAA/EDM page on NACDD](http://wiki.esipfed.org/index.php/Category:Attribute_Conventions_Dataset_Discovery){:target="_blank"}). 
 
-## Enabling `ncISO` Services
+## Enabling ncISO Services
 
 The `ncISO` services are enabled by default. 
 These services can be disabled for locally served datasets by including the following in the `threddsConfig.xml` file:

--- a/docs/adminguide/src/site/pages/thredds/ThreddsConfigRef.md
+++ b/docs/adminguide/src/site/pages/thredds/ThreddsConfigRef.md
@@ -309,14 +309,13 @@ Here is the description of the various options:
 
 ### ncISO Services
 
-By default, these services are disabled.
-Provided that you have added the [ncISO plugin](adding_ogc_iso_services.html#nciso-configuration), these services can be enabled by including the following in the `threddsConfig.xml` file:
+By default, these services are enabled, and can be disabled by including the following in the `threddsConfig.xml` file:
 
 ~~~xml
 <NCISO>
-  <ncmlAllow>true</ncmlAllow>
-  <uddcAllow>true</uddcAllow>
-  <isoAllow>true</isoAllow>
+  <ncmlAllow>false</ncmlAllow>
+  <uddcAllow>false</uddcAllow>
+  <isoAllow>false</isoAllow>
 </NCISO>
 ~~~
 

--- a/docs/devguide/src/site/pages/tds_tutorial/metadata/IsoMetadataRef.md
+++ b/docs/devguide/src/site/pages/tds_tutorial/metadata/IsoMetadataRef.md
@@ -14,7 +14,7 @@ The TDS distribution includes the [ncISO](https://www.ngdc.noaa.gov/wiki/index.p
 * `ISO`: an ISO 19115 metadata representation of the dataset; and
 * `UDDC`: an evaluation of how well the metadata contained in the dataset conforms to the [NetCDF Attribute Convention for Data Discovery (NACDD)](https://www.unidata.ucar.edu/software/netcdf-java/v4.6/metadata/DataDiscoveryAttConvention.html){:target="_blank"} (see the [NOAA/EDM page on NACDD](http://wiki.esipfed.org/index.php/Category:Attribute_Conventions_Dataset_Discovery){:target="_blank"}). 
 
-## Enabling `ncISO` Services
+## Enabling ncISO Services
 
 The `ncISO` services are enabled by default. 
 These services can be disabled for locally served datasets by including the following in the `threddsConfig.xml` file:

--- a/docs/devguide/src/site/pages/tds_tutorial/tds_configuration/AddingOgcIsoServices.md
+++ b/docs/devguide/src/site/pages/tds_tutorial/tds_configuration/AddingOgcIsoServices.md
@@ -9,7 +9,7 @@ permalink: adding_ogc_iso_services.html
 ## Configure TDS To Allow WCS, WMS, and `ncISO` Access
 
 Out of the box, the TDS distribution will have `WCS`, `WMS`, and `ncISO` enabled.
-If you do not wish to use these services, they must be explicitly allowed in the `threddsConfig.xml` file.
+If you do not wish to use these services, they must be explicitly disabled in the `threddsConfig.xml` file.
 Please see the  [threddsConfig.xml file](tds_config_ref.html#wcs-service) documentation for information on how to disable these services.
 The default `threddsConfig.xml` file (which should now be in your `${tds.content.root.path}/content/thredds` directory) contains commented out sections for each of these services.
 

--- a/docs/quickstart/src/site/pages/tds_tutorial/metadata/IsoMetadataRef.md
+++ b/docs/quickstart/src/site/pages/tds_tutorial/metadata/IsoMetadataRef.md
@@ -14,9 +14,9 @@ The TDS distribution includes the [ncISO](https://www.ngdc.noaa.gov/wiki/index.p
 * `ISO`: an ISO 19115 metadata representation of the dataset; and
 * `UDDC`: an evaluation of how well the metadata contained in the dataset conforms to the [NetCDF Attribute Convention for Data Discovery (NACDD)](https://www.unidata.ucar.edu/software/netcdf-java/v4.6/metadata/DataDiscoveryAttConvention.html){:target="_blank"} (see the [NOAA/EDM page on NACDD](http://wiki.esipfed.org/index.php/Category:Attribute_Conventions_Dataset_Discovery){:target="_blank"}). 
 
-## Enabling `ncISO` Services
+## Enabling ncISO Services
 
-The `ncISO` services are enabled by default. 
+The `ncISO` services are enabled by default.
 These services can be disabled for locally served datasets by including the following in the `threddsConfig.xml` file:
 
 ~~~xml

--- a/docs/quickstart/src/site/pages/tds_tutorial/production/Upgrade.md
+++ b/docs/quickstart/src/site/pages/tds_tutorial/production/Upgrade.md
@@ -95,11 +95,6 @@ As part of that update, the version of the h2 database, which holds coordinate r
 If you are upgrading from a previous version of TDS 5, you may encounter database incompatibility errors that will prevent startup of the TDS.
 You will need to manually remove the directory `${tds.content.root.path}/hredds/cache/edal-java/epsg/.h2` which contains the previous database files.
 
-### ncISO services
-To use the ncISO services, you must add the `tds-plugin-jar-with-dependencies.jar` artifact to your TDS for TDS versions >= 5.5.
-For TDS versions prior to 5.5 this artifact was included in the TDS war file.
-See [ncISO configuration](adding_ogc_iso_services.html#nciso-configuration) for more details.
-
 ## Java Web Start
 
 Java Web Start has been [deprecated as of Java 9](https://www.oracle.com/technetwork/java/javase/9-deprecated-features-3745636.html#JDK-8184998){:target="_blank"}, and has been removed in [Java 11](https://www.oracle.com/technetwork/java/javase/11-relnote-issues-5012449.html){:target="_blank"}, which is the Long-term Release post-Java 8.

--- a/docs/quickstart/src/site/pages/tds_tutorial/tds_configuration/AddingOgcIsoServices.md
+++ b/docs/quickstart/src/site/pages/tds_tutorial/tds_configuration/AddingOgcIsoServices.md
@@ -9,7 +9,7 @@ permalink: adding_ogc_iso_services.html
 ## Configure TDS To Allow WCS, WMS, and `ncISO` Access
 
 Out of the box, the TDS distribution will have `WCS`, `WMS`, and `ncISO` enabled.
-If you do not wish to use these services, they must be explicitly allowed in the `threddsConfig.xml` file.
+If you do not wish to use these services, they must be explicitly disabled in the `threddsConfig.xml` file.
 Please see the  [threddsConfig.xml file](tds_config_ref.html#wcs-service) documentation for information on how to disable these services.
 The default `threddsConfig.xml` file (which should now be in your `${tds.content.root.path}/content/thredds` directory) contains commented out sections for each of these services.
 

--- a/docs/quickstart/src/site/pages/thredds/ThreddsConfigRef.md
+++ b/docs/quickstart/src/site/pages/thredds/ThreddsConfigRef.md
@@ -309,14 +309,13 @@ Here is the description of the various options:
 
 ### ncISO Services
 
-By default, these services are disabled.
-Provided that you have added the [ncISO plugin](adding_ogc_iso_services.html#nciso-configuration), these services can be enabled by including the following in the `threddsConfig.xml` file:
+By default, these services are enabled, and can be disabled by including the following in the `threddsConfig.xml` file:
 
 ~~~xml
 <NCISO>
-  <ncmlAllow>true</ncmlAllow>
-  <uddcAllow>true</uddcAllow>
-  <isoAllow>true</isoAllow>
+  <ncmlAllow>false</ncmlAllow>
+  <uddcAllow>false</uddcAllow>
+  <isoAllow>false</isoAllow>
 </NCISO>
 ~~~
 

--- a/docs/userguide/src/site/pages/tds_tutorial/metadata/IsoMetadataRef.md
+++ b/docs/userguide/src/site/pages/tds_tutorial/metadata/IsoMetadataRef.md
@@ -17,14 +17,14 @@ The ncISO plugin provides three new services for datasets:
 
 ## Enabling ncISO Services
 
-The ncISO services are disabled by default.
-Provided that you have added the [ncISO plugin](adding_ogc_iso_services.html#nciso-configuration), these services can be enabled for locally served datasets by including the following in the `threddsConfig.xml` file:
+The `ncISO` services are enabled by default.
+These services can be disabled for locally served datasets by including the following in the `threddsConfig.xml` file:
 
 ~~~xml
 <NCISO>
-  <ncmlAllow>true</ncmlAllow>
-  <uddcAllow>true</uddcAllow>
-  <isoAllow>true</isoAllow>
+  <ncmlAllow>false</ncmlAllow>
+  <uddcAllow>false</uddcAllow>
+  <isoAllow>false</isoAllow>
 </NCISO>
 ~~~
 

--- a/docs/userguide/src/site/pages/tds_tutorial/production/Upgrade.md
+++ b/docs/userguide/src/site/pages/tds_tutorial/production/Upgrade.md
@@ -94,11 +94,6 @@ As part of that update, the version of the h2 database, which holds coordinate r
 If you are upgrading from a previous version of TDS 5, you may encounter database incompatibility errors that will prevent startup of the TDS.
 You will need to manually remove the directory `${tds.content.root.path}/hredds/cache/edal-java/epsg/.h2` which contains the previous database files.
 
-### ncISO services
-To use the ncISO services, you must add the `tds-plugin-jar-with-dependencies.jar` artifact to your TDS for TDS versions >= 5.5.
-For TDS versions prior to 5.5 this artifact was included in the TDS war file.
-See [ncISO configuration](adding_ogc_iso_services.html#nciso-configuration) for more details.
-
 ## Java Web Start
 
 Java Web Start has been [deprecated as of Java 9](https://www.oracle.com/technetwork/java/javase/9-deprecated-features-3745636.html#JDK-8184998){:target="_blank"}, and has been removed in [Java 11](https://www.oracle.com/technetwork/java/javase/11-relnote-issues-5012449.html){:target="_blank"}, which is the Long-term Release post-Java 8.

--- a/docs/userguide/src/site/pages/tds_tutorial/tds_configuration/AddingOgcIsoServices.md
+++ b/docs/userguide/src/site/pages/tds_tutorial/tds_configuration/AddingOgcIsoServices.md
@@ -8,9 +8,8 @@ permalink: adding_ogc_iso_services.html
 
 ## Configure TDS To Allow WCS, WMS, and ncISO Access
 
-Out of the box, the TDS distribution will have `WCS` and `WMS` enabled.
-If you do not wish to use these services, they must be explicitly allowed in the `threddsConfig.xml` file.
-The ncISO services are disabled by default but can be enabled by adding the plugin and updating the `threddsConfig.xml` file.
+Out of the box, the TDS distribution will have `WCS`, `WMS`, and `ncISO` enabled.
+If you do not wish to use these services, they must be explicitly disabled in the `threddsConfig.xml` file.
 Please see the [threddsConfig.xml file](tds_config_ref.html#wcs-service) documentation for information on how to enable/disable these services.
 The default `threddsConfig.xml` file (which should now be in your `${tds.content.root.path}/content/thredds` directory) contains commented out sections for each of these services.
 
@@ -44,13 +43,6 @@ More details are available in the `WMS` section of the [threddsConfig.xml file](
 
 ### ncISO Configuration
 
-#### Adding the plugin
-To use the ncISO services, you must add the `tds-plugin-jar-with-dependencies.jar` artifact to your TDS for TDS versions >= 5.5.
-For TDS versions prior to 5.5 this artifact was included in the TDS war file.
-To see which versions of the plugin are compatible with your TDS version see the table [here](https://github.com/Unidata/threddsIso).
-The plugin can be downloaded on the [TDS downloads page](https://downloads.unidata.ucar.edu/tds/){:target="_blank"}.
-The downloaded ncISO plugin jar file should be placed in your `${tomcat_home}/webapps/thredds/WEB-INF/lib/` directory.
-
 ##### Customizing the xsl
 If you need to customize the ISO output by updating the default `UnidataDD2MI.xsl`, you must place your custom version
 in `${tomcat_home}/webapps/thredds/WEB-INF/classes/resources/xsl/nciso/UnidataDD2MI.xsl`. For example:
@@ -66,15 +58,13 @@ The following section in the `threddsConfig.xml` file controls the ncISO service
 
 ~~~xml
 <NCISO>
-  <ncmlAllow>false</ncmlAllow>
-  <uddcAllow>false</uddcAllow>
-  <isoAllow>false</isoAllow>
+  <ncmlAllow>true</ncmlAllow>
+  <uddcAllow>true</uddcAllow>
+  <isoAllow>true</isoAllow>
 </NCISO>
 ~~~
 
 Each `*Allow` element allows one of the three ncISO services.
-
-After adding the ncISO plugin and updating your `threddsConfig.xml`, the TDS should be restarted.
 
 ### Adding `WCS` And `WMS` Services
 

--- a/docs/userguide/src/site/pages/thredds/ThreddsConfigRef.md
+++ b/docs/userguide/src/site/pages/thredds/ThreddsConfigRef.md
@@ -309,14 +309,13 @@ Here is the description of the various options:
 
 ### ncISO Services
 
-By default, these services are disabled.
-Provided that you have added the [ncISO plugin](adding_ogc_iso_services.html#nciso-configuration), these services can be enabled by including the following in the `threddsConfig.xml` file:
+By default, these services are enabled, and can be disabled by including the following in the `threddsConfig.xml` file:
 
 ~~~xml
 <NCISO>
-  <ncmlAllow>true</ncmlAllow>
-  <uddcAllow>true</uddcAllow>
-  <isoAllow>true</isoAllow>
+  <ncmlAllow>false</ncmlAllow>
+  <uddcAllow>false</uddcAllow>
+  <isoAllow>false</isoAllow>
 </NCISO>
 ~~~
 

--- a/gradle/any/shared-mvn-coords.gradle
+++ b/gradle/any/shared-mvn-coords.gradle
@@ -20,6 +20,7 @@ ext {
   depVersion = [:]
   depVersion.slf4j = '1.7.28'
   depVersion.gwt = '2.8.2'
+  // needs to match version used in threddsIso
   depVersion.jaxen = '1.1.6'
   depVersion.netcdfJava = '5.8.0'
   // gradle seems to have issues with the compileOnly configuration, so we need to provide the full maven

--- a/tds/build.gradle
+++ b/tds/build.gradle
@@ -36,6 +36,9 @@ dependencies {
   implementation 'edu.ucar:dap4'
   implementation project(':dap4:d4servlet')
 
+  // threddsIso
+  implementation 'EDS:nciso-common:2.4.7'
+
   // Server stuff
   providedCompile "jakarta.servlet:jakarta.servlet-api:${depVersion.jakartaServletApi}"
   runtimeOnly "jakarta.servlet.jsp.jstl:jakarta.servlet.jsp.jstl-api"

--- a/tds/src/integrationTests/java/thredds/server/catalog/TestServiceDefaults.java
+++ b/tds/src/integrationTests/java/thredds/server/catalog/TestServiceDefaults.java
@@ -41,7 +41,7 @@ public class TestServiceDefaults {
     Service s = ds.getServiceDefault();
     Assert.assertNotNull(s);
     Assert.assertTrue(s.getType() == ServiceType.Compound);
-    Assert.assertEquals(7, s.getNestedServices().size());
+    Assert.assertEquals(10, s.getNestedServices().size());
   }
 
   @Test
@@ -53,7 +53,7 @@ public class TestServiceDefaults {
 
     Service service = ds.getServiceDefault();
     assertThat(service.getType()).isEqualTo(ServiceType.Compound);
-    assertThat(service.getNestedServices().size()).isEqualTo(7);
+    assertThat(service.getNestedServices().size()).isEqualTo(10);
   }
 
   // Relies on:
@@ -76,7 +76,7 @@ public class TestServiceDefaults {
     Assert.assertNotNull(s);
 
     Assert.assertTrue(s.getType() == ServiceType.Compound);
-    Assert.assertEquals(7, s.getNestedServices().size());
+    Assert.assertEquals(10, s.getNestedServices().size());
   }
 
   @Test
@@ -86,7 +86,7 @@ public class TestServiceDefaults {
     Assert.assertEquals(3, cat.getServices().size());
 
     check(cat, "all", 11);
-    check(cat, "GridServices", 7);
+    check(cat, "GridServices", 10);
     check(cat, "opendapOnly", 1);
 
     Service localServices = cat.findService("opendapOnly");

--- a/tds/src/integrationTests/java/thredds/server/catalog/TestTdsGrib.java
+++ b/tds/src/integrationTests/java/thredds/server/catalog/TestTdsGrib.java
@@ -89,7 +89,7 @@ public class TestTdsGrib {
 
     Dataset full = cat.findDatasetByID("HRRR/analysis/TP");
     Assert.assertNotNull(full);
-    Assert.assertEquals(6, full.getAccess().size());
+    Assert.assertEquals(9, full.getAccess().size());
     Assert.assertNull(full.getAccess(ServiceType.Resolver));
     Assert.assertNull(full.getAccess(ServiceType.HTTPServer));
     Assert.assertNotNull(full.getAccess(ServiceType.CdmRemote));
@@ -170,7 +170,7 @@ public class TestTdsGrib {
   public void testDefaultGribServices() throws IOException {
     String catalog = "/catalog/grib.v5/NDFD/CONUS_5km/catalog.xml"; // no service name, should use GRID default
     Catalog cat = TdsLocalCatalog.open(catalog);
-    testCat(cat, 6, true, null, 0);
+    testCat(cat, 9, true, null, 0);
 
     Dataset top = cat.getDatasetsLocal().get(0);
     Assert.assertTrue(!top.hasAccess());
@@ -181,7 +181,7 @@ public class TestTdsGrib {
       } else {
         CatalogRef catref = (CatalogRef) ds;
         Catalog cat2 = TdsLocalCatalog.openFromURI(catref.getURI());
-        testCat(cat2, 6, false, "GridServices", 7);
+        testCat(cat2, 9, false, "GridServices", 10);
         break;
       }
     }

--- a/tds/src/main/java/thredds/server/metadata/controller/AbstractMetadataController.java
+++ b/tds/src/main/java/thredds/server/metadata/controller/AbstractMetadataController.java
@@ -1,0 +1,77 @@
+package thredds.server.metadata.controller;
+
+import java.io.IOException;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.web.context.ServletContextAware;
+import thredds.client.catalog.Dataset;
+import thredds.core.TdsRequestedDataset;
+
+public abstract class AbstractMetadataController implements ServletContextAware, IMetadataContoller {
+  private static org.slf4j.Logger _log = org.slf4j.LoggerFactory.getLogger(AbstractMetadataController.class);
+
+  protected static org.slf4j.Logger _logServerStartup = org.slf4j.LoggerFactory.getLogger("serverStartup");
+
+  protected boolean _allow = false;
+  protected String _metadataServiceType = "";
+  protected String _servletPath = "";
+
+  protected ServletContext sc;
+
+  public void setServletContext(ServletContext sc) {
+    this.sc = sc;
+  }
+
+  protected void isAllowed(final boolean allow, final String metadataServiceType, final HttpServletResponse res)
+      throws Exception {
+    // Check whether TDS is configured to support service.
+    if (!allow) {
+      res.sendError(HttpServletResponse.SC_FORBIDDEN, metadataServiceType + " service not supported");
+      return;
+    }
+  }
+
+  protected void returnError(final String message, final String metadataServiceType, final HttpServletResponse res)
+      throws Exception {
+    res.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, metadataServiceType + " service failed. " + message);
+    return;
+  }
+
+  /**
+   * All metadata controllers must implement a handleMetadataRequest method.
+   *
+   * @param req incoming url request
+   * @param res outgoing web based response
+   * @throws ServletException if ServletException occurred
+   * @throws IOException if IOException occurred
+   */
+  public void handleMetadataRequest(final HttpServletRequest req, final HttpServletResponse res)
+      throws ServletException, IOException {}
+
+  /**
+   * Get the THREDDS dataset object
+   * where catalogString and dataset are passed in the request string
+   *
+   * @param req incoming url request
+   */
+  protected Dataset getThreddsDataset(final HttpServletRequest req, final HttpServletResponse res) {
+    try {
+      return (Dataset) TdsRequestedDataset.getGridDataset(req, res, null);
+    } catch (IOException e) {
+      _log.error("IOException while trying to get GridDataset:\n" + e.getLocalizedMessage());
+      return null;
+    }
+  }
+
+  protected abstract String getPath();
+
+  protected String getInfoPath(HttpServletRequest req) {
+    String servletPath = req.getServletPath();
+    String pathInfo = servletPath.substring(getPath().length(), servletPath.length());
+    return pathInfo;
+  }
+
+
+}

--- a/tds/src/main/java/thredds/server/metadata/controller/IMetadataContoller.java
+++ b/tds/src/main/java/thredds/server/metadata/controller/IMetadataContoller.java
@@ -1,0 +1,55 @@
+/*
+ * Access and use of this software shall impose the following
+ * obligations and understandings on the user. The user is granted the
+ * right, without any fee or cost, to use, copy, modify, alter, enhance
+ * and distribute this software, and any derivative works thereof, and
+ * its supporting documentation for any purpose whatsoever, provided
+ * that this entire notice appears in all copies of the software,
+ * derivative works and supporting documentation. Further, the user
+ * agrees to credit NOAA/NGDC in any publications that result from
+ * the use of this software or in any product that includes this
+ * software. The names NOAA/NGDC, however, may not be used
+ * in any advertising or publicity to endorse or promote any products
+ * or commercial entity unless specific written permission is obtained
+ * from NOAA/NGDC. The user also understands that NOAA/NGDC
+ * is not obligated to provide the user with any support, consulting,
+ * training or assistance of any kind with regard to the use, operation
+ * and performance of this software nor to provide the user with any
+ * updates, revisions, new versions or "bug fixes".
+ *
+ * THIS SOFTWARE IS PROVIDED BY NOAA/NGDC "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL NOAA/NGDC BE LIABLE FOR ANY SPECIAL,
+ * INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER
+ * RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF
+ * CONTRACT, NEGLIGENCE OR OTHER TORTUOUS ACTION, ARISING OUT OF OR IN
+ * CONNECTION WITH THE ACCESS, USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+package thredds.server.metadata.controller;
+
+import java.io.IOException;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+/**
+ * IMetadataContoller
+ * Author: dneufeld Date: Jul 6, 2010
+ * <p/>
+ */
+public interface IMetadataContoller {
+
+  /**
+   * All metadata controllers must implement a handleMetadataRequest method.
+   * 
+   * @param req incoming url request
+   * @param res outgoing web based response
+   * @throws ServletException if ServletException occurred
+   * @throws IOException if IOException occurred
+   */
+  void handleMetadataRequest(final HttpServletRequest req, final HttpServletResponse res)
+      throws ServletException, IOException;
+
+}

--- a/tds/src/main/java/thredds/server/metadata/controller/IsoController.java
+++ b/tds/src/main/java/thredds/server/metadata/controller/IsoController.java
@@ -1,0 +1,149 @@
+/*
+ * Access and use of this software shall impose the following
+ * obligations and understandings on the user. The user is granted the
+ * right, without any fee or cost, to use, copy, modify, alter, enhance
+ * and distribute this software, and any derivative works thereof, and
+ * its supporting documentation for any purpose whatsoever, provided
+ * that this entire notice appears in all copies of the software,
+ * derivative works and supporting documentation. Further, the user
+ * agrees to credit NOAA/NGDC in any publications that result from
+ * the use of this software or in any product that includes this
+ * software. The names NOAA/NGDC, however, may not be used
+ * in any advertising or publicity to endorse or promote any products
+ * or commercial entity unless specific written permission is obtained
+ * from NOAA/NGDC. The user also understands that NOAA/NGDC
+ * is not obligated to provide the user with any support, consulting,
+ * training or assistance of any kind with regard to the use, operation
+ * and performance of this software nor to provide the user with any
+ * updates, revisions, new versions or "bug fixes".
+ *
+ * THIS SOFTWARE IS PROVIDED BY NOAA/NGDC "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL NOAA/NGDC BE LIABLE FOR ANY SPECIAL,
+ * INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER
+ * RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF
+ * CONTRACT, NEGLIGENCE OR OTHER TORTUOUS ACTION, ARISING OUT OF OR IN
+ * CONNECTION WITH THE ACCESS, USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+package thredds.server.metadata.controller;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.StringWriter;
+import java.io.Writer;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import thredds.client.catalog.Dataset;
+import thredds.core.StandardService;
+import thredds.server.metadata.nciso.exception.ThreddsUtilitiesException;
+import thredds.server.metadata.service.EnhancedMetadataService;
+import thredds.server.metadata.util.DatasetHandlerAdapter;
+import thredds.server.metadata.nciso.util.ThreddsTranslatorUtil;
+import thredds.core.AllowedServices;
+import thredds.util.ContentType;
+import ucar.nc2.dataset.NetcdfDataset;
+import ucar.nc2.dataset.NetcdfDatasets;
+
+/**
+ * Controller for ISO service
+ * Author: dneufeld Date: Jul 7, 2010
+ * <p/>
+ */
+@Controller
+@RequestMapping("/iso/")
+public class IsoController extends AbstractMetadataController {
+  private static org.slf4j.Logger _log = org.slf4j.LoggerFactory.getLogger(IsoController.class);
+  private static final String xslFile = "nciso/UnidataDD2MI.xsl";
+
+  @Autowired
+  private AllowedServices as;
+
+  protected String getPath() {
+    return _metadataServiceType + "/";
+  }
+
+  @EventListener
+  public void init(ContextRefreshedEvent event) throws ServletException {
+    if (event.getApplicationContext().getDisplayName().equals("Root WebApplicationContext")) {
+      _allow = as.isAllowed(StandardService.iso);
+      _metadataServiceType = "ISO";
+      _servletPath = "/iso";
+      _logServerStartup.info("Metadata ISO - initialization start");
+      _logServerStartup.info("NCISO.isoAllow = " + _allow);
+    }
+  }
+
+  public void destroy() {
+    NetcdfDatasets.shutdown();
+    _logServerStartup.info("Metadata ISO - destroy done");
+  }
+
+  /**
+   * Generate ISO 19115 metadata for the underlying NetcdfDataset
+   * 
+   * @param req incoming url request
+   * @param res outgoing web based response
+   * @throws ServletException if ServletException occurred
+   * @throws IOException if IOException occurred
+   */
+  @RequestMapping(value = "**", params = {})
+  public void handleMetadataRequest(final HttpServletRequest req, final HttpServletResponse res)
+      throws ServletException, IOException {
+    _log.info("Handling ISO metadata request.");
+
+    NetcdfDataset netCdfDataset = null;
+
+    try {
+      // If service not allowed, respond accordingly (403);
+      isAllowed(as.isAllowed(StandardService.iso), _metadataServiceType, res);
+      res.setContentType(ContentType.xml.getContentHeader());
+      netCdfDataset = DatasetHandlerAdapter.openDataset(req, res, getInfoPath(req));
+      if (netCdfDataset == null) {
+        res.sendError(HttpServletResponse.SC_NOT_FOUND, "ThreddsIso Extension: Requested resource not found.");
+      } else {
+        Writer writer = new StringWriter();
+        // Get Thredds level metadata if it exists
+        Dataset ids = this.getThreddsDataset(req, res);
+
+        // Enhance with file and dataset level metadata
+        EnhancedMetadataService.enhance(netCdfDataset, ids, writer);
+
+        String ncml = writer.toString();
+        writer.flush();
+        writer.close();
+        InputStream is = new ByteArrayInputStream(ncml.getBytes("UTF-8"));
+
+        ThreddsTranslatorUtil.transform(xslFile, is, res.getWriter());
+        res.getWriter().flush();
+      }
+    } catch (ThreddsUtilitiesException tue) {
+      String errMsg = "Error in " + _metadataServiceType + ": " + req.getQueryString();
+      _log.error(errMsg, tue);
+      try {
+        this.returnError(errMsg, _metadataServiceType, res);
+      } catch (Exception fe) {
+      }
+    } catch (Exception e) {
+      String errMsg = "Error in " + _metadataServiceType + ": " + req.getQueryString();
+      _log.error(errMsg, e);
+      try {
+        this.returnError(errMsg, _metadataServiceType, res);
+      } catch (Exception fe) {
+      }
+
+    } finally {
+      DatasetHandlerAdapter.closeDataset(netCdfDataset);
+    }
+
+  }
+
+}

--- a/tds/src/main/java/thredds/server/metadata/controller/NcmlController.java
+++ b/tds/src/main/java/thredds/server/metadata/controller/NcmlController.java
@@ -1,0 +1,132 @@
+/*
+ * Access and use of this software shall impose the following
+ * obligations and understandings on the user. The user is granted the
+ * right, without any fee or cost, to use, copy, modify, alter, enhance
+ * and distribute this software, and any derivative works thereof, and
+ * its supporting documentation for any purpose whatsoever, provided
+ * that this entire notice appears in all copies of the software,
+ * derivative works and supporting documentation. Further, the user
+ * agrees to credit NOAA/NGDC in any publications that result from
+ * the use of this software or in any product that includes this
+ * software. The names NOAA/NGDC, however, may not be used
+ * in any advertising or publicity to endorse or promote any products
+ * or commercial entity unless specific written permission is obtained
+ * from NOAA/NGDC. The user also understands that NOAA/NGDC
+ * is not obligated to provide the user with any support, consulting,
+ * training or assistance of any kind with regard to the use, operation
+ * and performance of this software nor to provide the user with any
+ * updates, revisions, new versions or "bug fixes".
+ *
+ * THIS SOFTWARE IS PROVIDED BY NOAA/NGDC "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL NOAA/NGDC BE LIABLE FOR ANY SPECIAL,
+ * INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER
+ * RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF
+ * CONTRACT, NEGLIGENCE OR OTHER TORTUOUS ACTION, ARISING OUT OF OR IN
+ * CONNECTION WITH THE ACCESS, USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+package thredds.server.metadata.controller;
+
+import java.io.IOException;
+import java.io.Writer;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import thredds.client.catalog.Dataset;
+import thredds.core.AllowedServices;
+import thredds.core.StandardService;
+import thredds.server.metadata.service.EnhancedMetadataService;
+import thredds.server.metadata.util.DatasetHandlerAdapter;
+import thredds.util.ContentType;
+import ucar.nc2.dataset.NetcdfDataset;
+import ucar.nc2.dataset.NetcdfDatasets;
+
+/**
+ * Controller for NCML service
+ * Author: dneufeld Date: Jul 7, 2010
+ * <p/>
+ */
+@Controller
+@RequestMapping("/ncml/")
+public class NcmlController extends AbstractMetadataController {
+  private static org.slf4j.Logger _log = org.slf4j.LoggerFactory.getLogger(NcmlController.class);
+
+  @Autowired
+  private AllowedServices as;
+
+  protected String getPath() {
+    return _metadataServiceType + "/";
+  }
+
+  @EventListener
+  public void init(ContextRefreshedEvent event) throws ServletException {
+    if (event.getApplicationContext().getDisplayName().equals("Root WebApplicationContext")) {
+      _allow = as.isAllowed(StandardService.iso_ncml);
+      _metadataServiceType = "NCML";
+      _servletPath = "/ncml";
+      _logServerStartup.info("Metadata NCML - initialization start");
+      _logServerStartup.info("NCISO.ncmlAllow = " + _allow);
+    }
+  }
+
+  public void destroy() {
+    NetcdfDatasets.shutdown();
+    _logServerStartup.info("Metadata NCML - destroy done");
+  }
+
+  /**
+   * Generate NCML for the underlying NetcdfDataset
+   * 
+   * @param req incoming url request
+   * @param res outgoing web based response
+   * @throws ServletException if ServletException occurred
+   * @throws IOException if IOException occurred
+   */
+  @RequestMapping(value = "**", params = {})
+  public void handleMetadataRequest(final HttpServletRequest req, final HttpServletResponse res)
+      throws ServletException, IOException {
+    _log.info("Handling NCML metadata request.");
+
+    NetcdfDataset netCdfDataset = null;
+
+    try {
+      // If service not allowed, respond accordingly (403);
+      isAllowed(as.isAllowed(StandardService.iso), _metadataServiceType, res);
+      res.setContentType(ContentType.xml.getContentHeader());
+
+      netCdfDataset = DatasetHandlerAdapter.openDataset(req, res, getInfoPath(req));
+      if (netCdfDataset == null) {
+        res.sendError(HttpServletResponse.SC_NOT_FOUND, "ThreddsIso Extension: Requested resource not found.");
+      } else {
+        // Get the response writer
+        Writer writer = res.getWriter();
+
+        // Get Thredds level metadata if it exists
+        Dataset ids = this.getThreddsDataset(req, res);
+
+        // Enhance with file and dataset level metadata
+        EnhancedMetadataService.enhance(netCdfDataset, ids, writer);
+        writer.flush();
+      }
+
+    } catch (Exception e) {
+      String errMsg = "Error in " + _metadataServiceType + ": " + req.getQueryString();
+      _log.error(errMsg, e);
+      try {
+        this.returnError(errMsg, _metadataServiceType, res);
+      } catch (Exception fe) {
+      }
+
+    } finally {
+      DatasetHandlerAdapter.closeDataset(netCdfDataset);
+    }
+  }
+
+}

--- a/tds/src/main/java/thredds/server/metadata/controller/UddcController.java
+++ b/tds/src/main/java/thredds/server/metadata/controller/UddcController.java
@@ -1,0 +1,145 @@
+/*
+ * Access and use of this software shall impose the following
+ * obligations and understandings on the user. The user is granted the
+ * right, without any fee or cost, to use, copy, modify, alter, enhance
+ * and distribute this software, and any derivative works thereof, and
+ * its supporting documentation for any purpose whatsoever, provided
+ * that this entire notice appears in all copies of the software,
+ * derivative works and supporting documentation. Further, the user
+ * agrees to credit NOAA/NGDC in any publications that result from
+ * the use of this software or in any product that includes this
+ * software. The names NOAA/NGDC, however, may not be used
+ * in any advertising or publicity to endorse or promote any products
+ * or commercial entity unless specific written permission is obtained
+ * from NOAA/NGDC. The user also understands that NOAA/NGDC
+ * is not obligated to provide the user with any support, consulting,
+ * training or assistance of any kind with regard to the use, operation
+ * and performance of this software nor to provide the user with any
+ * updates, revisions, new versions or "bug fixes".
+ *
+ * THIS SOFTWARE IS PROVIDED BY NOAA/NGDC "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL NOAA/NGDC BE LIABLE FOR ANY SPECIAL,
+ * INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER
+ * RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF
+ * CONTRACT, NEGLIGENCE OR OTHER TORTUOUS ACTION, ARISING OUT OF OR IN
+ * CONNECTION WITH THE ACCESS, USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
+package thredds.server.metadata.controller;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.io.StringWriter;
+import java.io.Writer;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import thredds.client.catalog.Dataset;
+import thredds.core.AllowedServices;
+import thredds.core.StandardService;
+import thredds.server.metadata.nciso.exception.ThreddsUtilitiesException;
+import thredds.server.metadata.service.EnhancedMetadataService;
+import thredds.server.metadata.util.DatasetHandlerAdapter;
+import thredds.server.metadata.nciso.util.ThreddsTranslatorUtil;
+import thredds.util.ContentType;
+import ucar.nc2.dataset.NetcdfDataset;
+import ucar.nc2.dataset.NetcdfDatasets;
+
+/**
+ * Controller for UDDC service
+ * Author: dneufeld Date: Jul 7, 2010
+ * <p/>
+ */
+@Controller
+@RequestMapping("/uddc/")
+public class UddcController extends AbstractMetadataController {
+  private static org.slf4j.Logger _log = org.slf4j.LoggerFactory.getLogger(UddcController.class);
+  private static final String xslFile = "nciso/UnidataDDCount-HTML.xsl";
+
+
+  @Autowired
+  private AllowedServices as;
+
+  protected String getPath() {
+    return _metadataServiceType + "/";
+  }
+
+  @EventListener
+  public void init(ContextRefreshedEvent event) throws ServletException {
+    if (event.getApplicationContext().getDisplayName().equals("Root WebApplicationContext")) {
+      _allow = as.isAllowed(StandardService.uddc);
+      _metadataServiceType = "UDDC";
+      _servletPath = "/uddc";
+      _logServerStartup.info("Metadata UDDC - initialization start");
+      _logServerStartup.info("NCISO.uddcAllow = " + _allow);
+    }
+  }
+
+  public void destroy() {
+    NetcdfDatasets.shutdown();
+    _logServerStartup.info("Metadata UDDC - destroy done");
+  }
+
+  /**
+   * Generate a report on quality of the metadata for the underlying NetcdfDataset
+   * 
+   * @param req incoming url request
+   * @param res outgoing web based response
+   * @throws ServletException if ServletException occurred
+   */
+  @RequestMapping(value = "**", params = {})
+  public void handleMetadataRequest(final HttpServletRequest req, final HttpServletResponse res)
+      throws ServletException {
+    _log.info("Handling UDDC metadata request.");
+
+    NetcdfDataset netCdfDataset = null;
+
+    try {
+      res.setContentType(ContentType.html.getContentHeader());
+      // If service not allowed, respond accordingly (403);
+      isAllowed(as.isAllowed(StandardService.iso), _metadataServiceType, res);
+      netCdfDataset = DatasetHandlerAdapter.openDataset(req, res, getInfoPath(req));
+      if (netCdfDataset == null) {
+        res.sendError(HttpServletResponse.SC_NOT_FOUND, "ThreddsIso Extension: Requested resource not found.");
+      } else {
+        Writer writer = new StringWriter();
+        // Get Thredds level metadata if it exists
+        // InvDataset ids = this.getThreddsDataset(req);
+        Dataset ids = this.getThreddsDataset(req, res);
+        EnhancedMetadataService.enhance(netCdfDataset, ids, writer);
+        String ncml = writer.toString();
+        writer.flush();
+        writer.close();
+
+        InputStream is = new ByteArrayInputStream(ncml.getBytes("UTF-8"));
+        ThreddsTranslatorUtil.transform(xslFile, is, res.getWriter());
+        res.getWriter().flush();
+      }
+    } catch (ThreddsUtilitiesException tue) {
+      String errMsg = "Error in UDDCController: " + req.getQueryString();
+      _log.error(errMsg, tue);
+      try {
+        this.returnError(errMsg, _metadataServiceType, res);
+      } catch (Exception fe) {
+      }
+    } catch (Exception e) {
+      String errMsg = "Error in UDDCController: " + req.getQueryString();
+      _log.error(errMsg, e);
+      try {
+        this.returnError(errMsg, _metadataServiceType, res);
+      } catch (Exception fe) {
+      }
+
+    } finally {
+      DatasetHandlerAdapter.closeDataset(netCdfDataset);
+    }
+  }
+
+}

--- a/tds/src/main/java/thredds/server/metadata/service/EnhancedMetadataService.java
+++ b/tds/src/main/java/thredds/server/metadata/service/EnhancedMetadataService.java
@@ -1,0 +1,101 @@
+/*
+ * Access and use of this software shall impose the following
+ * obligations and understandings on the user. The user is granted the
+ * right, without any fee or cost, to use, copy, modify, alter, enhance
+ * and distribute this software, and any derivative works thereof, and
+ * its supporting documentation for any purpose whatsoever, provided
+ * that this entire notice appears in all copies of the software,
+ * derivative works and supporting documentation. Further, the user
+ * agrees to credit NOAA/NGDC in any publications that result from
+ * the use of this software or in any product that includes this
+ * software. The names NOAA/NGDC, however, may not be used
+ * in any advertising or publicity to endorse or promote any products
+ * or commercial entity unless specific written permission is obtained
+ * from NOAA/NGDC. The user also understands that NOAA/NGDC
+ * is not obligated to provide the user with any support, consulting,
+ * training or assistance of any kind with regard to the use, operation
+ * and performance of this software nor to provide the user with any
+ * updates, revisions, new versions or "bug fixes".
+ *
+ * THIS SOFTWARE IS PROVIDED BY NOAA/NGDC "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL NOAA/NGDC BE LIABLE FOR ANY SPECIAL,
+ * INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER
+ * RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF
+ * CONTRACT, NEGLIGENCE OR OTHER TORTUOUS ACTION, ARISING OUT OF OR IN
+ * CONNECTION WITH THE ACCESS, USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+package thredds.server.metadata.service;
+
+import thredds.client.catalog.Dataset;
+import thredds.server.metadata.nciso.bean.Extent;
+import thredds.server.metadata.nciso.util.ElementNameComparator;
+import thredds.server.metadata.nciso.util.NCMLModifier;
+import thredds.server.metadata.nciso.util.ThreddsExtentUtil;
+import thredds.server.metadata.nciso.util.XMLUtil;
+import ucar.nc2.dataset.NetcdfDataset;
+import ucar.nc2.write.NcmlWriter;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.Writer;
+import java.util.List;
+
+import org.jdom2.Attribute;
+import org.jdom2.Element;
+
+/**
+ * EnhancedMetadataService
+ *
+ * @author: dneufeld
+ *          Date: Jul 19, 2010
+ */
+public class EnhancedMetadataService {
+  static private org.slf4j.Logger _log = org.slf4j.LoggerFactory.getLogger(EnhancedMetadataService.class);
+
+  /**
+   * Enhance NCML with Data Discovery conventions elements if not already in place in the metadata.
+   *
+   * @param dataset NetcdfDataset to enhance the NCML
+   * @param writer writer to send enhanced NCML to
+   */
+  public static void enhance(final NetcdfDataset dataset, final Dataset ids, final Writer writer) throws Exception {
+    Extent ext = null;
+
+    NCMLModifier ncmlMod = new NCMLModifier();
+
+    ext = ThreddsExtentUtil.getExtent(dataset);
+
+    NcmlWriter ncMLWriter = new NcmlWriter();
+    ByteArrayOutputStream dsToNcml = new ByteArrayOutputStream();
+    dataset.writeNcml(dsToNcml, null);
+    InputStream ncmlIs = new ByteArrayInputStream(dsToNcml.toByteArray());
+    XMLUtil xmlUtil = new XMLUtil(ncmlIs);
+
+    List<Element> list =
+        xmlUtil.elemFinder("//ncml:netcdf", "ncml", "http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2");
+    Element rootElem = list.get(0);
+    Element cfGroupElem = ncmlMod.doAddGroupElem(rootElem, "CFMetadata");
+    ncmlMod.addCFMetadata(ext, cfGroupElem);
+
+    Element ncIsoGroupElem = ncmlMod.doAddGroupElem(rootElem, "NCISOMetadata");
+    ncmlMod.addNcIsoMetadata(ncIsoGroupElem);
+
+    if (ids != null) {
+      Element threddsGroupElem = ncmlMod.doAddGroupElem(rootElem, "THREDDSMetadata");
+      ncmlMod.addThreddsMetadata(ids, threddsGroupElem);
+    }
+
+    Attribute locAttr = rootElem.getAttribute("location");
+    String openDapService = (ncmlMod.getOpenDapService() == null) ? "Not provided because of security concerns."
+        : ncmlMod.getOpenDapService();
+    locAttr.setValue(openDapService);
+
+    xmlUtil.sortElements(rootElem, new ElementNameComparator());
+    xmlUtil.write(writer);
+
+
+  }
+
+}

--- a/tds/src/main/java/thredds/server/metadata/util/DatasetHandlerAdapter.java
+++ b/tds/src/main/java/thredds/server/metadata/util/DatasetHandlerAdapter.java
@@ -1,0 +1,112 @@
+/*
+ * Access and use of this software shall impose the following
+ * obligations and understandings on the user. The user is granted the
+ * right, without any fee or cost, to use, copy, modify, alter, enhance
+ * and distribute this software, and any derivative works thereof, and
+ * its supporting documentation for any purpose whatsoever, provided
+ * that this entire notice appears in all copies of the software,
+ * derivative works and supporting documentation. Further, the user
+ * agrees to credit NOAA/NGDC in any publications that result from
+ * the use of this software or in any product that includes this
+ * software. The names NOAA/NGDC, however, may not be used
+ * in any advertising or publicity to endorse or promote any products
+ * or commercial entity unless specific written permission is obtained
+ * from NOAA/NGDC. The user also understands that NOAA/NGDC
+ * is not obligated to provide the user with any support, consulting,
+ * training or assistance of any kind with regard to the use, operation
+ * and performance of this software nor to provide the user with any
+ * updates, revisions, new versions or "bug fixes".
+ *
+ * THIS SOFTWARE IS PROVIDED BY NOAA/NGDC "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL NOAA/NGDC BE LIABLE FOR ANY SPECIAL,
+ * INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER
+ * RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF
+ * CONTRACT, NEGLIGENCE OR OTHER TORTUOUS ACTION, ARISING OUT OF OR IN
+ * CONNECTION WITH THE ACCESS, USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+package thredds.server.metadata.util;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import thredds.core.TdsRequestedDataset;
+import thredds.servlet.ServletUtil;
+import ucar.nc2.NetcdfFile;
+import ucar.nc2.dataset.NetcdfDataset;
+import ucar.nc2.dataset.NetcdfDatasets;
+
+/**
+ * DatasetHandlerAdapter
+ * 
+ * @author: dneufeld
+ *          Date: Jul 19, 2010
+ */
+public class DatasetHandlerAdapter {
+  static private org.slf4j.Logger _log = org.slf4j.LoggerFactory.getLogger(DatasetHandlerAdapter.class);
+
+  /**
+   * Open a NetcdfDataset based on the incoming url request.
+   *
+   * @param req incoming url request
+   * @param res outgoing web based response
+   * @return dataset a NetcdfDataset as specified in the request
+   */
+  public static NetcdfDataset openDataset(final HttpServletRequest req, final HttpServletResponse res,
+      String datasetPath) throws Exception {
+
+    NetcdfFile netcdfFile = null;
+    NetcdfDataset dataset = null;
+    // String datasetPath = req.getPathInfo();
+
+    if (datasetPath == null) { // passing in a dataset URL, presumably
+      // opendap
+      datasetPath = ServletUtil.getParameterIgnoreCase(req, "dataset");
+      _log.debug("opendap datasetPath: " + datasetPath);
+      try {
+        dataset = NetcdfDatasets.openDataset(datasetPath);
+      } catch (IOException e) {
+        res.setStatus(HttpServletResponse.SC_NOT_FOUND);
+        _log.debug("Failed to open dataset <" + datasetPath + ">: " + e.getMessage());
+      }
+    } else {
+
+      try {
+        netcdfFile = TdsRequestedDataset.getNetcdfFile(req, res, datasetPath);
+
+        _log.debug("datasetPath: " + datasetPath + " netcdfFile location: " + netcdfFile.getLocation());
+
+        dataset = NetcdfDatasets.enhance(netcdfFile, NetcdfDataset.getDefaultEnhanceMode(), null);
+
+      } catch (FileNotFoundException fnfe) {
+        res.setStatus(HttpServletResponse.SC_NOT_FOUND);
+        _log.debug("Failed to get NetcdfFile <" + datasetPath + ">: " + fnfe.getMessage(), fnfe);
+      } catch (IOException ioe) {
+        res.setStatus(HttpServletResponse.SC_NOT_FOUND);
+        _log.debug("Failed to get NetcdfFile <" + datasetPath + "> using " + netcdfFile.getLocation() + ": "
+            + ioe.getMessage(), ioe);
+      }
+    }
+    return dataset;
+
+  }
+
+  /**
+   * Close a NetcdfDataset.
+   *
+   * @param dataset the NetcdfDataset to close
+   */
+  public static void closeDataset(final NetcdfDataset dataset) {
+    if (dataset == null)
+      return;
+    try {
+      dataset.close();
+    } catch (IOException ioe) {
+      _log.warn("Failed to properly close the dataset", ioe);
+    }
+  }
+}

--- a/tds/src/main/webapp/WEB-INF/tdsGlobalConfig.xml
+++ b/tds/src/main/webapp/WEB-INF/tdsGlobalConfig.xml
@@ -16,9 +16,9 @@
         <entry key="opendap" value="true"/>
         <entry key="wcs" value="true"/>
         <entry key="wms" value="true"/>
-        <entry key="iso" value="false"/>
-        <entry key="iso_ncml" value="false"/>
-        <entry key="uddc" value="false"/>
+        <entry key="iso" value="true"/>
+        <entry key="iso_ncml" value="true"/>
+        <entry key="uddc" value="true"/>
         <entry key="jupyterNotebook" value="true"/>
       </map>
     </property>

--- a/tds/src/test/java/thredds/server/metadata/NcIsoIT.java
+++ b/tds/src/test/java/thredds/server/metadata/NcIsoIT.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2023-2025 University Corporation for Atmospheric Research/Unidata
+ * See LICENSE.txt for license information.
+ */
+
+package thredds.server.metadata;
+
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
+
+import org.apache.http.HttpStatus;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.RequestBuilder;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.w3c.dom.Node;
+import org.xmlunit.builder.DiffBuilder;
+import org.xmlunit.builder.Input;
+import org.xmlunit.diff.Diff;
+import org.xmlunit.util.Predicate;
+import thredds.mock.web.MockTdsContextLoader;
+import thredds.util.ContentType;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@WebAppConfiguration
+@ContextConfiguration(locations = {"/WEB-INF/applicationContext.xml", "/WEB-INF/spring-servlet.xml"},
+    loader = MockTdsContextLoader.class)
+public class NcIsoIT {
+
+  @Autowired
+  private WebApplicationContext wac;
+
+  private MockMvc mockMvc;
+
+  @Before
+  public void setup() {
+    this.mockMvc = MockMvcBuilders.webAppContextSetup(this.wac).build();
+  }
+
+  @Test
+  public void shouldReturnNcml() throws Exception {
+    String path = "/ncml/scanLocal/testgrid1.nc";
+    RequestBuilder rb = MockMvcRequestBuilders.get(path).servletPath(path);
+
+    MvcResult result = mockMvc.perform(rb).andReturn();
+    assertThat(result.getResponse().getStatus()).isEqualTo(HttpStatus.SC_OK);
+    byte[] response = result.getResponse().getContentAsByteArray();
+
+    final String expectedOutput = "/thredds/server/ncIso/testgrid1.ncml.xml";
+    final Predicate<Node> filter = node -> !(node.hasAttributes() && node.getAttributes().getNamedItem("name") != null
+        && (node.getAttributes().getNamedItem("name").getNodeValue().equals("metadata_creation")
+            || node.getAttributes().getNamedItem("name").getNodeValue().equals("nciso_version")));
+    compare(response, expectedOutput, ContentType.xml, filter);
+  }
+
+  @Test
+  public void shouldReturnIso() throws Exception {
+    String path = "/iso/scanLocal/testgrid1.nc";
+    RequestBuilder rb = MockMvcRequestBuilders.get(path).servletPath(path);
+
+    MvcResult result = mockMvc.perform(rb).andReturn();
+    assertThat(result.getResponse().getStatus()).isEqualTo(HttpStatus.SC_OK);
+    byte[] response = result.getResponse().getContentAsByteArray();
+
+    final String expectedOutput = "/thredds/server/ncIso/testgrid1.iso.xml";
+    final Predicate<Node> filter =
+        node -> !node.getTextContent().startsWith("This record was translated from NcML using")
+            && !node.getNodeName().startsWith("gco:Date");
+    compare(response, expectedOutput, ContentType.xml, filter);
+  }
+
+  @Test
+  public void shouldReturnUddc() throws Exception {
+    String path = "/uddc/scanLocal/testgrid1.nc";
+    RequestBuilder rb = MockMvcRequestBuilders.get(path).servletPath(path);
+
+    MvcResult result = mockMvc.perform(rb).andReturn();
+    assertThat(result.getResponse().getStatus()).isEqualTo(HttpStatus.SC_OK);
+    byte[] response = result.getResponse().getContentAsByteArray();
+
+    final String expectedOutput = "/thredds/server/ncIso/testgrid1.uddc.html";
+    compare(response, expectedOutput, ContentType.html, node -> true);
+  }
+
+  private void compare(byte[] response, String expectedOutput, ContentType expectedType, Predicate<Node> filter) {
+
+    final Diff diff = DiffBuilder.compare(Input.fromStream(getClass().getResourceAsStream(expectedOutput)))
+        .withTest(Input.fromByteArray(response)).normalizeWhitespace()
+        // don't compare elements with e.g. version/ current datetime
+        .withNodeFilter(filter).build();
+    assertWithMessage(diff.toString()).that(diff.hasDifferences()).isFalse();
+  }
+}

--- a/tds/src/test/java/thredds/server/metadata/controller/IsoControllerTest.java
+++ b/tds/src/test/java/thredds/server/metadata/controller/IsoControllerTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2020-2025 University Corporation for Atmospheric Research/Unidata
+ * See LICENSE.txt for license information.
+ */
+
+package thredds.server.metadata.controller;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.StringWriter;
+import java.io.Writer;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import thredds.client.catalog.Dataset;
+import thredds.server.metadata.nciso.util.ThreddsTranslatorUtil;
+import thredds.server.metadata.service.EnhancedMetadataService;
+import ucar.nc2.dataset.NetcdfDataset;
+import ucar.nc2.dataset.NetcdfDatasets;
+
+/**
+ * Testing the IsoController
+ */
+public class IsoControllerTest {
+
+  private static File xslFile;
+
+  @BeforeClass
+  public static void setXls() throws IOException {
+    xslFile = File.createTempFile("TDS-IsoControllerTest-", null);
+    xslFile.deleteOnExit();
+    try (InputStream is = ThreddsTranslatorUtil.class.getResourceAsStream("/resources/xsl/nciso/UnidataDD2MI.xsl");
+        OutputStream os = new FileOutputStream(xslFile);) {
+      assertThat(is).isNotNull();
+      is.transferTo(os);
+    }
+  }
+
+  @Test
+  public void testFakeIsoController() throws Exception {
+    NetcdfDataset netCdfDataset =
+        NetcdfDatasets.openDataset("src/test/resources/thredds/server/ncIso/extent/test.ncml");
+    Writer writer = new StringWriter();
+    // Get Thredds level metadata if it exists
+    Dataset ids = null;
+
+    // Enhance with file and dataset level metadata
+    EnhancedMetadataService.enhance(netCdfDataset, ids, writer);
+
+    String ncml = writer.toString();
+    writer.flush();
+    writer.close();
+    InputStream is = new ByteArrayInputStream(ncml.getBytes("UTF-8"));
+    Writer isoWriter = new StringWriter();
+    ThreddsTranslatorUtil.transform(xslFile, is, isoWriter);
+    is.close();
+    String iso = isoWriter.toString();
+    assertThat(iso).isNotEmpty();
+  }
+
+}

--- a/tds/src/test/java/thredds/server/metadata/service/TestEnhancedMetadataService.java
+++ b/tds/src/test/java/thredds/server/metadata/service/TestEnhancedMetadataService.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2023-2025 University Corporation for Atmospheric Research/Unidata
+ * See LICENSE.txt for license information.
+ */
+
+package thredds.server.metadata.service;
+
+import static com.google.common.truth.Truth.assertWithMessage;
+
+import java.io.StringWriter;
+import java.io.Writer;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.junit.Test;
+import org.w3c.dom.Node;
+import org.xmlunit.builder.DiffBuilder;
+import org.xmlunit.builder.Input;
+import org.xmlunit.diff.Diff;
+import org.xmlunit.util.Predicate;
+import ucar.nc2.dataset.NetcdfDataset;
+import ucar.nc2.dataset.NetcdfDatasets;
+
+public class TestEnhancedMetadataService {
+
+  @Test
+  public void shouldReturnMetadata() throws Exception {
+    final Path path = Paths.get("src/test/content/thredds/public/testdata/testgrid1.nc");
+    final Writer writer = new StringWriter();
+
+    try (NetcdfDataset netcdfDataset = NetcdfDatasets.openDataset(path.toAbsolutePath().toString())) {
+      EnhancedMetadataService.enhance(netcdfDataset, null, writer);
+    }
+
+    // don't compare elements with current datetime or version
+    final Predicate<Node> filter = node -> !(node.hasAttributes() && node.getAttributes().getNamedItem("name") != null
+        && (node.getAttributes().getNamedItem("name").getNodeValue().equals("metadata_creation")
+            || node.getAttributes().getNamedItem("name").getNodeValue().equals("nciso_version")));
+
+    final Diff diff = DiffBuilder
+        .compare(Input.fromStream(getClass().getResourceAsStream("/thredds/server/ncIso/testgrid1.ncml.xml")))
+        .withTest(writer.toString()).withNodeFilter(filter).build();
+    assertWithMessage(diff.toString()).that(diff.hasDifferences()).isFalse();
+  }
+}

--- a/tds/src/test/resources/thredds/server/ncIso/extent/test.ncml
+++ b/tds/src/test/resources/thredds/server/ncIso/extent/test.ncml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<netcdf xmlns="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2">
+  <dimension name="time" length="2" isUnlimited="true" />
+  <dimension name="lat" length="3" />
+  <dimension name="lon" length="3" />
+  <dimension name="depth" length="2" />
+
+  <variable name="lat" shape="lat" type="float">
+    <attribute name="units" type="String" value="degrees_north" />
+    <values>41.0 40.0 39.0</values>
+  </variable>
+
+  <variable name="lon" shape="lon" type="float">
+    <attribute name="units" type="String" value="degrees_east" />
+    <values>-109.0 -107.0 -105.0</values>
+  </variable>
+
+  <variable name="time" shape="time" type="int">
+    <attribute name="units" type="String" value="hours since 2015-01-01T00:00:00Z" />
+    <values>6 18</values>
+  </variable>
+
+  <variable name="depth" shape="depth" type="float">
+    <attribute name="units" type="String" value="meters" />
+    <attribute name="positive" type="String" value="up" />
+    <values>0.0 -10.0</values>
+  </variable>
+
+  <variable name="temp" shape="time lat lon depth" type="double">
+    <attribute name="long_name" type="String" value="air temperature" />
+    <attribute name="standard_name" type="String" value="air_temperature" />
+    <attribute name="units" type="String" value="degrees_Celsius" />
+  </variable>
+</netcdf>

--- a/tds/src/test/resources/thredds/server/ncIso/testgrid1.iso.xml
+++ b/tds/src/test/resources/thredds/server/ncIso/testgrid1.iso.xml
@@ -1,0 +1,152 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gmi:MI_Metadata xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:gco="http://www.isotc211.org/2005/gco"
+  xmlns:gmd="http://www.isotc211.org/2005/gmd"
+  xmlns:gmi="http://www.isotc211.org/2005/gmi"
+  xmlns:srv="http://www.isotc211.org/2005/srv"
+  xmlns:gmx="http://www.isotc211.org/2005/gmx"
+  xmlns:gsr="http://www.isotc211.org/2005/gsr"
+  xmlns:gss="http://www.isotc211.org/2005/gss"
+  xmlns:gts="http://www.isotc211.org/2005/gts"
+  xmlns:gml="http://www.opengis.net/gml/3.2"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xsi:schemaLocation="http://www.isotc211.org/2005/gmi http://www.ngdc.noaa.gov/metadata/published/xsd/schema.xsd">
+  <gmd:fileIdentifier gco:nilReason="missing"/>
+  <gmd:language>
+    <gmd:LanguageCode codeList="http://www.ngdc.noaa.gov/metadata/published/xsd/schema/resources/Codelist/gmxCodelists.xml#LanguageCode"
+      codeListValue="eng">eng</gmd:LanguageCode>
+  </gmd:language>
+  <gmd:characterSet>
+    <gmd:MD_CharacterSetCode codeList="http://www.ngdc.noaa.gov/metadata/published/xsd/schema/resources/Codelist/gmxCodelists.xml#MD_CharacterSetCode"
+      codeListValue="UTF8">UTF8</gmd:MD_CharacterSetCode>
+  </gmd:characterSet>
+  <gmd:hierarchyLevel>
+    <gmd:MD_ScopeCode codeList="http://www.ngdc.noaa.gov/metadata/published/xsd/schema/resources/Codelist/gmxCodelists.xml#MD_ScopeCode"
+      codeListValue="dataset">dataset</gmd:MD_ScopeCode>
+  </gmd:hierarchyLevel>
+  <gmd:contact gco:nilReason="missing"/>
+  <gmd:dateStamp>
+    <gco:Date>2023-09-20</gco:Date>
+  </gmd:dateStamp>
+  <gmd:metadataStandardName>
+    <gco:CharacterString>ISO 19115-2 Geographic Information - Metadata Part 2 Extensions for imagery and gridded data</gco:CharacterString>
+  </gmd:metadataStandardName>
+  <gmd:metadataStandardVersion>
+    <gco:CharacterString>ISO 19115-2:2009(E)</gco:CharacterString>
+  </gmd:metadataStandardVersion>
+  <gmd:spatialRepresentationInfo gco:nilReason="missing"/>
+  <gmd:identificationInfo>
+    <gmd:MD_DataIdentification id="DataIdentification">
+      <gmd:citation>
+        <gmd:CI_Citation>
+          <gmd:title gco:nilReason="missing"/>
+          <gmd:date gco:nilReason="missing"/>
+          <gmd:identifier gco:nilReason="missing"/>
+        </gmd:CI_Citation>
+      </gmd:citation>
+      <gmd:abstract gco:nilReason="missing"/>
+      <gmd:pointOfContact gco:nilReason="missing"/>
+      <gmd:language>
+        <gco:CharacterString>eng</gco:CharacterString>
+      </gmd:language>
+      <gmd:topicCategory>
+        <gmd:MD_TopicCategoryCode>climatologyMeteorologyAtmosphere</gmd:MD_TopicCategoryCode>
+      </gmd:topicCategory>
+      <gmd:extent>
+        <gmd:EX_Extent id="boundingExtent">
+          <gmd:geographicElement>
+            <gmd:EX_GeographicBoundingBox id="boundingGeographicBoundingBox">
+              <gmd:extentTypeCode>
+                <gco:Boolean>1</gco:Boolean>
+              </gmd:extentTypeCode>
+              <gmd:westBoundLongitude>
+                <gco:Decimal>-15.0</gco:Decimal>
+              </gmd:westBoundLongitude>
+              <gmd:eastBoundLongitude>
+                <gco:Decimal>-1.0</gco:Decimal>
+              </gmd:eastBoundLongitude>
+              <gmd:southBoundLatitude>
+                <gco:Decimal>17.0</gco:Decimal>
+              </gmd:southBoundLatitude>
+              <gmd:northBoundLatitude>
+                <gco:Decimal>23.0</gco:Decimal>
+              </gmd:northBoundLatitude>
+            </gmd:EX_GeographicBoundingBox>
+          </gmd:geographicElement>
+        </gmd:EX_Extent>
+      </gmd:extent>
+    </gmd:MD_DataIdentification>
+  </gmd:identificationInfo>
+  <gmd:contentInfo>
+    <gmi:MI_CoverageDescription>
+      <gmd:attributeDescription gco:nilReason="unknown"/>
+      <gmd:contentType gco:nilReason="unknown"/>
+      <gmd:dimension>
+        <gmd:MD_Band>
+          <gmd:sequenceIdentifier>
+            <gco:MemberName>
+              <gco:aName>
+                <gco:CharacterString>var</gco:CharacterString>
+              </gco:aName>
+              <gco:attributeType>
+                <gco:TypeName>
+                  <gco:aName>
+                    <gco:CharacterString>double</gco:CharacterString>
+                  </gco:aName>
+                </gco:TypeName>
+              </gco:attributeType>
+            </gco:MemberName>
+          </gmd:sequenceIdentifier>
+          <gmd:descriptor gco:nilReason="missing"/>
+        </gmd:MD_Band>
+      </gmd:dimension>
+      <gmd:dimension>
+        <gmd:MD_Band>
+          <gmd:sequenceIdentifier>
+            <gco:MemberName>
+              <gco:aName>
+                <gco:CharacterString>lat</gco:CharacterString>
+              </gco:aName>
+              <gco:attributeType>
+                <gco:TypeName>
+                  <gco:aName>
+                    <gco:CharacterString>float</gco:CharacterString>
+                  </gco:aName>
+                </gco:TypeName>
+              </gco:attributeType>
+            </gco:MemberName>
+          </gmd:sequenceIdentifier>
+          <gmd:descriptor gco:nilReason="missing"/>
+        </gmd:MD_Band>
+      </gmd:dimension>
+      <gmd:dimension>
+        <gmd:MD_Band>
+          <gmd:sequenceIdentifier>
+            <gco:MemberName>
+              <gco:aName>
+                <gco:CharacterString>lon</gco:CharacterString>
+              </gco:aName>
+              <gco:attributeType>
+                <gco:TypeName>
+                  <gco:aName>
+                    <gco:CharacterString>float</gco:CharacterString>
+                  </gco:aName>
+                </gco:TypeName>
+              </gco:attributeType>
+            </gco:MemberName>
+          </gmd:sequenceIdentifier>
+          <gmd:descriptor gco:nilReason="missing"/>
+        </gmd:MD_Band>
+      </gmd:dimension>
+    </gmi:MI_CoverageDescription>
+  </gmd:contentInfo>
+  <gmd:metadataMaintenance>
+    <gmd:MD_MaintenanceInformation>
+      <gmd:maintenanceAndUpdateFrequency gco:nilReason="unknown"/>
+      <gmd:maintenanceNote>
+        <gco:CharacterString>This record was translated from NcML using UnidataDD2MI.xsl Version 2.3.4. (2023-09-20T09:43:59.594-06:00)</gco:CharacterString>
+      </gmd:maintenanceNote>
+    </gmd:MD_MaintenanceInformation>
+  </gmd:metadataMaintenance>
+</gmi:MI_Metadata>

--- a/tds/src/test/resources/thredds/server/ncIso/testgrid1.ncml.xml
+++ b/tds/src/test/resources/thredds/server/ncIso/testgrid1.ncml.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<netcdf xmlns="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2" location="Not provided because of security concerns.">
+  <attribute name="_CoordSysBuilder" value="ucar.nc2.internal.dataset.conv.DefaultConventions" />
+  <dimension name="lat" length="2" />
+  <dimension name="lon" length="2" />
+  <group name="CFMetadata">
+    <attribute name="geospatial_lon_min" value="-15.0" type="float" />
+    <attribute name="geospatial_lat_min" value="17.0" type="float" />
+    <attribute name="geospatial_lon_max" value="-1.0" type="float" />
+    <attribute name="geospatial_lat_max" value="23.0" type="float" />
+    <attribute name="geospatial_lon_units" value="" />
+    <attribute name="geospatial_lat_units" value="" />
+    <attribute name="geospatial_lon_resolution" value="14.0" />
+    <attribute name="geospatial_lat_resolution" value="6.0" />
+  </group>
+  <group name="NCISOMetadata">
+    <attribute name="metadata_creation" value="2023-09-20" />
+    <attribute name="nciso_version" value="2.2.3" />
+  </group>
+  <variable name="var" shape="lat lon" type="double" />
+  <variable name="lat" shape="lat" type="float">
+    <attribute name="_CoordinateAxisType" value="Lat" />
+  </variable>
+  <variable name="lon" shape="lon" type="float">
+    <attribute name="_CoordinateAxisType" value="Lon" />
+  </variable>
+</netcdf>

--- a/tds/src/test/resources/thredds/server/ncIso/testgrid1.uddc.html
+++ b/tds/src/test/resources/thredds/server/ncIso/testgrid1.uddc.html
@@ -1,0 +1,719 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<html xmlns:nc="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2"
+      xmlns:xs="http://www.w3.org/2001/XMLSchema">
+<style type="text/css">
+  table {
+    empty-cells : show;
+  }</style>
+<h1>NetCDF Attribute Convention for Dataset Discovery Report</h1> The Unidata Attribute Convention for Data Discovery provides recommendations for netCDF attributes that can be added to netCDF files to
+facilitate discovery of those files using standard metadata searches. This tool tests conformance with those recommendations using this <a href="http://www.ngdc.noaa.gov/metadata/published/xsl/UnidataDDCount-HTML.xsl">stylesheet</a>. More <a href="https://geo-ide.noaa.gov/wiki/index.php?title=NetCDF_Attribute_Convention_for_Dataset_Discovery#Conformance_Test">Information on Convention and Tool</a>. <h2> Title: </h2>
+<h2>Total Score: 8/46</h2>
+<h2>General File Characteristics</h2>
+<table>
+  <tr>
+    <td>Number of Global Attributes</td>
+    <td>1</td>
+  </tr>
+  <tr>
+    <td>Number of Variables</td>
+    <td>3</td>
+  </tr>
+  <tr>
+    <td>Number of Variable Attributes</td>
+    <td>2</td>
+  </tr>
+  <tr>
+    <td>Number of Standard Names</td>
+    <td>0</td>
+  </tr>
+  <tr>
+    <td>Number of Services</td>
+    <td>0</td>
+  </tr>
+</table>
+<table width="95%" border="1" cellpadding="2" cellspacing="2">
+  <tr>
+    <th>Spiral</th>
+    <th>None</th>
+    <th>1-33%</th>
+    <th>34-66%</th>
+    <th>67-99%</th>
+    <th>All</th>
+  </tr>
+  <tr>
+    <td width="20%">
+      <a href="#Total">Total</a>
+    </td>
+    <td/>
+    <td align="center" bgcolor="CC00CC">X</td>
+    <td/>
+    <td/>
+    <td/>
+  </tr>
+  <tr>
+    <td width="20%">
+      <a href="#Identification">Identification</a>
+    </td>
+    <td align="center" bgcolor="CC00CC">X</td>
+    <td/>
+    <td/>
+    <td/>
+    <td/>
+  </tr>
+  <tr>
+    <td width="20%">
+      <a href="#Text Search">Text Search</a>
+    </td>
+    <td align="center" bgcolor="CC00CC">X</td>
+    <td/>
+    <td/>
+    <td/>
+    <td/>
+  </tr>
+  <tr>
+    <td width="20%">
+      <a href="#Extent Search">Extent Search</a>
+    </td>
+    <td/>
+    <td/>
+    <td align="center" bgcolor="CC00CC">X</td>
+    <td/>
+    <td/>
+  </tr>
+  <tr>
+    <td width="20%">
+      <a href="#Other Extent Information">Other Extent Information</a>
+    </td>
+    <td/>
+    <td/>
+    <td align="center" bgcolor="CC00CC">X</td>
+    <td/>
+    <td/>
+  </tr>
+  <tr>
+    <td width="20%">
+      <a href="#Creator Search">Creator Search</a>
+    </td>
+    <td align="center" bgcolor="CC00CC">X</td>
+    <td/>
+    <td/>
+    <td/>
+    <td/>
+  </tr>
+  <tr>
+    <td width="20%">
+      <a href="#Contributor Search">Contributor Search</a>
+    </td>
+    <td align="center" bgcolor="CC00CC">X</td>
+    <td/>
+    <td/>
+    <td/>
+    <td/>
+  </tr>
+  <tr>
+    <td width="20%">
+      <a href="#Publisher Search">Publisher Search</a>
+    </td>
+    <td align="center" bgcolor="CC00CC">X</td>
+    <td/>
+    <td/>
+    <td/>
+    <td/>
+  </tr>
+  <tr>
+    <td width="20%">
+      <a href="#Other Attributes">Other Attributes</a>
+    </td>
+    <td align="center" bgcolor="CC00CC">X</td>
+    <td/>
+    <td/>
+    <td/>
+    <td/>
+  </tr>
+</table>
+<a href="#Identification">Identification</a> | <a href="#Text Search">Text Search</a> | <a href="#Extent Search">Extent Search</a> | <a href="#Other Extent Information">Other Extent Information</a> | <a href="#Creator Search">Creator Search</a> | <a href="#Contributor Search">Contributor Search</a> | <a href="#Publisher Search">Publisher Search</a> | <a href="#Other Attributes">Other Attributes</a>
+<a name="Identification"/>
+<h2>Identification / Metadata Reference Score: 0/4</h2>
+<p>As metadata are shared between national and international repositories it is becoming increasing important to be able to unambiguously identify and refer to specific records. This is facilitated by including an identifier in
+  the metadata. Some mechanism must exist for ensuring that these identifiers are unique. This is accomplished by specifying the naming authority or namespace for the identifier. It is the responsibility of the manager of the
+  namespace to ensure that the identifiers in that namespace are unique. Identifying the Metadata Convention being used in the file and providing a link to more complete metadata, possibly using a different convention, are
+  also important.</p>
+<table width="95%" border="1" cellpadding="2" cellspacing="2">
+  <tr>
+    <th valign="top">Score</th>
+    <th valign="top">Attribute</th>
+    <th valign="top">Description</th>
+    <th valign="top">THREDDS</th>
+    <th valign="top">ISO 19115-2</th>
+  </tr>
+  <tr>
+    <td align="center" bgcolor="FF0033">0</td>
+    <td valign="top">
+      <a href="http://www.unidata.ucar.edu/software/netcdf-java/formats/DataDiscoveryAttConvention.html#id_Attribute">id</a>
+      <br/>
+    </td>
+    <td rowspan="2" valign="top">The combination of the "naming authority" and the "id" should be a globally unique identifier for the dataset.<br/>
+    </td>
+    <td valign="top">dataset@id</td>
+    <td colspan="1" valign="top">/gmi:MI_Metadata/gmd:fileIdentifier/gco:CharacterString<br/>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" bgcolor="FF0033">0</td>
+    <td valign="top">
+      <a href="http://www.unidata.ucar.edu/software/netcdf-java/formats/DataDiscoveryAttConvention.html#naming_authority_Attribute">naming_authority</a>
+      <br/>
+    </td>
+    <td/>
+    <td colspan="1" valign="top">/gmi:MI_Metadata/gmd:fileIdentifier/gco:CharacterString<br/>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" bgcolor="FF0033">0</td>
+    <td valign="top">Metadata_Conventions</td>
+    <td valign="top">This attribute should be set to "Unidata Dataset Discovery v1.0" for NetCDF files that follow this convention.</td>
+    <td valign="top"/>
+    <td valign="top"/>
+  </tr>
+  <tr>
+    <td align="center" bgcolor="FF0033">0</td>
+    <td valign="top">Metadata_Link or metadata_link</td>
+    <td valign="top">This attribute provides a link to a complete metadata record for this dataset or the collection that contains this dataset. <i>This attribute is not included in Version 1 of the Unidata Attribute
+      Convention for Data Discovery. It is recommended here because a complete metadata collection for a dataset will likely contain more information than can be included in granule formats. This attribute contains a
+      link to that information.</i>
+    </td>
+    <td valign="top"/>
+    <td valign="top"/>
+  </tr>
+</table>
+<a href="#Identification">Identification</a> | <a href="#Text Search">Text Search</a> | <a href="#Extent Search">Extent Search</a> | <a href="#Other Extent Information">Other Extent Information</a> | <a href="#Creator Search">Creator Search</a> | <a href="#Contributor Search">Contributor Search</a> | <a href="#Publisher Search">Publisher Search</a> | <a href="#Other Attributes">Other Attributes</a>
+<a name="Text Search"/>
+<h2>Text Search Score: 0/7</h2>
+<p>Text searches are a very important mechanism for data discovery. This group includes attributes that contain descriptive text that could be the target of these searches. Some of these attributes, for example title and
+  summary, might also be displayed in the results of text searches.</p>
+<table width="95%" border="1" cellpadding="2" cellspacing="2">
+  <tr>
+    <th valign="top">Score</th>
+    <th valign="top">Attribute</th>
+    <th valign="top">Description</th>
+    <th valign="top">THREDDS</th>
+    <th valign="top">ISO 19115-2</th>
+  </tr>
+  <tr>
+    <td align="center" bgcolor="FF0033">0</td>
+    <td valign="top">
+      <a href="http://www.unidata.ucar.edu/software/netcdf-java/formats/DataDiscoveryAttConvention.html#title_Attribute">title</a>
+      <br/>
+    </td>
+    <td valign="top">A short description of the dataset.<br/>
+    </td>
+    <td valign="top">dataset@name<br/>
+    </td>
+    <td valign="top">/gmi:MI_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:title/gco:CharacterString<br/>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" bgcolor="FF0033">0</td>
+    <td valign="top">
+      <a href="http://www.unidata.ucar.edu/software/netcdf-java/formats/DataDiscoveryAttConvention.html#summary_Attribute">summary</a>
+      <br/>
+    </td>
+    <td valign="top">A paragraph describing the dataset.<br/>
+    </td>
+    <td valign="top">metadata/documentation[@type="summary"]<br/>
+    </td>
+    <td valign="top">/gmi:MI_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:abstract/gco:CharacterString<br/>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" bgcolor="FF0033">0</td>
+    <td valign="top">
+      <a href="http://www.unidata.ucar.edu/software/netcdf-java/formats/DataDiscoveryAttConvention.html#keywords_Attribute">keywords</a>
+      <br/>
+    </td>
+    <td valign="top">A comma separated list of key words and phrases.<br/>
+    </td>
+    <td valign="top">metadata/keyword<br/>
+    </td>
+    <td valign="top">/gmi:MI_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:descriptiveKeywords/gmd:MD_Keywords/gmd:keyword/gco:CharacterString<br/>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" bgcolor="FF0033">0</td>
+    <td valign="top">
+      <a href="http://www.unidata.ucar.edu/software/netcdf-java/formats/DataDiscoveryAttConvention.html#keywords_vocabulary_Attribute">keywords_vocabulary</a>
+      <br/>
+    </td>
+    <td valign="top">If you are following a guideline for the words/phrases in your "keywords" attribute, put the name of that guideline here.<br/>
+    </td>
+    <td valign="top">metadata/keyword@vocabulary</td>
+    <td valign="top">/gmi:MI_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:descriptiveKeywords/gmd:MD_Keywords/gmd:thesaurusName/gmd:CI_Citation/gmd:title/gco:CharacterString <br/>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" bgcolor="FF0033">0</td>
+    <td valign="top">
+      <a href="http://www.unidata.ucar.edu/software/netcdf-java/formats/DataDiscoveryAttConvention.html#standard_name_vocabulary_Attribute">standard_name_vocabulary</a>
+      <br/>
+    </td>
+    <td valign="top">The name of the controlled vocabulary from which variable standard names are taken.<br/>
+    </td>
+    <td valign="top">metadata/variables@vocabulary</td>
+    <td valign="top">/gmi:MI_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:descriptiveKeywords/gmd:MD_Keywords/gmd:thesaurusName/gmd:CI_Citation/gmd:title/gco:CharacterString <br/>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" bgcolor="FF0033">0</td>
+    <td valign="top">
+      <a href="http://www.unidata.ucar.edu/software/netcdf-java/formats/DataDiscoveryAttConvention.html#history_Attribute">history</a>
+      <br/>
+    </td>
+    <td valign="top">Provides an audit trail for modifications to the original data.</td>
+    <td valign="top"/>
+    <td valign="top">/gmi:MI_Metadata/gmd:dataQualityInfo/gmd:DQ_DataQuality/gmd:lineage/gmd:LI_Lineage/gmd:statement/gco:CharacterString</td>
+  </tr>
+  <tr>
+    <td align="center" bgcolor="FF0033">0</td>
+    <td valign="top">
+      <a href="http://www.unidata.ucar.edu/software/netcdf-java/formats/DataDiscoveryAttConvention.html#comment_Attribute">comment</a>
+      <br/>
+    </td>
+    <td valign="top">Miscellaneous information about the data.</td>
+    <td valign="top">metadata/documentation<br/>
+    </td>
+    <td valign="top">/gmi:MI_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:supplementalInformation<br/>
+    </td>
+  </tr>
+</table>
+<a href="#Identification">Identification</a> | <a href="#Text Search">Text Search</a> | <a href="#Extent Search">Extent Search</a> | <a href="#Other Extent Information">Other Extent Information</a> | <a href="#Creator Search">Creator Search</a> | <a href="#Contributor Search">Contributor Search</a> | <a href="#Publisher Search">Publisher Search</a> | <a href="#Other Attributes">Other Attributes</a>
+<a name="Extent Search"/>
+<h2>Extent Search Score: 4/8</h2>
+<p>This basic extent information supports spatial/temporal searches that are increasingly important as the number of map based search interfaces increases. Many of the attributes included in this spiral can be calculated from
+  the data if the file is compliant with the <a href="http://cf-pcmdi.llnl.gov/">NetCDF Climate and Forecast (CF) Metadata Convention</a>. </p>
+<table width="95%" border="1" cellpadding="2" cellspacing="2">
+  <tr>
+    <th valign="top">Score</th>
+    <th valign="top">Attribute</th>
+    <th valign="top">Description</th>
+    <th valign="top">THREDDS</th>
+    <th valign="top">ISO 19115-2</th>
+  </tr>
+  <tr>
+    <td align="center" bgcolor="66CC66">1</td>
+    <td valign="top">
+      <a href="http://www.unidata.ucar.edu/software/netcdf-java/formats/DataDiscoveryAttConvention.html#geospatial_lat_min_Attribute">geospatial_lat_min</a>
+      <br/>
+    </td>
+    <td rowspan="13" colspan="1" valign="top">Describes a simple latitude, longitude, vertical and temporal bounding box. For a more detailed geospatial coverage, see the <a href="http://www.unidata.ucar.edu/software/netcdf-java/formats/DataDiscoveryAttConvention.html#suggested_geospatial">suggested geospatial attributes</a>.<br/> Further refinement of the geospatial bounding box can
+      be provided by using these units and resolution attributes.<br/>
+      <br/>
+      <i>Many of these extent attributes are calculated using the CF-Conventions.</i>
+    </td>
+    <td valign="top">metadata/geospatialCoverage/northsouth/start<br/>
+    </td>
+    <td valign="top">/gmi:MI_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:extent/gmd:EX_Extent/gmd:geographicElement/gmd:EX_GeographicBoundingBox/gmd:southBoundLatitude/gco:Decimal<br/>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" bgcolor="66CC66">1</td>
+    <td valign="top">
+      <a href="http://www.unidata.ucar.edu/software/netcdf-java/formats/DataDiscoveryAttConvention.html#geospatial_lat_max_Attribute">geospatial_lat_max</a>
+    </td>
+    <td valign="top">metadata/geospatialCoverage/northsouth/size</td>
+    <td valign="top">/gmi:MI_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:extent/gmd:EX_Extent/gmd:geographicElement/gmd:EX_GeographicBoundingBox/gmd:northBoundLatitude/gco:Decimal<br/>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" bgcolor="66CC66">1</td>
+    <td valign="top">
+      <a href="http://www.unidata.ucar.edu/software/netcdf-java/formats/DataDiscoveryAttConvention.html#geospatial_lon_min_Attribute">geospatial_lon_min</a>
+    </td>
+    <td valign="top">metadata/geospatialCoverage/eastwest/start</td>
+    <td valign="top">/gmi:MI_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:extent/gmd:EX_Extent/gmd:geographicElement/gmd:EX_GeographicBoundingBox/gmd:westBoundLongitude/gco:Decimal<br/>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" bgcolor="66CC66">1</td>
+    <td valign="top">
+      <a href="http://www.unidata.ucar.edu/software/netcdf-java/formats/DataDiscoveryAttConvention.html#geospatial_lon_max_Attribute">geospatial_lon_max</a>
+    </td>
+    <td valign="top">metadata/geospatialCoverage/eastwest/size</td>
+    <td valign="top">/gmi:MI_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:extent/gmd:EX_Extent/gmd:geographicElement/gmd:EX_GeographicBoundingBox/gmd:eastBoundLongitude/gco:Decimal<br/>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" bgcolor="FF0033">0</td>
+    <td valign="top">
+      <a href="http://www.unidata.ucar.edu/software/netcdf-java/formats/DataDiscoveryAttConvention.html#time_coverage_start_Attribute">time_coverage_start</a>
+    </td>
+    <td valign="top">metadata/timeCoverage/start</td>
+    <td valign="top">/gmi:MI_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:extent/gmd:EX_Extent/gmd:temporalElement/gmd:EX_TemporalExtent/gmd:extent/gml:TimePeriod/gml:beginPosition</td>
+  </tr>
+  <tr>
+    <td align="center" bgcolor="FF0033">0</td>
+    <td valign="top">
+      <a href="http://www.unidata.ucar.edu/software/netcdf-java/formats/DataDiscoveryAttConvention.html#time_coverage_end_Attribute">time_coverage_end</a>
+    </td>
+    <td valign="top">metadata/timeCoverage/end</td>
+    <td valign="top">/gmi:MI_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:extent/gmd:EX_Extent/gmd:temporalElement/gmd:EX_TemporalExtent/gmd:extent/gml:TimePeriod/gml:endPosition</td>
+  </tr>
+  <tr>
+    <td align="center" bgcolor="FF0033">0</td>
+    <td valign="top">
+      <a href="http://www.unidata.ucar.edu/software/netcdf-java/formats/DataDiscoveryAttConvention.html#geospatial_vertical_min_Attribute">geospatial_vertical_min</a>
+      <br/>
+    </td>
+    <td valign="top">metadata/geospatialCoverage/updown/start</td>
+    <td valign="top">/gmi:MI_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:extent/gmd:EX_Extent/gmd:verticalElement/gmd:EX_VerticalExtent/gmd:minimumValue/gco:Real</td>
+  </tr>
+  <tr>
+    <td align="center" bgcolor="FF0033">0</td>
+    <td valign="top">
+      <a href="http://www.unidata.ucar.edu/software/netcdf-java/formats/DataDiscoveryAttConvention.html#geospatial_vertical_max_Attribute">geospatial_vertical_max</a>
+    </td>
+    <td valign="top">metadata/geospatialCoverage/updown/size</td>
+    <td valign="top">/gmi:MI_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:extent/gmd:EX_Extent/gmd:verticalElement/gmd:EX_VerticalExtent/gmd:maximumValue/gco:Real</td>
+  </tr>
+</table>
+<a href="#Identification">Identification</a> | <a href="#Text Search">Text Search</a> | <a href="#Extent Search">Extent Search</a> | <a href="#Other Extent Information">Other Extent Information</a> | <a href="#Creator Search">Creator Search</a> | <a href="#Contributor Search">Contributor Search</a> | <a href="#Publisher Search">Publisher Search</a> | <a href="#Other Attributes">Other Attributes</a>
+<a name="Other Extent Information"/>
+<h2>Other Extent Information Score: 4/10</h2>
+<p>This information provides more details on the extent attributes than the basic information included in the Extent Spiral. Many of the attributes included in this spiral can be calculated from the data if the file is compliant
+  with the <a href="http://cf-pcmdi.llnl.gov/">NetCDF Climate and Forecast (CF) Metadata Convention</a> .</p>
+<table width="95%" border="1" cellpadding="2" cellspacing="2">
+  <tr>
+    <th valign="top">Score</th>
+    <th valign="top">Attribute</th>
+    <th valign="top">Description</th>
+    <th valign="top">THREDDS</th>
+    <th valign="top">ISO 19115-2</th>
+  </tr>
+  <tr>
+    <td align="center" bgcolor="66CC66">1</td>
+    <td valign="top">
+      <a href="http://www.unidata.ucar.edu/software/netcdf-java/formats/DataDiscoveryAttConvention.html#geospatial_lon_units_Attribute">geospatial_lon_units</a>
+      <br/>
+    </td>
+    <td valign="top">metadata/geospatialCoverage/eastwest/units</td>
+    <td valign="top">/gmi:MI_Metadata/gmd:spatialRepresentationInfo/gmd:MD_Georectified/gmd:axisDimensionProperties/gmd:MD_Dimension/gmd:resolution/gco:Measure/@uom</td>
+  </tr>
+  <tr>
+    <td align="center" bgcolor="66CC66">1</td>
+    <td valign="top">
+      <a href="http://www.unidata.ucar.edu/software/netcdf-java/formats/DataDiscoveryAttConvention.html#geospatial_lon_resolution_Attribute">geospatial_lon_resolution</a>
+    </td>
+    <td valign="top">metadata/geospatialCoverage/eastwest/resolution</td>
+    <td valign="top">/gmi:MI_Metadata/gmd:spatialRepresentationInfo/gmd:MD_Georectified/gmd:axisDimensionProperties/gmd:MD_Dimension/gmd:resolution/gco:Measure</td>
+  </tr>
+  <tr>
+    <td align="center" bgcolor="66CC66">1</td>
+    <td valign="top">
+      <a href="http://www.unidata.ucar.edu/software/netcdf-java/formats/DataDiscoveryAttConvention.html#geospatial_lat_units_Attribute">geospatial_lat_units</a>
+      <br/>
+    </td>
+    <td valign="top">metadata/geospatialCoverage/northsouth/units</td>
+    <td valign="top">/gmi:MI_Metadata/gmd:spatialRepresentationInfo/gmd:MD_Georectified/gmd:axisDimensionProperties/gmd:MD_Dimension/gmd:resolution/gco:Measure/@uom</td>
+  </tr>
+  <tr>
+    <td align="center" bgcolor="66CC66">1</td>
+    <td valign="top">
+      <a href="http://www.unidata.ucar.edu/software/netcdf-java/formats/DataDiscoveryAttConvention.html#geospatial_lat_resolution_Attribute">geospatial_lat_resolution</a>
+    </td>
+    <td valign="top">metadata/geospatialCoverage/northsouth/resolution</td>
+    <td valign="top">/gmi:MI_Metadata/gmd:spatialRepresentationInfo/gmd:MD_Georectified/gmd:axisDimensionProperties/gmd:MD_Dimension/gmd:resolution/gco:Measure</td>
+  </tr>
+  <tr>
+    <td align="center" bgcolor="FF0033">0</td>
+    <td valign="top">
+      <a href="http://www.unidata.ucar.edu/software/netcdf-java/formats/DataDiscoveryAttConvention.html#geospatial_vertical_units_Attribute">geospatial_vertical_units</a>
+      <br/>
+    </td>
+    <td valign="top">metadata/geospatialCoverage/updown/units</td>
+    <td valign="top" rowspan="3">/gmi:MI_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:extent/gmd:EX_Extent/gmd:verticalElement/gmd:EX_VerticalExtent/gmd:verticalCRS</td>
+  </tr>
+  <tr>
+    <td align="center" bgcolor="FF0033">0</td>
+    <td valign="top">
+      <a href="http://www.unidata.ucar.edu/software/netcdf-java/formats/DataDiscoveryAttConvention.html#geospatial_vertical_resolution_Attribute">geospatial_vertical_resolution</a>
+      <br/>
+    </td>
+    <td valign="top">metadata/geospatialCoverage/updown/resolution<br/>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" bgcolor="FF0033">0</td>
+    <td valign="top">
+      <a href="http://www.unidata.ucar.edu/software/netcdf-java/formats/DataDiscoveryAttConvention.html#geospatial_vertical_positive_Attribute">geospatial_vertical_positive</a>
+      <br/>
+    </td>
+    <td valign="top">metadata/geospatialCoverage@zpositive<br/>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" bgcolor="FF0033">0</td>
+    <td valign="top">
+      <a href="http://www.unidata.ucar.edu/software/netcdf-java/formats/DataDiscoveryAttConvention.html#time_coverage_duration_Attribute">time_coverage_units</a>
+    </td>
+    <td valign="top">This attribute is calculated using the CF Conventions</td>
+    <td valign="top">/gmi:MI_Metadata/gmd:spatialRepresentationInfo/gmd:MD_GridSpatialRepresentation/gmd:axisDimensionProperties/gmd:MD_Dimension/gmd:resolution/gco:Measure/@uom.</td>
+  </tr>
+  <tr>
+    <td align="center" bgcolor="FF0033">0</td>
+    <td valign="top">
+      <a href="http://www.unidata.ucar.edu/software/netcdf-java/formats/DataDiscoveryAttConvention.html#time_coverage_duration_Attribute">time_coverage_duration</a>
+    </td>
+    <td valign="top">metadata/timeCoverage/duration</td>
+    <td valign="top">/gmi:MI_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:extent/gmd:EX_Extent/gmd:temporalElement/gmd:EX_TemporalExtent/gmd:extent/gml:TimePeriod/gml:beginPosition provides an ISO8601
+      compliant description of the time period covered by the dataset. This standard supports descriptions of <a href="http://en.wikipedia.org/wiki/ISO_8601#Durations">durations</a>.</td>
+  </tr>
+  <tr>
+    <td align="center" bgcolor="FF0033">0</td>
+    <td valign="top">
+      <a href="http://www.unidata.ucar.edu/software/netcdf-java/formats/DataDiscoveryAttConvention.html#time_coverage_resolution_Attribute">time_coverage_resolution</a>
+    </td>
+    <td valign="top">metadata/timeCoverage/resolution</td>
+    <td/>
+  </tr>
+</table>
+<a href="#Identification">Identification</a> | <a href="#Text Search">Text Search</a> | <a href="#Extent Search">Extent Search</a> | <a href="#Other Extent Information">Other Extent Information</a> | <a href="#Creator Search">Creator Search</a> | <a href="#Contributor Search">Contributor Search</a> | <a href="#Publisher Search">Publisher Search</a> | <a href="#Other Attributes">Other Attributes</a>
+<a name="Creator Search"/>
+<h2>Creator Search Score: 0/9</h2>
+<p>This group includes attributes that could support searches for people/institutions/projects that are responsible for datasets. This information is also critical for the correct attribution of the people and institutions that
+  produce datasets.</p>
+<table width="95%" border="1" cellpadding="2" cellspacing="2">
+  <tr>
+    <th valign="top">Score</th>
+    <th valign="top">Attribute</th>
+    <th valign="top">Description</th>
+    <th valign="top">THREDDS</th>
+    <th valign="top">ISO 19115-2</th>
+  </tr>
+  <tr>
+    <td align="center" bgcolor="FF0033">0</td>
+    <td valign="top">
+      <a href="http://www.unidata.ucar.edu/software/netcdf-java/formats/DataDiscoveryAttConvention.html#creator_name_Attribute">creator_name</a>
+      <br/>
+    </td>
+    <td rowspan="4" colspan="1" valign="top">The data creator's name, URL, and email. The "institution" attribute will be used if the "creator_name" attribute does not exist.<br/>
+    </td>
+    <td valign="top">metadata/creator/name<br/>
+    </td>
+    <td valign="top">/gmi:MI_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:individualName/gco:CharacterString<br/>
+      CI_RoleCode="originator"</td>
+  </tr>
+  <tr>
+    <td align="center" bgcolor="FF0033">0</td>
+    <td valign="top">
+      <a href="http://www.unidata.ucar.edu/software/netcdf-java/formats/DataDiscoveryAttConvention.html#creator_url_Attribute">creator_url</a>
+      <br/>
+    </td>
+    <td valign="top">metadata/creator/contact@url<br/>
+    </td>
+    <td valign="top">/gmi:MI_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:linkage/gmd:URL<br/>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" bgcolor="FF0033">0</td>
+    <td valign="top">
+      <a href="http://www.unidata.ucar.edu/software/netcdf-java/formats/DataDiscoveryAttConvention.html#creator_email_Attribute">creator_email</a>
+      <br/>
+    </td>
+    <td valign="top">metadata/creator/contact@email</td>
+    <td valign="top">/gmi:MI_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:electronicMailAddress/gco:CharacterString</td>
+  </tr>
+  <tr>
+    <td align="center" bgcolor="FF0033">0</td>
+    <td valign="top">
+      <a href="http://www.unidata.ucar.edu/software/netcdf-java/formats/DataDiscoveryAttConvention.html#institution_Attribute">institution</a>
+      <br/>
+    </td>
+    <td valign="top">metadata/creator/name</td>
+    <td valign="top">/gmi:MI_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:organisationName/gco:CharacterString</td>
+  </tr>
+  <tr>
+    <td align="center" bgcolor="FF0033">0</td>
+    <td valign="top">
+      <a href="http://www.unidata.ucar.edu/software/netcdf-java/formats/DataDiscoveryAttConvention.html#date_created_Attribute">date_created</a>
+    </td>
+    <td valign="top">The date on which the data was created.<br/>
+    </td>
+    <td valign="top">metadata/date[@type="created"]</td>
+    <td valign="top">/gmi:MI_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:date/gmd:CI_Date/gmd:date/gco:Date<br/> /gmd:dateType/gmd:CI_DateTypeCode="creation"</td>
+  </tr>
+  <tr>
+    <td align="center" bgcolor="FF0033">0</td>
+    <td valign="top">
+      <a href="http://www.unidata.ucar.edu/software/netcdf-java/formats/DataDiscoveryAttConvention.html#date_modified_Attribute">date_modified</a>
+      <br/>
+    </td>
+    <td valign="top">The date on which this data was last modified.<br/>
+    </td>
+    <td valign="top">metadata/date[@type="modified"]</td>
+    <td valign="top">/gmi:MI_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:date/gmd:CI_Date/gmd:date/gco:Date<br/> /gmd:dateType/gmd:CI_DateTypeCode="revision"</td>
+  </tr>
+  <tr>
+    <td align="center" bgcolor="FF0033">0</td>
+    <td valign="top">
+      <a href="http://www.unidata.ucar.edu/software/netcdf-java/formats/DataDiscoveryAttConvention.html#date_issued_Attribute">date_issued</a>
+      <br/>
+    </td>
+    <td valign="top">The date on which this data was formally issued.<br/>
+    </td>
+    <td valign="top">metadata/date[@type="issued"]</td>
+    <td valign="top">/gmi:MI_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:date/gmd:CI_Date/gmd:date/gco:Date<br/> /gmd:dateType/gmd:CI_DateTypeCode="publication"</td>
+  </tr>
+  <tr>
+    <td align="center" bgcolor="FF0033">0</td>
+    <td valign="top">
+      <a href="http://www.unidata.ucar.edu/software/netcdf-java/formats/DataDiscoveryAttConvention.html#project_Attribute">project</a>
+      <br/>
+    </td>
+    <td valign="top">The scientific project that produced the data.<br/>
+    </td>
+    <td valign="top">metadata/project<br/>
+    </td>
+    <td valign="top">/gmi:MI_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:aggregationInfo/gmd:MD_AggregateInformation/gmd:aggregateDataSetName/gmd:CI_Citation/gmd:title/gco:CharacterString<br/>
+      DS_AssociationTypeCode="largerWorkCitation" and DS_InitiativeTypeCode="project"<br/>and/or<br/>
+      /gmi:MI_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:descriptiveKeywords/gmd:MD_Keywords/gmd:keyword/gco:CharacterString with gmd:MD_KeywordTypeCode="project" </td>
+  </tr>
+  <tr>
+    <td align="center" bgcolor="FF0033">0</td>
+    <td valign="top">
+      <a href="http://www.unidata.ucar.edu/software/netcdf-java/formats/DataDiscoveryAttConvention.html#acknowledgement_Attribute">acknowledgment</a>
+    </td>
+    <td valign="top">A place to acknowledge various type of support for the project that produced this data.<br/>
+    </td>
+    <td valign="top">metadata/documentation[@type="funding"]</td>
+    <td valign="top">/gmi:MI_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:credit/gco:CharacterString</td>
+  </tr>
+</table>
+<a href="#Identification">Identification</a> | <a href="#Text Search">Text Search</a> | <a href="#Extent Search">Extent Search</a> | <a href="#Other Extent Information">Other Extent Information</a> | <a href="#Creator Search">Creator Search</a> | <a href="#Contributor Search">Contributor Search</a> | <a href="#Publisher Search">Publisher Search</a> | <a href="#Other Attributes">Other Attributes</a>
+<a name="Contributor Search"/>
+<h2>Contributor Search Score: 0/2</h2>
+<p>This section allows a data provider to include information about those that contribute to a data product in the metadata for the product. This is important for many reasons.</p>
+<table border="1">
+  <tr>
+    <th valign="top">Score</th>
+    <th valign="top">Attribute</th>
+    <th valign="top">Description</th>
+    <th valign="top">THREDDS</th>
+    <th valign="top">ISO 19115-2</th>
+  </tr>
+  <tr>
+    <td align="center" bgcolor="FF0033">0</td>
+    <td valign="top">
+      <a href="http://www.unidata.ucar.edu/software/netcdf-java/formats/DataDiscoveryAttConvention.html#contributor_name_Attribute">contributor_name</a>
+      <br/>
+    </td>
+    <td rowspan="2" colspan="1" valign="top">The name and role of any individuals or institutions that contributed to the creation of this data.<br/>
+    </td>
+    <td valign="top">metadata/contributor<br/>
+    </td>
+    <td valign="top">/gmi:MI_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:individualName/gco:CharacterString<br/>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" bgcolor="FF0033">0</td>
+    <td valign="top">
+      <a href="http://www.unidata.ucar.edu/software/netcdf-java/formats/DataDiscoveryAttConvention.html#contributor_role_Attribute">contributor_role</a>
+      <br/>
+    </td>
+    <td valign="top">metadata/contributor@role</td>
+    <td valign="top">/gmi:MI_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:role/gmd:CI_RoleCode<br/> ="principalInvestigator" |
+      "author"</td>
+  </tr>
+</table>
+<a href="#Identification">Identification</a> | <a href="#Text Search">Text Search</a> | <a href="#Extent Search">Extent Search</a> | <a href="#Other Extent Information">Other Extent Information</a> | <a href="#Creator Search">Creator Search</a> | <a href="#Contributor Search">Contributor Search</a> | <a href="#Publisher Search">Publisher Search</a> | <a href="#Other Attributes">Other Attributes</a>
+<a name="Publisher Search"/>
+<h2>Publisher Search Score: 0/3</h2>
+<p>This section allows a data provider to include contact information for the publisher of a data product in the metadata for the product.</p>
+<table border="1">
+  <tr>
+    <th valign="top">Score</th>
+    <th valign="top">Attribute</th>
+    <th valign="top">Description</th>
+    <th valign="top">THREDDS</th>
+    <th valign="top">ISO 19115-2</th>
+  </tr>
+  <tr>
+    <td align="center" bgcolor="FF0033">0</td>
+    <td valign="top">
+      <a href="http://www.unidata.ucar.edu/software/netcdf-java/formats/DataDiscoveryAttConvention.html#publisher_name_Attribute">publisher_name</a>
+      <br/>
+    </td>
+    <td rowspan="3" colspan="1" valign="top">The data publisher's name, URL, and email. The publisher may be an individual or an institution.</td>
+    <td valign="top">metadata/publisher/name<br/>
+    </td>
+    <td valign="top">/gmi:MI_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:individualName/gco:CharacterString<br/>
+      CI_RoleCode="publisher"<br/>and/or<br/> /gmi:MI_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:descriptiveKeywords/gmd:MD_Keywords/gmd:keyword/gco:CharacterString with
+      gmd:MD_KeywordTypeCode="dataCenter" </td>
+  </tr>
+  <tr>
+    <td align="center" bgcolor="FF0033">0</td>
+    <td valign="top">
+      <a href="http://www.unidata.ucar.edu/software/netcdf-java/formats/DataDiscoveryAttConvention.html#publisher_url_Attribute">publisher_url</a>
+      <br/>
+    </td>
+    <td valign="top">metadata/publisher/contact@url<br/>
+    </td>
+    <td valign="top">/gmi:MI_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:onlineResource/gmd:CI_OnlineResource/gmd:linkage/gmd:URL<br/>
+      CI_RoleCode="publisher"</td>
+  </tr>
+  <tr>
+    <td align="center" bgcolor="FF0033">0</td>
+    <td valign="top">
+      <a href="http://www.unidata.ucar.edu/software/netcdf-java/formats/DataDiscoveryAttConvention.html#publisher_email_Attribute">publisher_email</a>
+      <br/>
+    </td>
+    <td valign="top">metadata/publisher/contact@email</td>
+    <td valign="top">/gmi:MI_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:electronicMailAddress/gco:CharacterString<br/>
+      CI_RoleCode="publisher"</td>
+  </tr>
+</table>
+<a href="#Identification">Identification</a> | <a href="#Text Search">Text Search</a> | <a href="#Extent Search">Extent Search</a> | <a href="#Other Extent Information">Other Extent Information</a> | <a href="#Creator Search">Creator Search</a> | <a href="#Contributor Search">Contributor Search</a> | <a href="#Publisher Search">Publisher Search</a> | <a href="#Other Attributes">Other Attributes</a>
+<a name="Other Attributes"/>
+<h2>Other Attributes Score: 0/3</h2>
+<p>This group includes attributes that don't seem to fit in the other categories.</p>
+<table width="95%" border="1" cellpadding="2" cellspacing="2">
+  <tr>
+    <th valign="top">Score</th>
+    <th valign="top">Attribute</th>
+    <th valign="top">Description</th>
+    <th valign="top">THREDDS</th>
+    <th valign="top">ISO 19115-2</th>
+  </tr>
+  <tr>
+    <td align="center" bgcolor="FF0033">0</td>
+    <td valign="top">
+      <a href="http://www.unidata.ucar.edu/software/netcdf-java/formats/DataDiscoveryAttConvention.html#processing_level_Attribute">processing_level</a>
+    </td>
+    <td valign="top">A textual description of the processing (or quality control) level of the data.<br/>
+    </td>
+    <td valign="top">metadata/documentation[@type="processing_level"]</td>
+  </tr>
+  <tr>
+    <td align="center" bgcolor="FF0033">0</td>
+    <td valign="top">
+      <a href="http://www.unidata.ucar.edu/software/netcdf-java/formats/DataDiscoveryAttConvention.html#license_Attribute">license</a>
+    </td>
+    <td valign="top">Describe the restrictions to data access and distribution. </td>
+    <td valign="top">metadata/documentation[@type="rights"]</td>
+    <td valign="top">/gmi:MI_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:resourceConstraints/gmd:MD_LegalConstraints/gmd:useLimitation/gco:CharacterString<br/>
+    </td>
+  </tr>
+  <tr>
+    <td align="center" bgcolor="FF0033">0</td>
+    <td valign="top">
+      <a href="http://www.unidata.ucar.edu/software/netcdf-java/formats/DataDiscoveryAttConvention.html#cdm_data_type_Attribute">cdm_data_type</a>
+      <br/>
+    </td>
+    <td valign="top">The <a href="http://www.unidata.ucar.edu/projects/THREDDS/tech/catalog/InvCatalogSpec.html#dataType">THREDDS data type</a> appropriate for this dataset.</td>
+    <td valign="top">metadata/dataType</td>
+    <td valign="top">/gmi:MI_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:spatialRepresentationType/gmd:MD_SpatialRepresentationTypeCode<br/> May need some extensions to this codelist. Current values:
+      vector, grid, textTable, tin, stereoModel, video.</td>
+  </tr>
+</table>
+<a href="#Identification">Identification</a> | <a href="#Text Search">Text Search</a> | <a href="#Extent Search">Extent Search</a> | <a href="#Other Extent Information">Other Extent Information</a> | <a href="#Creator Search">Creator Search</a> | <a href="#Contributor Search">Contributor Search</a> | <a href="#Publisher Search">Publisher Search</a> | <a href="#Other Attributes">Other Attributes</a>
+<hr/> Rubric Version: 2.0<br/>
+<a href="https://geo-ide.noaa.gov/wiki/index.php?title=NetCDF_Attribute_Convention_for_Dataset_Discovery">More Information</a>
+</html>


### PR DESCRIPTION
This PR pulls in enough of threddsIso to prevent the circular dependency, thus allowing us to cleanly distribute it with the TDS.

Closes Unidata/tds#591