### PR TITLE
Extend datasetScan to handle Zarr

### DIFF
--- a/tdcommon/build.gradle
+++ b/tdcommon/build.gradle
@@ -10,6 +10,7 @@ dependencies {
   testImplementation enforcedPlatform (project(':tds-testing-platform'))
   implementation 'edu.ucar:cdm-core'
   implementation 'edu.ucar:cdm-s3'
+  implementation 'edu.ucar:cdm-zarr'
   implementation 'edu.ucar:grib'
   implementation 'org.jdom:jdom2'
 

--- a/tdcommon/src/main/java/thredds/util/MFileUtils.java
+++ b/tdcommon/src/main/java/thredds/util/MFileUtils.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2025 University Corporation for Atmospheric Research/Unidata
+ * See LICENSE for license information.
+ */
+
+package thredds.util;
+
+import thredds.inventory.MFile;
+import ucar.nc2.iosp.zarr.ZarrKeys;
+
+public class MFileUtils {
+
+  /**
+   * Determine if a Zarr MFile can be opened by netCDF-Java
+   *
+   * @param mfile possible Zarr dataset
+   * @return true if can be opened by netCDF-Java
+   */
+  public static boolean isMfileZarr(MFile mfile) {
+    boolean isZarr = false;
+    boolean isDir = mfile.isDirectory();
+    if (isDir) {
+      // if directory contains a .zgroup, it can be served as a netCDF-Java
+      // zarr dataset (in addition to being explored as a directory)
+      // I think having a .array should be enough as well, but the
+      // netCDF-Java IOSP really wants a .zgroup to create the dataset.
+      // TODO: revisit if ISOP extended to work with just .zarray
+      MFile zgroup = mfile.getChild(ZarrKeys.ZGROUP);
+      isZarr = zgroup != null && zgroup.exists();
+    }
+    return isZarr;
+  }
+}

--- a/tds/src/integrationTests/java/thredds/server/catalog/TestTdsDatasetScan.java
+++ b/tds/src/integrationTests/java/thredds/server/catalog/TestTdsDatasetScan.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998-2021 University Corporation for Atmospheric Research/Unidata
+ * Copyright (c) 1998-2025 University Corporation for Atmospheric Research/Unidata
  * See LICENSE for license information.
  */
 
@@ -7,6 +7,7 @@ package thredds.server.catalog;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import java.io.IOException;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.slf4j.Logger;
@@ -148,6 +149,34 @@ public class TestTdsDatasetScan {
 
     List<Dataset> children = top.getDatasetsLocal();
     assertThat(children.size()).isEqualTo(3);
+  }
+
+  @Test
+  public void zarrLocalDatasetScan() throws IOException {
+    Catalog cat = TdsLocalCatalog.open("catalog/scanLocalZarr/zarr_test_data.zarr/catalog.xml");
+    assertThat(cat).isNotNull();
+
+    final Dataset dataset = cat.findDatasetByID("scanLocalZarr/zarr_test_data.zarr/group_with_dims");
+    assertThat(dataset).isNotNull();
+    assertThat(dataset.getServiceNameDefault()).ignoringCase().isEqualTo("all");
+
+    final Dataset zarrComponentDataset = cat.findDatasetByID("scanLocalZarr/zarr_test_data.zarr/.zgroup");
+    assertThat(zarrComponentDataset).isNotNull();
+    assertThat(zarrComponentDataset.getServiceNameDefault()).ignoringCase().isEqualTo("HTTPServer");
+  }
+
+  @Test
+  public void zarrS3DatasetScan() throws IOException {
+    Catalog cat = TdsLocalCatalog.open("catalog/s3-dataset-scan-zarr/zarr_test_data.zarr/catalog.xml");
+    assertThat(cat).isNotNull();
+
+    final Dataset dataset = cat.findDatasetByID("testS3DatasetScanZarr/zarr_test_data.zarr/group_with_dims");
+    assertThat(dataset).isNotNull();
+    assertThat(dataset.getServiceNameDefault()).ignoringCase().isEqualTo("all");
+
+    final Dataset zarrComponentDataset = cat.findDatasetByID("testS3DatasetScanZarr/zarr_test_data.zarr/.zgroup");
+    assertThat(zarrComponentDataset).isNotNull();
+    assertThat(zarrComponentDataset.getServiceNameDefault()).ignoringCase().isEqualTo("HTTPServer");
   }
 
   //////////////////////////////////////////////////////

--- a/tds/src/integrationTests/java/thredds/tds/TestZarr.java
+++ b/tds/src/integrationTests/java/thredds/tds/TestZarr.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2024-2025 University Corporation for Atmospheric Research/Unidata
+ * See LICENSE for license information.
+ */
+
 package thredds.tds;
 
 import static com.google.common.truth.Truth.assertThat;
@@ -11,6 +16,8 @@ public class TestZarr {
   final private static String ZARR_DIR_PATH = "localContent/zarr/zarr_test_data.zarr";
   final private static String ZARR_ZIP_PATH = "localContent/zarr/zarr_test_data.zip";
   final private static String ZARR_S3_PATH = "s3-zarr/zarr_test_data.zarr/";
+  final private static String ZARR_DIR_DATASET_SCAN_PATH = "scanLocalZarr/zarr_test_data.zarr/";
+  final private static String ZARR_S3_DATASET_SCAN_PATH = "s3-dataset-scan-zarr/zarr_test_data.zarr/";
 
   @Test
   public void shouldOpenZarrDirectory() {
@@ -28,10 +35,35 @@ public class TestZarr {
   }
 
   @Test
+  public void shouldOpenDatasetScanZarr() {
+    checkWithOpendap(ZARR_DIR_DATASET_SCAN_PATH);
+    checkWithOpendap(ZARR_S3_DATASET_SCAN_PATH);
+  }
+
+  @Test
   public void shouldOpenZarrTwice() {
     // Test it works correctly with the netcdf file cache
     checkWithOpendap(ZARR_DIR_PATH);
     checkWithOpendap(ZARR_DIR_PATH);
+  }
+
+  @Test
+  public void dirFileServerLocal() {
+    // The HTTPServer service normally returns a status code 400 for requests for a directory
+    // However, in the case of a Zarr dataset, we should return a 200 with a zero byte response
+    checkWithHttpServer(ZARR_DIR_DATASET_SCAN_PATH);
+  }
+
+  @Test
+  public void dirFileServerS3() {
+    // The HTTPServer service normally returns a status code 400 for requests for a directory
+    // However, in the case of a Zarr dataset, we should return a 200 with a zero byte response
+    checkWithHttpServer(ZARR_S3_DATASET_SCAN_PATH);
+  }
+
+  private static void checkWithHttpServer(String path) {
+    final String endpoint = TestOnLocalServer.withHttpPath("fileServer/" + path);
+    TestOnLocalServer.getContent(endpoint, HttpServletResponse.SC_OK);
   }
 
   private static void checkWithOpendap(String path) {

--- a/tds/src/main/java/thredds/servlet/ServletUtil.java
+++ b/tds/src/main/java/thredds/servlet/ServletUtil.java
@@ -1,9 +1,11 @@
 /*
- * Copyright (c) 1998-2018 John Caron and University Corporation for Atmospheric Research/Unidata
+ * Copyright (c) 1998-2025 John Caron and University Corporation for Atmospheric Research/Unidata
  * See LICENSE for license information.
  */
 
 package thredds.servlet;
+
+import static thredds.util.MFileUtils.isMfileZarr;
 
 import java.nio.charset.StandardCharsets;
 import jakarta.servlet.ServletContext;
@@ -290,15 +292,19 @@ public class ServletUtil {
 
     final MFile file = MFiles.create(location);
 
-    if (file == null) {
+    if (file == null || !file.exists()) {
       response.sendError(HttpServletResponse.SC_NOT_FOUND, "Could not find file with URL path: " + requestPath);
       return;
     }
 
     if (file.isDirectory() && !file.isZipFile()) {
-      response.sendError(HttpServletResponse.SC_BAD_REQUEST,
-          "Expected a file name instead of a directory for URL path: " + requestPath);
-      return;
+      if (isMfileZarr(file)) {
+        return;
+      } else {
+        response.sendError(HttpServletResponse.SC_BAD_REQUEST,
+            "Expected a file name instead of a directory for URL path: " + requestPath);
+        return;
+      }
     }
 
     response.setContentType(getContentType(requestPath, request.getServletContext()));

--- a/tds/src/test/content/thredds/tds-zarr.xml
+++ b/tds/src/test/content/thredds/tds-zarr.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <catalog name="Zarr Test Catalog"
   xmlns="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0"
-  xmlns:ncml="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2" version="1.2">
+  version="1.2">
 
   <dataset name="Test Zarr Directory" ID="test-zarr-dir" urlPath="localContent/zarr/zarr_test_data.zarr" serviceName="all"/>
 
@@ -9,4 +9,21 @@
 
   <datasetRoot path="s3-zarr" location="cdms3:unidata-zarr-test-data#delimiter=/" />
   <dataset name="Test S3 Zarr" ID="test-s3-zarr" urlPath="s3-zarr/zarr_test_data.zarr/" serviceName="all"/>
+
+  <datasetScan name="Filesystem Dataset Scan Zarr" path="scanLocalZarr" location="content/testdata/zarr">
+    <metadata inherited="true">
+      <serviceName>all</serviceName>
+    </metadata>
+    <sort>
+      <lexigraphicByName increasing="true"/>
+    </sort>
+  </datasetScan>
+
+  <datasetScan name="S3 Dataset Scan Zarr"
+    ID="testS3DatasetScanZarr"
+    path="s3-dataset-scan-zarr"
+    location="cdms3:unidata-zarr-test-data#delimiter=/">
+    <serviceName>all</serviceName>
+  </datasetScan>
+
 </catalog>


### PR DESCRIPTION
Expose Zarr "directory" dataset as both a catalogRef and a direct access dataset for datasetScan generated catalogs. Fixes Unidata/tds#619