### PR TITLE
TDM and remote catalogRefs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,10 @@ buildscript {
   }
 }
 
+plugins {
+  id("test-report-aggregation")
+}
+
 allprojects {
   // Matches Maven's "project.groupId". Used in MANIFEST.MF for "Implementation-Vendor-Id".
   group = 'edu.ucar'

--- a/gradle/root/testing.gradle
+++ b/gradle/root/testing.gradle
@@ -102,25 +102,6 @@ gradle.projectsEvaluated {
     dependsOn subprojectTestTasks
     // If we run testAll, generate coverage report after all of the tests run
   }
-
-  task rootTestReport(type: TestReport, group: 'Reports') {
-    description = 'Generates an aggregate test report'
-    destinationDir = file("$buildDir/reports/allTests")
-
-    // All Test tasks will be finalized by this task. As a result, this task needn't be invoked directly.
-    subprojectTestTasks*.finalizedBy it
-
-    // We could also do "reportOn subprojectTestTasks" here, but that would cause this task to be dependent on
-    // all subproject Tests. So, we couldn't do something like ":grib:test" and expect only GRIB tests to run
-    // because:
-    //     ":grib:test" --finalizedBy--> ":rootTestReport" --dependsOn--> "all_subproject_Tests"
-    // In other words, all subproject tests would get run, no matter what.
-    // Passing File arguments to reportOn() instead doesn't create that dependency.
-    reportOn subprojectTestTasks*.binaryResultsDirectory
-
-    // Wait until all Test tasks have run. This creates a task *ordering*, not a dependency.
-    mustRunAfter subprojectTestTasks
-  }
 }
 
 apply plugin: 'base'  // Gives us the "clean" task for removing rootTestReport's output.

