### PR TITLE
Include colored_fat_arrows style with TDS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ tds/src/test/content/thredds/cache
 tds/src/test/content/thredds/state
 tds/src/test/content/thredds/notebooks/default_viewer.ipynb
 tds/src/test/content/thredds/templates/
+tds/src/test/content/thredds/wmsStyles/
 tds/src/test/content/README.txt
 tds/src/test/content/thredds/README.txt
 

--- a/docs/adminguide/src/site/pages/thredds/ThreddsConfigRef.md
+++ b/docs/adminguide/src/site/pages/thredds/ThreddsConfigRef.md
@@ -260,11 +260,10 @@ where they are contained.
   * More information on the format of palette files can also be found in the 
   [ncWMS documentation](https://reading-escience-centre.gitbooks.io/ncwms-user-guide/content/06-development.html#:~:text=To%20add%20new,in%20hexadecimal%20notation.).
   * If you created palette files for TDS 4.x and would like to use them in TDS 5.x, an open source tool named [Magic Palette Converter](https://github.com/billyz313/magic-palette-converter){:target="_blank"} for THREDDS is available to assist in the conversion (special thanks to [Billy Ashmall](https://github.com/Unidata/tds/discussions/346){:target="_blank"}!)
-* `stylesLocationDir`: optionally specify the location of the directory containing your own style files, by specifying the directory
+* `stylesLocationDir`: optionally specify the location of a directory containing your own style files, by specifying the directory
   where they are contained.
+  Note: the default directory for style files is `${tds.content.root.path}/thredds/wmsStyles` and will always be searched.
   * If the directory location starts with a `/`, the path is absolute, otherwise it is relative to `${tds.content.root.path}/thredds/`.
-  * The default directory for custom styles files is `${tds.content.root.path}/thredds/wmsStyles`.
-  * If you don't specify a custom styles directory, or specify it incorrectly, the default directory will be used.
   * More information on the format of style files can also be found in the
     [ncWMS documentation](https://reading-escience-centre.gitbooks.io/ncwms-user-guide/content/06-development.html#styles).
 * `maxImageWidth`: the maximum image width in pixels that this WMS service will return.

--- a/docs/quickstart/src/site/pages/thredds/ThreddsConfigRef.md
+++ b/docs/quickstart/src/site/pages/thredds/ThreddsConfigRef.md
@@ -260,11 +260,10 @@ Here is the description of the various options:
   * More information on the format of palette files can also be found in the
     [ncWMS documentation](https://reading-escience-centre.gitbooks.io/ncwms-user-guide/content/06-development.html#:~:text=To%20add%20new,in%20hexadecimal%20notation.).
   * If you created palette files for TDS 4.x and would like to use them in TDS 5.x, an open source tool named [Magic Palette Converter](https://github.com/billyz313/magic-palette-converter){:target="_blank"} for THREDDS is available to assist in the conversion (special thanks to [Billy Ashmall](https://github.com/Unidata/tds/discussions/346){:target="_blank"}!)
-* `stylesLocationDir`: optionally specify the location of the directory containing your own style files, by specifying the directory
+* `stylesLocationDir`: optionally specify the location of a directory containing your own style files, by specifying the directory
   where they are contained.
+  Note: the default directory for style files is `${tds.content.root.path}/thredds/wmsStyles` and will always be searched.
   * If the directory location starts with a `/`, the path is absolute, otherwise it is relative to `${tds.content.root.path}/thredds/`.
-  * The default directory for custom styles files is `${tds.content.root.path}/thredds/wmsStyles`.
-  * If you don't specify a custom styles directory, or specify it incorrectly, the default directory will be used.
   * More information on the format of style files can also be found in the
     [ncWMS documentation](https://reading-escience-centre.gitbooks.io/ncwms-user-guide/content/06-development.html#styles).
 * `maxImageWidth`: the maximum image width in pixels that this WMS service will return.

--- a/docs/userguide/src/site/pages/thredds/ThreddsConfigRef.md
+++ b/docs/userguide/src/site/pages/thredds/ThreddsConfigRef.md
@@ -260,11 +260,10 @@ where they are contained.
   * More information on the format of palette files can also be found in the 
   [ncWMS documentation](https://reading-escience-centre.gitbooks.io/ncwms-user-guide/content/06-development.html#:~:text=To%20add%20new,in%20hexadecimal%20notation.).
   * If you created palette files for TDS 4.x and would like to use them in TDS 5.x, an open source tool named [Magic Palette Converter](https://github.com/billyz313/magic-palette-converter){:target="_blank"} for THREDDS is available to assist in the conversion (special thanks to [Billy Ashmall](https://github.com/Unidata/tds/discussions/346){:target="_blank"}!)
-* `stylesLocationDir`: optionally specify the location of the directory containing your own style files, by specifying the directory
+* `stylesLocationDir`: optionally specify the location of a directory containing your own style files, by specifying the directory
   where they are contained.
+  Note: the default directory for style files is `${tds.content.root.path}/thredds/wmsStyles` and will always be searched.
   * If the directory location starts with a `/`, the path is absolute, otherwise it is relative to `${tds.content.root.path}/thredds/`.
-  * The default directory for custom styles files is `${tds.content.root.path}/thredds/wmsStyles`.
-  * If you don't specify a custom styles directory, or specify it incorrectly, the default directory will be used.
   * More information on the format of style files can also be found in the
     [ncWMS documentation](https://reading-escience-centre.gitbooks.io/ncwms-user-guide/content/06-development.html#styles).
 * `maxImageWidth`: the maximum image width in pixels that this WMS service will return.

--- a/tds/src/main/webapp/WEB-INF/altContent/startup/bundled_styles/colored_fat_arrows.xml
+++ b/tds/src/main/webapp/WEB-INF/altContent/startup/bundled_styles/colored_fat_arrows.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<StyledLayerDescriptor version="1.1.0" xsi:schemaLocation="http://www.opengis.net/sldStyledLayerDescriptor.xsd"
+  xmlns="http://www.opengis.net/sld" xmlns:ogc="http://www.opengis.net/ogc"
+  xmlns:se="http://www.opengis.net/se" xmlns:xlink="http://www.w3.org/1999/xlink"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:resc="http://www.resc.reading.ac.uk">
+  <NamedLayer>
+    <se:Name>$layerName-dir</se:Name>
+    <UserStyle>
+      <se:CoverageStyle>
+        <se:Rule>
+          <resc:ColoredSizedArrowSymbolizer>
+            <se:Opacity>$opacity</se:Opacity>
+            <resc:ArrowSizeField>$layerName-mag</resc:ArrowSizeField>
+            <resc:ArrowColourField>$layerName-mag</resc:ArrowColourField>
+            <resc:ArrowMinSize>8</resc:ArrowMinSize>
+            <resc:ArrowMaxSize>8</resc:ArrowMaxSize>
+            <resc:Range>
+              <resc:Minimum>$scaleMin</resc:Minimum>
+              <resc:Maximum>$scaleMax</resc:Maximum>
+              <resc:Spacing>$logarithmic</resc:Spacing>
+            </resc:Range>
+            <se:ColorMap>
+              <resc:Segment fallbackValue="$bgColor">
+                <se:LookupValue>Rasterdata</se:LookupValue>
+                <resc:BelowMinValue>$belowMinColor</resc:BelowMinValue>
+                <resc:ValueList>
+                  <se:Name>$paletteName</se:Name>
+                </resc:ValueList>
+                <resc:AboveMaxValue>$aboveMaxColor</resc:AboveMaxValue>
+                <resc:Range>
+                  <resc:Minimum>$scaleMin</resc:Minimum>
+                  <resc:Maximum>$scaleMax</resc:Maximum>
+                  <resc:Spacing>$logarithmic</resc:Spacing>
+                </resc:Range>
+                <resc:NumberOfSegments>$numColorBands</resc:NumberOfSegments>
+              </resc:Segment>
+            </se:ColorMap>
+            <resc:ArrowStyle>FAT_ARROW</resc:ArrowStyle>
+          </resc:ColoredSizedArrowSymbolizer>
+        </se:Rule>
+      </se:CoverageStyle>
+    </UserStyle>
+  </NamedLayer>
+</StyledLayerDescriptor>


### PR DESCRIPTION
Enable the TDS to ship with and use additional WMS styles, starting with the colored_fat_arrows style that used to be included with ncWMS v1. Fixes Unidata/TDS#596