### PR TITLE
Upgrade dependencies

### DIFF
--- a/gradle/any/shared-mvn-coords.gradle
+++ b/gradle/any/shared-mvn-coords.gradle
@@ -22,7 +22,7 @@ ext {
   depVersion.gwt = '2.8.2'
   // needs to match version used in threddsIso
   depVersion.jaxen = '1.1.6'
-  depVersion.netcdfJava = '5.9.0-SNAPSHOT'
+  depVersion.netcdfJava = '5.9.0'
   // gradle seems to have issues with the compileOnly configuration, so we need to provide the full maven
   // coordinates for jakarta.servlet-api if the gradle plugin in applied. If we don't, we see errors like this:
   depVersion.jakartaServletApi = '5.0.0'

--- a/tds-platform/build.gradle
+++ b/tds-platform/build.gradle
@@ -107,12 +107,15 @@ dependencies {
     api 'org.n52.sensorweb:52n-xml-om-v20'
 
     // edal-java (ncwms)
-    def edalVersion = '1.5.3.0'
+    def edalVersion = '1.5.3.1-SNAPSHOT'
     api "uk.ac.rdg.resc:edal-common:${edalVersion}"
     api "uk.ac.rdg.resc:edal-cdm:${edalVersion}"
     api "uk.ac.rdg.resc:edal-wms:${edalVersion}"
     api "uk.ac.rdg.resc:edal-graphics:${edalVersion}"
     api "uk.ac.rdg.resc:edal-godiva:${edalVersion}"
+
+    // threddsIso
+    api 'EDS:nciso-common:2.4.8-SNAPSHOT'
 
     // gwt version defined in gradle/any/shared-mvn-coords.gradle, accessible via gradle/any/dependencies.gradle
     api "com.google.gwt:gwt-dev:${depVersion.gwt}"

--- a/tds/build.gradle
+++ b/tds/build.gradle
@@ -37,7 +37,7 @@ dependencies {
   implementation project(':dap4:d4servlet')
 
   // threddsIso
-  implementation 'EDS:nciso-common:2.4.8-SNAPSHOT'
+  implementation 'EDS:nciso-common'
 
   // Server stuff
   providedCompile "jakarta.servlet:jakarta.servlet-api:${depVersion.jakartaServletApi}"


### PR DESCRIPTION
Upgrade netCDF-Java to 5.9.0 (release), and use latest edal-java and threddsIso snapshots (which now use netCDF-Java 5.9.0 release).