--- a/tdm/build.gradle
+++ b/tdm/build.gradle
@@ -12,6 +12,7 @@ apply plugin: 'com.gradleup.shadow'
 
 dependencies {
   implementation enforcedPlatform(project(':tds-platform'))
+  testImplementation enforcedPlatform (project(':tds-testing-platform'))
 
   implementation project(':tdcommon')
   implementation 'edu.ucar:httpservices'
@@ -30,6 +31,15 @@ dependencies {
 
   implementation 'org.slf4j:slf4j-api'
   implementation 'org.apache.logging.log4j:log4j-slf4j2-impl'
+
+  testImplementation 'edu.ucar:cdm-test-utils'  // Contains stuff like the JUnit @Category classes.
+  testImplementation 'com.google.truth:truth'
+  testImplementation 'junit:junit'
+  testImplementation 'ch.qos.logback:logback-classic'
+}
+
+configurations.testRuntimeOnly {
+  exclude group: 'org.apache.logging.log4j'
 }
 
 shadowJar {

--- a/tdm/src/main/java/thredds/tdm/CatalogConfigReader.java
+++ b/tdm/src/main/java/thredds/tdm/CatalogConfigReader.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2013-2025 University Corporation for Atmospheric Research/Unidata
+ * See LICENSE for license information.
+ */
+
 package thredds.tdm;
 
 import org.jdom2.Element;
@@ -109,13 +114,16 @@ public class CatalogConfigReader {
       findNestedElems(root, "catalogRef", catrefElems);
       for (Element catrefElem : catrefElems) {
         String href = catrefElem.getAttributeValue("href", Catalog.xlinkNS);
-        File refCat = new File(catFile.getParent(), href);
-        Resource catRnested = new FileSystemResource(refCat);
-        if (!catRnested.exists()) {
-          log.error("Relative catalog {} does not exist", refCat);
-          continue;
+        // do not try to use remote catalogRefs
+        if (!(href.startsWith("https:") || href.startsWith("http:"))) {
+          File refCat = new File(catFile.getParent(), href);
+          Resource catRnested = new FileSystemResource(refCat);
+          if (!catRnested.exists()) {
+            log.error("Relative catalog {} does not exist", refCat);
+            continue;
+          }
+          readCatalog(catRnested);
         }
-        readCatalog(catRnested);
       }
     } catch (IllegalStateException e) {
       e.printStackTrace();

--- a/tdm/src/test/data/catalogs/cat_refs.xml
+++ b/tdm/src/test/data/catalogs/cat_refs.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<catalog xmlns="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  name="THREDDS Top Catalog, points to other THREDDS catalogs"
+  version="1.0.1">
+
+  <dataset name="CatalogRefs">
+    <catalogRef xlink:title="Server 1 (don't scan)" name="" xlink:href="http://motherlode.ucar.edu:8080/thredds/catalog.xml" />
+    <catalogRef xlink:title="relative catalog" name="" xlink:href="subdir/gribbby-cat.xml" />
+  </dataset>
+</catalog>

--- a/tdm/src/test/data/catalogs/subdir/gribbby-cat.xml
+++ b/tdm/src/test/data/catalogs/subdir/gribbby-cat.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<catalog xmlns="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  name="Unidata THREDDS Data Server - NCEP models"
+  version="1.0.7">
+
+  <dataset name="GRIB stuff">
+    <dataset name="Look ma, I'm GRIB!">
+      <featureCollection name="Pick me, pick me" featureType="GRIB2" path="grib/barf">
+        <collection name="GRIB-barf"
+          spec="./.*grib2$"
+          timePartition="file"
+          dateFormatMark="#baaaaarf_#yyyyMMdd_HHmm"
+          olderThan="5 min"/>
+        <tdm rewrite="test" rescan="0 16/15 * * * ? *"/>
+        <gribConfig>
+          <filesSort increasing="false" />
+        </gribConfig>
+      </featureCollection>
+    </dataset>
+  </dataset>
+</catalog>

--- a/tdm/src/test/java/thredds/tdm/CatalogConfigReaderTest.java
+++ b/tdm/src/test/java/thredds/tdm/CatalogConfigReaderTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2025 University Corporation for Atmospheric Research/Unidata
+ * See LICENSE for license information.
+ */
+
+package thredds.tdm;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.core.io.Resource;
+
+public class CatalogConfigReaderTest {
+
+  static Logger logger = (Logger) LoggerFactory.getLogger(CatalogConfigReader.class);
+  private static final ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
+
+  @BeforeClass
+  public static void setupLogger() {
+    // create and start a ListAppender
+    listAppender.start();
+    logger.addAppender(listAppender);
+  }
+
+  @After
+  public void clearLogs() {
+    listAppender.list.clear();
+  }
+
+  @AfterClass
+  public static void teardownLogger() {
+    listAppender.stop();
+    logger.detachAppender(listAppender);
+  }
+
+  @Test
+  public void catalogRefCount() throws IOException {
+    String catalogXml = "src/test/data/catalogs/cat_refs.xml";
+    Resource catalog = new FileSystemResource(catalogXml);
+    Path rootPath = Paths.get(catalogXml).toRealPath().getParent();
+    assertThat(rootPath.toFile().exists()).isTrue();
+    CatalogConfigReader catReader = new CatalogConfigReader(rootPath, catalog);
+    assertThat(catReader).isNotNull();
+    assertThat(catReader.errlog.toString()).isEmpty();
+    assertThat(catReader.getFcList()).hasSize(1);
+  }
+
+  @Test
+  public void httpCatalogRefs() throws IOException {
+    String catalogXml = "src/test/data/catalogs/cat_refs.xml";
+    Resource catalog = new FileSystemResource(catalogXml);
+    Path rootPath = Paths.get(catalogXml).toRealPath().getParent();
+    assertThat(rootPath.toFile().exists()).isTrue();
+    CatalogConfigReader catReader = new CatalogConfigReader(rootPath, catalog);
+    List<ILoggingEvent> logsList = listAppender.list;
+    assertThat(catReader).isNotNull();
+    assertThat(catReader.errlog.toString()).isEmpty();
+    // check for specific message about relative catalog not existing (for when
+    // catalogRef points to remote catalog
+    assertThat(logsList.stream().filter(e -> e.getMessage().toLowerCase().startsWith("relative catalog")
+        && e.getMessage().toLowerCase().endsWith("does not exist")).count()).isEqualTo(0);
+
+    // should not have errors in general
+    assertThat(logsList.stream().filter(e -> e.getLevel() == Level.ERROR).count()).isEqualTo(0);
+  }
+}


### PR DESCRIPTION
Fixes Unidata/tds#597. Also addresses an issue with the gradle build in that some subproject tests were being run even when a single, unrelated, subproject test was executed.