### PR TITLE
Extend datasetScan to optionally exclude empty directories 

### DIFF
--- a/docs/adminguide/src/site/_config.yml
+++ b/docs/adminguide/src/site/_config.yml
@@ -81,3 +81,4 @@ netcdf-java_docset_version: 5.9
 tomcat_version: 10.1
 java_version: 17
 servlet_spec: 6.0
+inv_catalog_schema_version: 1.3

--- a/docs/adminguide/src/site/pages/tds_tutorial/client_catalogs/XmlValidation.md
+++ b/docs/adminguide/src/site/pages/tds_tutorial/client_catalogs/XmlValidation.md
@@ -34,6 +34,6 @@ Or, you can simply use the [THREDDS Catalog Validation service](https://thredds.
 This service already knows where the schemas are located, so it's not necessary to add that information to the catalog; you only need it if you want to do your own validation.
 
 {%include note.html content="
-For more information, you can look at the [schema](https://www.unidata.ucar.edu/schemas/thredds/InvCatalog.1.0.7.xsd){:target='_blank'} referenced in the above example.
+For more information, you can look at the [schema](https://schemas.unidata.ucar.edu/thredds/InvCatalog.1.0.7.xsd){:target='_blank'} referenced in the above example.
 However, you'll probably want to study the [catalog specification](client_side_catalog_specification.html) instead, as it is much more digestible.
 " %}

--- a/docs/adminguide/src/site/pages/tds_tutorial/feature_collections/GribFeatureCollections.md
+++ b/docs/adminguide/src/site/pages/tds_tutorial/feature_collections/GribFeatureCollections.md
@@ -105,7 +105,7 @@ And, this is the result:
 
 ~~~xml
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<catalog xmlns="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0" version="1.2" name="FNL-2010-01" xmlns:xlink="http://www.w3.org/1999/xlink">
+<catalog xmlns="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0" version="{{ site.inv_catalog_schema_version }}" name="FNL-2010-01" xmlns:xlink="http://www.w3.org/1999/xlink">
   <service name="VirtualServices" base="" serviceType="Compound">
     <service name="ncdods" base="/thredds/dodsC/" serviceType="OPENDAP"/>
     <service name="wcs" base="/thredds/wcs/" serviceType="WCS"/>

--- a/docs/adminguide/src/site/pages/thredds/DatasetScanRef.md
+++ b/docs/adminguide/src/site/pages/thredds/DatasetScanRef.md
@@ -357,3 +357,18 @@ So, when cataloged, this dataset would end up as something like this:
 <dataset name="NCEP GFS 191km Alaska 2005-10-11 00:00:00 GMT"
          urlPath="models/NCEP/GFS/Alaska_191km/GFS_Alaska_191km_20051011_0000.grib1"/>
 ~~~
+
+## Skipping Empty Directories
+
+By default, `datasetScan` will add a `catalogRef` for each directory that it finds, including directories that are empty.
+Starting with version 5.9 of the TDS, you can skip empty directories by adding the `excludeEmptyDirs="true"` attribute to the `datasetScan` element.
+For example:
+
+~~~xml
+<datasetScan name="Dataset Name" path="unique/path"
+  location="/data/directory/to/scan"
+  excludeEmptyDirs="true">
+~~~
+
+This will cause `datasetScan` to skip adding `catalogRef`s for empty directories.
+To preserve backwards compatibility, the `excludeEmptyDirs` attribute defaults to `false`.

--- a/docs/adminguide/src/site/pages/thredds/DatasetScanRef.md
+++ b/docs/adminguide/src/site/pages/thredds/DatasetScanRef.md
@@ -18,7 +18,7 @@ Here is a minimal catalog containing a `datasetScan` element:
 
 ~~~xml
 <?xml version="1.0" encoding="UTF-8"?>
-<catalog name="Unidata Workshop 2006 - NCEP Model Data" version="1.0.1"
+<catalog name="Unidata Workshop 2006 - NCEP Model Data" version="{{ site.inv_catalog_schema_version }}"
     xmlns="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0"
     xmlns:xlink="http://www.w3.org/1999/xlink">
   <service name="myserver" serviceType="OpenDAP" base="/thredds/dodsC/" />
@@ -40,7 +40,7 @@ The main points are:
 In the catalog that the TDS server sends to a client, the `datasetScan` element is shown as a catalog reference:
 
 ~~~xml
-<catalog name="Unidata Workshop 2006 - NCEP Model Data" version="1.0.1"
+<catalog name="Unidata Workshop 2006 - NCEP Model Data" version="{{ site.inv_catalog_schema_version }}"
     xmlns="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0"
     xmlns:xlink="http://www.w3.org/1999/xlink">
 
@@ -124,7 +124,7 @@ The `datasetScan` element is an extension of a `dataset` element, and it can con
 Typically, you want all of its contained datasets to inherit the `metadata`, so add an inherited `metadata` element contained in the `datasetScan` element, for example:
 
 ~~~xml
-<catalog name="Unidata Workshop 2006 - NCEP Model Data" version="1.0.1"
+<catalog name="Unidata Workshop 2006 - NCEP Model Data" version="{{ site.inv_catalog_schema_version }}"
     xmlns="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0">
 
   <service name="myserver" serviceType="OpenDAP" base="/thredds/dodsC/" />
@@ -176,7 +176,7 @@ Its a good idea to always use a filter element with explicit includes, so if str
 
 ~~~xml
 <?xml version="1.0" encoding="UTF-8"?>
-<catalog name="Unidata Workshop 2006 - NCEP Model Data" version="1.0.1"
+<catalog name="Unidata Workshop 2006 - NCEP Model Data" version="{{ site.inv_catalog_schema_version }}"
     xmlns="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0"
     xmlns:xlink="http://www.w3.org/1999/xlink">
 
@@ -209,7 +209,7 @@ A few gotchas to remember:
 
 ~~~xml
 <?xml version="1.0" encoding="UTF-8"?>
-<catalog name="Unidata Workshop 2006 - NCEP Model Data" version="1.0.1"
+<catalog name="Unidata Workshop 2006 - NCEP Model Data" version="{{ site.inv_catalog_schema_version }}"
     xmlns="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0"
     xmlns:xlink="http://www.w3.org/1999/xlink">
 

--- a/docs/adminguide/src/site/pages/thredds/GribConfigRef.md
+++ b/docs/adminguide/src/site/pages/thredds/GribConfigRef.md
@@ -345,9 +345,9 @@ Sort the files [lexicographically](https://en.wikipedia.org/wiki/Lexicographical
 
 ## `gribConfig` XML Schema
 
-The `gribConfig` schema definition, version 1.2.
+The `gribConfig` schema definition, version 1.3.
 
-see: [https://schemas.unidata.ucar.edu/thredds/InvCatalog.1.2.xsd](https://schemas.unidata.ucar.edu/thredds/InvCatalog.1.2.xsd){:target="_blank"}
+see: [https://schemas.unidata.ucar.edu/thredds/InvCatalog.{{ site.inv_catalog_schema_version }}.xsd](https://schemas.unidata.ucar.edu/thredds/InvCatalog.{{ site.inv_catalog_schema_version }}.xsd){:target="_blank"}
 
 ~~~xsd
 <xsd:complexType name="gribConfigType">

--- a/docs/adminguide/src/site/pages/thredds/GribConfigRef.md
+++ b/docs/adminguide/src/site/pages/thredds/GribConfigRef.md
@@ -347,7 +347,7 @@ Sort the files [lexicographically](https://en.wikipedia.org/wiki/Lexicographical
 
 The `gribConfig` schema definition, version 1.2.
 
-see: [https://www.unidata.ucar.edu/schemas/thredds/InvCatalog.1.2.xsd](https://www.unidata.ucar.edu/schemas/thredds/InvCatalog.1.2.xsd){:target="_blank"}
+see: [https://schemas.unidata.ucar.edu/thredds/InvCatalog.1.2.xsd](https://schemas.unidata.ucar.edu/thredds/InvCatalog.1.2.xsd){:target="_blank"}
 
 ~~~xsd
 <xsd:complexType name="gribConfigType">

--- a/docs/adminguide/src/site/pages/thredds/InvCatalogClientSpec.md
+++ b/docs/adminguide/src/site/pages/thredds/InvCatalogClientSpec.md
@@ -18,7 +18,7 @@ Related resources:
 
 * [Client Catalog Primer](basic_client_catalog.html) 
 * [Client Catalog Example](https://thredds.ucar.edu/thredds/idd/forecastModels.xml){:target="_blank"} 
-* [Catalog XML Schema](https://www.unidata.ucar.edu/schemas/thredds/InvCatalog.1.2.xsd){:target="_blank"}
+* [Catalog XML Schema](https://schemas.unidata.ucar.edu/thredds/InvCatalog.1.2.xsd){:target="_blank"}
 * [Server-Side Catalog Specification](server_side_catalog_specification.html)
 
 ## Base Catalog Elements

--- a/docs/adminguide/src/site/pages/thredds/InvCatalogClientSpec.md
+++ b/docs/adminguide/src/site/pages/thredds/InvCatalogClientSpec.md
@@ -18,7 +18,7 @@ Related resources:
 
 * [Client Catalog Primer](basic_client_catalog.html) 
 * [Client Catalog Example](https://thredds.ucar.edu/thredds/idd/forecastModels.xml){:target="_blank"} 
-* [Catalog XML Schema](https://schemas.unidata.ucar.edu/thredds/InvCatalog.1.2.xsd){:target="_blank"}
+* [Catalog XML Schema](https://schemas.unidata.ucar.edu/thredds/InvCatalog.{{ site.inv_catalog_schema_version }}.xsd){:target="_blank"}
 * [Server-Side Catalog Specification](server_side_catalog_specification.html)
 
 ## Base Catalog Elements

--- a/docs/adminguide/src/site/pages/thredds/InvCatalogServerSpec.md
+++ b/docs/adminguide/src/site/pages/thredds/InvCatalogServerSpec.md
@@ -16,7 +16,7 @@ Also, see:
 
 * [DatasetScan](tds_dataset_scan_ref.html) reference
 * [FeatureCollection](feature_collections_ref.html) reference
-* [Catalog XML Schema](https://schemas.unidata.ucar.edu/thredds/InvCatalog.1.2.xsd){:target="_blank"}
+* [Catalog XML Schema](https://schemas.unidata.ucar.edu/thredds/InvCatalog.{{ site.inv_catalog_schema_version }}.xsd){:target="_blank"}
 * [Client-Side Catalog Specification](client_side_catalog_specification.html)
 
 ## Base Catalog Elements

--- a/docs/adminguide/src/site/pages/thredds/InvCatalogServerSpec.md
+++ b/docs/adminguide/src/site/pages/thredds/InvCatalogServerSpec.md
@@ -154,18 +154,20 @@ A `datasetScan` can be used wherever a `dataset` element is allowed.
         <xsd:attribute name="path" type="xsd:string" use="required"/>
         <xsd:attribute name="location" type="xsd:string"/>
         <xsd:attribute name="addLatest" type="xsd:boolean"/>
+        <xsd:attribute name="excludeEmptyDirs" type="xsd:boolean"/>
       </xsd:extension>
     </xsd:complexContent>
   </xsd:complexType>
 </xsd:element>
 ~~~
 
-* The `datasetScan` element generates nested THREDDS catalogs by scanning the directory named in the `location` attribute, and creating a `dataset` for each file found, and a `catalogRef` for each subdirectory. 
-* The location must be an absolute path. 
-* The `path` attribute is used to create the URL for these files and catalogs. 
-* The path must be globally unique over all paths for the TDS. 
-* Do not put leading or trailing slashes on the path.
+* The `datasetScan` element generates nested THREDDS catalogs by scanning the directory named in the `location` attribute, and creating a `dataset` for each file found, and a `catalogRef` for each subdirectory.
+  The location must be an absolute path.
+* The `path` attribute is used to create the URL for these files and catalogs.
+  The path must be globally unique over all paths for the TDS.
+  Do not put leading or trailing slashes on the path.
 * The `addLatest` attribute adds a *latest resolver service* to the `datasetScan`.
+* The `excludeEmptyDirs` configures the `datasetScan` to skip adding `catalogRef`s for empty directories.
 
 A `datasetScan` element is in the `dataset substitutionGroup`, so it can be used wherever a `dataset` element can be used. 
 It is an extension of a `DatasetType`, so any of the `dataset` element nested elements and attributes can be used in it. 

--- a/docs/adminguide/src/site/pages/thredds/InvCatalogServerSpec.md
+++ b/docs/adminguide/src/site/pages/thredds/InvCatalogServerSpec.md
@@ -16,7 +16,7 @@ Also, see:
 
 * [DatasetScan](tds_dataset_scan_ref.html) reference
 * [FeatureCollection](feature_collections_ref.html) reference
-* [Catalog XML Schema](https://www.unidata.ucar.edu/schemas/thredds/InvCatalog.1.2.xsd){:target="_blank"}
+* [Catalog XML Schema](https://schemas.unidata.ucar.edu/thredds/InvCatalog.1.2.xsd){:target="_blank"}
 * [Client-Side Catalog Specification](client_side_catalog_specification.html)
 
 ## Base Catalog Elements

--- a/docs/quickstart/src/site/_config.yml
+++ b/docs/quickstart/src/site/_config.yml
@@ -81,3 +81,4 @@ netcdf-java_docset_version: 5.9
 tomcat_version: 10.1
 java_version: 17
 servlet_spec: 6.0
+inv_catalog_schema_version: 1.3

--- a/docs/quickstart/src/site/pages/tds_tutorial/client_catalogs/XmlValidation.md
+++ b/docs/quickstart/src/site/pages/tds_tutorial/client_catalogs/XmlValidation.md
@@ -34,6 +34,6 @@ Or, you can simply use the [THREDDS Catalog Validation service](https://thredds.
 This service already knows where the schemas are located, so it's not necessary to add that information to the catalog; you only need it if you want to do your own validation.
 
 {%include note.html content="
-For more information, you can look at the [schema](https://www.unidata.ucar.edu/schemas/thredds/InvCatalog.1.0.7.xsd){:target='_blank'} referenced in the above example.
+For more information, you can look at the [schema](https://schemas.unidata.ucar.edu/thredds/InvCatalog.1.0.7.xsd){:target='_blank'} referenced in the above example.
 However, you'll probably want to study the [catalog specification](client_side_catalog_specification.html) instead, as it is much more digestible.
 " %}

--- a/docs/quickstart/src/site/pages/tds_tutorial/feature_collections/GribFeatureCollections.md
+++ b/docs/quickstart/src/site/pages/tds_tutorial/feature_collections/GribFeatureCollections.md
@@ -105,7 +105,7 @@ And, this is the result:
 
 ~~~xml
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<catalog xmlns="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0" version="1.2" name="FNL-2010-01" xmlns:xlink="http://www.w3.org/1999/xlink">
+<catalog xmlns="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0" version="{{ site.inv_catalog_schema_version }}" name="FNL-2010-01" xmlns:xlink="http://www.w3.org/1999/xlink">
   <service name="VirtualServices" base="" serviceType="Compound">
     <service name="ncdods" base="/thredds/dodsC/" serviceType="OPENDAP"/>
     <service name="wcs" base="/thredds/wcs/" serviceType="WCS"/>

--- a/docs/quickstart/src/site/pages/tds_tutorial/production/Upgrade.md
+++ b/docs/quickstart/src/site/pages/tds_tutorial/production/Upgrade.md
@@ -323,7 +323,7 @@ Here are some additional, optional changes you can make to increase maintainabil
 
   ~~~xml
   <?xml version='1.0' encoding='UTF-8'?>
-  <catalog name="ESGF Master Catalog" version="1.2"
+  <catalog name="ESGF Master Catalog" version="{{ site.inv_catalog_schema_version }}"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xlink="http://www.w3.org/1999/xlink"
         xmlns="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0"
         xsi:schemaLocation="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0 https://schemas.unidata.ucar.edu/thredds/InvCatalog.1.2.xsd">

--- a/docs/quickstart/src/site/pages/thredds/DatasetScanRef.md
+++ b/docs/quickstart/src/site/pages/thredds/DatasetScanRef.md
@@ -357,3 +357,18 @@ So, when cataloged, this dataset would end up as something like this:
 <dataset name="NCEP GFS 191km Alaska 2005-10-11 00:00:00 GMT"
          urlPath="models/NCEP/GFS/Alaska_191km/GFS_Alaska_191km_20051011_0000.grib1"/>
 ~~~
+
+## Skipping Empty Directories
+
+By default, `datasetScan` will add a `catalogRef` for each directory that it finds, including directories that are empty.
+Starting with version 5.9 of the TDS, you can skip empty directories by adding the `excludeEmptyDirs="true"` attribute to the `datasetScan` element.
+For example:
+
+~~~xml
+<datasetScan name="Dataset Name" path="unique/path"
+  location="/data/directory/to/scan"
+  excludeEmptyDirs="true">
+~~~
+
+This will cause `datasetScan` to skip adding `catalogRef`s for empty directories.
+To preserve backwards compatibility, the `excludeEmptyDirs` attribute defaults to `false`.

--- a/docs/quickstart/src/site/pages/thredds/DatasetScanRef.md
+++ b/docs/quickstart/src/site/pages/thredds/DatasetScanRef.md
@@ -18,7 +18,7 @@ Here is a minimal catalog containing a `datasetScan` element:
 
 ~~~xml
 <?xml version="1.0" encoding="UTF-8"?>
-<catalog name="Unidata Workshop 2006 - NCEP Model Data" version="1.0.1"
+<catalog name="Unidata Workshop 2006 - NCEP Model Data" version="{{ site.inv_catalog_schema_version }}"
     xmlns="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0"
     xmlns:xlink="http://www.w3.org/1999/xlink">
   <service name="myserver" serviceType="OpenDAP" base="/thredds/dodsC/" />
@@ -40,7 +40,7 @@ The main points are:
 In the catalog that the TDS server sends to a client, the `datasetScan` element is shown as a catalog reference:
 
 ~~~xml
-<catalog name="Unidata Workshop 2006 - NCEP Model Data" version="1.0.1"
+<catalog name="Unidata Workshop 2006 - NCEP Model Data" version="{{ site.inv_catalog_schema_version }}"
     xmlns="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0"
     xmlns:xlink="http://www.w3.org/1999/xlink">
 
@@ -124,7 +124,7 @@ The `datasetScan` element is an extension of a `dataset` element, and it can con
 Typically, you want all of its contained datasets to inherit the `metadata`, so add an inherited `metadata` element contained in the `datasetScan` element, for example:
 
 ~~~xml
-<catalog name="Unidata Workshop 2006 - NCEP Model Data" version="1.0.1"
+<catalog name="Unidata Workshop 2006 - NCEP Model Data" version="{{ site.inv_catalog_schema_version }}"
     xmlns="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0">
 
   <service name="myserver" serviceType="OpenDAP" base="/thredds/dodsC/" />
@@ -176,7 +176,7 @@ Its a good idea to always use a filter element with explicit includes, so if str
 
 ~~~xml
 <?xml version="1.0" encoding="UTF-8"?>
-<catalog name="Unidata Workshop 2006 - NCEP Model Data" version="1.0.1"
+<catalog name="Unidata Workshop 2006 - NCEP Model Data" version="{{ site.inv_catalog_schema_version }}"
     xmlns="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0"
     xmlns:xlink="http://www.w3.org/1999/xlink">
 
@@ -209,7 +209,7 @@ A few gotchas to remember:
 
 ~~~xml
 <?xml version="1.0" encoding="UTF-8"?>
-<catalog name="Unidata Workshop 2006 - NCEP Model Data" version="1.0.1"
+<catalog name="Unidata Workshop 2006 - NCEP Model Data" version="{{ site.inv_catalog_schema_version }}"
     xmlns="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0"
     xmlns:xlink="http://www.w3.org/1999/xlink">
 

--- a/docs/quickstart/src/site/pages/thredds/GribConfigRef.md
+++ b/docs/quickstart/src/site/pages/thredds/GribConfigRef.md
@@ -347,7 +347,7 @@ Sort the files [lexicographically](https://en.wikipedia.org/wiki/Lexicographical
 
 The `gribConfig` schema definition, version 1.2.
 
-see: [https://www.unidata.ucar.edu/schemas/thredds/InvCatalog.1.2.xsd](https://www.unidata.ucar.edu/schemas/thredds/InvCatalog.1.2.xsd){:target="_blank"}
+see: [https://schemas.unidata.ucar.edu/thredds/InvCatalog.1.2.xsd](https://schemas.unidata.ucar.edu/thredds/InvCatalog.1.2.xsd){:target="_blank"}
 
 ~~~xsd
 <xsd:complexType name="gribConfigType">

--- a/docs/quickstart/src/site/pages/thredds/GribConfigRef.md
+++ b/docs/quickstart/src/site/pages/thredds/GribConfigRef.md
@@ -347,7 +347,7 @@ Sort the files [lexicographically](https://en.wikipedia.org/wiki/Lexicographical
 
 The `gribConfig` schema definition, version 1.2.
 
-see: [https://schemas.unidata.ucar.edu/thredds/InvCatalog.1.2.xsd](https://schemas.unidata.ucar.edu/thredds/InvCatalog.1.2.xsd){:target="_blank"}
+see: [https://schemas.unidata.ucar.edu/thredds/InvCatalog.{{ site.inv_catalog_schema_version }}.xsd](https://schemas.unidata.ucar.edu/thredds/InvCatalog.{{ site.inv_catalog_schema_version }}.xsd){:target="_blank"}
 
 ~~~xsd
 <xsd:complexType name="gribConfigType">

--- a/docs/quickstart/src/site/pages/thredds/InvCatalogClientSpec.md
+++ b/docs/quickstart/src/site/pages/thredds/InvCatalogClientSpec.md
@@ -18,7 +18,7 @@ Related resources:
 
 * [Client Catalog Primer](basic_client_catalog.html) 
 * [Client Catalog Example](https://thredds.ucar.edu/thredds/idd/forecastModels.xml){:target="_blank"} 
-* [Catalog XML Schema](https://www.unidata.ucar.edu/schemas/thredds/InvCatalog.1.2.xsd){:target="_blank"}
+* [Catalog XML Schema](https://schemas.unidata.ucar.edu/thredds/InvCatalog.1.2.xsd){:target="_blank"}
 * [Server-Side Catalog Specification](server_side_catalog_specification.html)
 
 ## Base Catalog Elements

--- a/docs/quickstart/src/site/pages/thredds/InvCatalogClientSpec.md
+++ b/docs/quickstart/src/site/pages/thredds/InvCatalogClientSpec.md
@@ -18,7 +18,7 @@ Related resources:
 
 * [Client Catalog Primer](basic_client_catalog.html) 
 * [Client Catalog Example](https://thredds.ucar.edu/thredds/idd/forecastModels.xml){:target="_blank"} 
-* [Catalog XML Schema](https://schemas.unidata.ucar.edu/thredds/InvCatalog.1.2.xsd){:target="_blank"}
+* [Catalog XML Schema](https://schemas.unidata.ucar.edu/thredds/InvCatalog.{{ site.inv_catalog_schema_version }}.xsd){:target="_blank"}
 * [Server-Side Catalog Specification](server_side_catalog_specification.html)
 
 ## Base Catalog Elements

--- a/docs/quickstart/src/site/pages/thredds/InvCatalogServerSpec.md
+++ b/docs/quickstart/src/site/pages/thredds/InvCatalogServerSpec.md
@@ -16,7 +16,7 @@ Also, see:
 
 * [DatasetScan](tds_dataset_scan_ref.html) reference
 * [FeatureCollection](feature_collections_ref.html) reference
-* [Catalog XML Schema](https://schemas.unidata.ucar.edu/thredds/InvCatalog.1.2.xsd){:target="_blank"}
+* [Catalog XML Schema](https://schemas.unidata.ucar.edu/thredds/InvCatalog.{{ site.inv_catalog_schema_version }}.xsd){:target="_blank"}
 * [Client-Side Catalog Specification](client_side_catalog_specification.html)
 
 ## Base Catalog Elements

--- a/docs/quickstart/src/site/pages/thredds/InvCatalogServerSpec.md
+++ b/docs/quickstart/src/site/pages/thredds/InvCatalogServerSpec.md
@@ -154,18 +154,20 @@ A `datasetScan` can be used wherever a `dataset` element is allowed.
         <xsd:attribute name="path" type="xsd:string" use="required"/>
         <xsd:attribute name="location" type="xsd:string"/>
         <xsd:attribute name="addLatest" type="xsd:boolean"/>
+        <xsd:attribute name="excludeEmptyDirs" type="xsd:boolean"/>
       </xsd:extension>
     </xsd:complexContent>
   </xsd:complexType>
 </xsd:element>
 ~~~
 
-* The `datasetScan` element generates nested THREDDS catalogs by scanning the directory named in the `location` attribute, and creating a `dataset` for each file found, and a `catalogRef` for each subdirectory. 
-* The location must be an absolute path. 
-* The `path` attribute is used to create the URL for these files and catalogs. 
-* The path must be globally unique over all paths for the TDS. 
-* Do not put leading or trailing slashes on the path.
+* The `datasetScan` element generates nested THREDDS catalogs by scanning the directory named in the `location` attribute, and creating a `dataset` for each file found, and a `catalogRef` for each subdirectory.
+  The location must be an absolute path.
+* The `path` attribute is used to create the URL for these files and catalogs.
+  The path must be globally unique over all paths for the TDS.
+  Do not put leading or trailing slashes on the path.
 * The `addLatest` attribute adds a *latest resolver service* to the `datasetScan`.
+* The `excludeEmptyDirs` configures the `datasetScan` to skip adding `catalogRef`s for empty directories.
 
 A `datasetScan` element is in the `dataset substitutionGroup`, so it can be used wherever a `dataset` element can be used. 
 It is an extension of a `DatasetType`, so any of the `dataset` element nested elements and attributes can be used in it. 

--- a/docs/quickstart/src/site/pages/thredds/InvCatalogServerSpec.md
+++ b/docs/quickstart/src/site/pages/thredds/InvCatalogServerSpec.md
@@ -16,7 +16,7 @@ Also, see:
 
 * [DatasetScan](tds_dataset_scan_ref.html) reference
 * [FeatureCollection](feature_collections_ref.html) reference
-* [Catalog XML Schema](https://www.unidata.ucar.edu/schemas/thredds/InvCatalog.1.2.xsd){:target="_blank"}
+* [Catalog XML Schema](https://schemas.unidata.ucar.edu/thredds/InvCatalog.1.2.xsd){:target="_blank"}
 * [Client-Side Catalog Specification](client_side_catalog_specification.html)
 
 ## Base Catalog Elements

--- a/docs/userguide/src/site/_config.yml
+++ b/docs/userguide/src/site/_config.yml
@@ -80,3 +80,4 @@ netcdf-java_docset_version: 5.9
 tomcat_version: 10.1
 java_version: 17
 servlet_spec: 6.0
+inv_catalog_schema_version: 1.3

--- a/docs/userguide/src/site/pages/tds_tutorial/client_catalogs/XmlValidation.md
+++ b/docs/userguide/src/site/pages/tds_tutorial/client_catalogs/XmlValidation.md
@@ -34,6 +34,6 @@ Or, you can simply use the [THREDDS Catalog Validation service](https://thredds.
 This service already knows where the schemas are located, so it's not necessary to add that information to the catalog; you only need it if you want to do your own validation.
 
 {%include note.html content="
-For more information, you can look at the [schema](https://www.unidata.ucar.edu/schemas/thredds/InvCatalog.1.0.7.xsd){:target='_blank'} referenced in the above example.
+For more information, you can look at the [schema](https://schemas.unidata.ucar.edu/thredds/InvCatalog.1.0.7.xsd){:target='_blank'} referenced in the above example.
 However, you'll probably want to study the [catalog specification](client_side_catalog_specification.html) instead, as it is much more digestible.
 " %}

--- a/docs/userguide/src/site/pages/tds_tutorial/feature_collections/GribFeatureCollections.md
+++ b/docs/userguide/src/site/pages/tds_tutorial/feature_collections/GribFeatureCollections.md
@@ -105,7 +105,7 @@ And, this is the result:
 
 ~~~xml
 <?xml version="1.0" encoding="ISO-8859-1"?>
-<catalog xmlns="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0" version="1.2" name="FNL-2010-01" xmlns:xlink="http://www.w3.org/1999/xlink">
+<catalog xmlns="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0" version="{{ site.inv_catalog_schema_version }}" name="FNL-2010-01" xmlns:xlink="http://www.w3.org/1999/xlink">
   <service name="VirtualServices" base="" serviceType="Compound">
     <service name="ncdods" base="/thredds/dodsC/" serviceType="OPENDAP"/>
     <service name="wcs" base="/thredds/wcs/" serviceType="WCS"/>

--- a/docs/userguide/src/site/pages/tds_tutorial/production/Upgrade.md
+++ b/docs/userguide/src/site/pages/tds_tutorial/production/Upgrade.md
@@ -322,7 +322,7 @@ Here are some additional, optional changes you can make to increase maintainabil
 
   ~~~xml
   <?xml version='1.0' encoding='UTF-8'?>
-  <catalog name="ESGF Master Catalog" version="1.2"
+  <catalog name="ESGF Master Catalog" version="{{ site.inv_catalog_schema_version }}"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xlink="http://www.w3.org/1999/xlink"
         xmlns="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0"
         xsi:schemaLocation="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0 https://schemas.unidata.ucar.edu/thredds/InvCatalog.1.2.xsd">

--- a/docs/userguide/src/site/pages/thredds/DatasetScanRef.md
+++ b/docs/userguide/src/site/pages/thredds/DatasetScanRef.md
@@ -360,3 +360,18 @@ So, when cataloged, this dataset would end up as something like this:
 <dataset name="NCEP GFS 191km Alaska 2005-10-11 00:00:00 GMT"
          urlPath="models/NCEP/GFS/Alaska_191km/GFS_Alaska_191km_20051011_0000.grib1"/>
 ~~~
+
+## Skipping Empty Directories
+
+By default, `datasetScan` will add a `catalogRef` for each directory that it finds, including directories that are empty.
+Starting with version 5.9 of the TDS, you can skip empty directories by adding the `excludeEmptyDirs="true"` attribute to the `datasetScan` element.
+For example:
+
+~~~xml
+<datasetScan name="Dataset Name" path="unique/path"
+  location="/data/directory/to/scan"
+  excludeEmptyDirs="true">
+~~~
+
+This will cause `datasetScan` to skip adding `catalogRef`s for empty directories.
+To preserve backwards compatibility, the `excludeEmptyDirs` attribute defaults to `false`.

--- a/docs/userguide/src/site/pages/thredds/DatasetScanRef.md
+++ b/docs/userguide/src/site/pages/thredds/DatasetScanRef.md
@@ -18,7 +18,7 @@ Here is a minimal catalog containing a `datasetScan` element:
 
 ~~~xml
 <?xml version="1.0" encoding="UTF-8"?>
-<catalog name="Unidata Workshop 2006 - NCEP Model Data" version="1.0.1"
+<catalog name="Unidata Workshop 2006 - NCEP Model Data" version="{{ site.inv_catalog_schema_version }}"
     xmlns="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0"
     xmlns:xlink="http://www.w3.org/1999/xlink">
   <service name="myserver" serviceType="OpenDAP" base="/thredds/dodsC/" />
@@ -43,7 +43,7 @@ For more information on Object Store files and URL syntax see [Dataset URLs](htt
 In the catalog that the TDS server sends to a client, the `datasetScan` element is shown as a catalog reference:
 
 ~~~xml
-<catalog name="Unidata Workshop 2006 - NCEP Model Data" version="1.0.1"
+<catalog name="Unidata Workshop 2006 - NCEP Model Data" version="{{ site.inv_catalog_schema_version }}"
     xmlns="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0"
     xmlns:xlink="http://www.w3.org/1999/xlink">
 
@@ -127,7 +127,7 @@ The `datasetScan` element is an extension of a `dataset` element, and it can con
 Typically, you want all of its contained datasets to inherit the `metadata`, so add an inherited `metadata` element contained in the `datasetScan` element, for example:
 
 ~~~xml
-<catalog name="Unidata Workshop 2006 - NCEP Model Data" version="1.0.1"
+<catalog name="Unidata Workshop 2006 - NCEP Model Data" version="{{ site.inv_catalog_schema_version }}"
     xmlns="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0">
 
   <service name="myserver" serviceType="OpenDAP" base="/thredds/dodsC/" />
@@ -179,7 +179,7 @@ Its a good idea to always use a filter element with explicit includes, so if str
 
 ~~~xml
 <?xml version="1.0" encoding="UTF-8"?>
-<catalog name="Unidata Workshop 2006 - NCEP Model Data" version="1.0.1"
+<catalog name="Unidata Workshop 2006 - NCEP Model Data" version="{{ site.inv_catalog_schema_version }}"
     xmlns="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0"
     xmlns:xlink="http://www.w3.org/1999/xlink">
 
@@ -212,7 +212,7 @@ A few gotchas to remember:
 
 ~~~xml
 <?xml version="1.0" encoding="UTF-8"?>
-<catalog name="Unidata Workshop 2006 - NCEP Model Data" version="1.0.1"
+<catalog name="Unidata Workshop 2006 - NCEP Model Data" version="{{ site.inv_catalog_schema_version }}"
     xmlns="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0"
     xmlns:xlink="http://www.w3.org/1999/xlink">
 

--- a/docs/userguide/src/site/pages/thredds/GribConfigRef.md
+++ b/docs/userguide/src/site/pages/thredds/GribConfigRef.md
@@ -347,7 +347,7 @@ Sort the files [lexicographically](https://en.wikipedia.org/wiki/Lexicographical
 
 The `gribConfig` schema definition, version 1.2.
 
-see: [https://www.unidata.ucar.edu/schemas/thredds/InvCatalog.1.2.xsd](https://www.unidata.ucar.edu/schemas/thredds/InvCatalog.1.2.xsd){:target="_blank"}
+see: [https://schemas.unidata.ucar.edu/thredds/InvCatalog.1.2.xsd](https://schemas.unidata.ucar.edu/thredds/InvCatalog.1.2.xsd){:target="_blank"}
 
 ~~~xsd
 <xsd:complexType name="gribConfigType">

--- a/docs/userguide/src/site/pages/thredds/GribConfigRef.md
+++ b/docs/userguide/src/site/pages/thredds/GribConfigRef.md
@@ -347,7 +347,7 @@ Sort the files [lexicographically](https://en.wikipedia.org/wiki/Lexicographical
 
 The `gribConfig` schema definition, version 1.2.
 
-see: [https://schemas.unidata.ucar.edu/thredds/InvCatalog.1.2.xsd](https://schemas.unidata.ucar.edu/thredds/InvCatalog.1.2.xsd){:target="_blank"}
+see: [https://schemas.unidata.ucar.edu/thredds/InvCatalog.{{ site.inv_catalog_schema_version }}.xsd](https://schemas.unidata.ucar.edu/thredds/InvCatalog.{{ site.inv_catalog_schema_version }}.xsd){:target="_blank"}
 
 ~~~xsd
 <xsd:complexType name="gribConfigType">

--- a/docs/userguide/src/site/pages/thredds/InvCatalogClientSpec.md
+++ b/docs/userguide/src/site/pages/thredds/InvCatalogClientSpec.md
@@ -18,7 +18,7 @@ Related resources:
 
 * [Client Catalog Primer](basic_client_catalog.html) 
 * [Client Catalog Example](https://thredds.ucar.edu/thredds/idd/forecastModels.xml){:target="_blank"} 
-* [Catalog XML Schema](https://www.unidata.ucar.edu/schemas/thredds/InvCatalog.1.2.xsd){:target="_blank"}
+* [Catalog XML Schema](https://schemas.unidata.ucar.edu/thredds/InvCatalog.1.2.xsd){:target="_blank"}
 * [Server-Side Catalog Specification](server_side_catalog_specification.html)
 
 ## Base Catalog Elements

--- a/docs/userguide/src/site/pages/thredds/InvCatalogClientSpec.md
+++ b/docs/userguide/src/site/pages/thredds/InvCatalogClientSpec.md
@@ -18,7 +18,7 @@ Related resources:
 
 * [Client Catalog Primer](basic_client_catalog.html) 
 * [Client Catalog Example](https://thredds.ucar.edu/thredds/idd/forecastModels.xml){:target="_blank"} 
-* [Catalog XML Schema](https://schemas.unidata.ucar.edu/thredds/InvCatalog.1.2.xsd){:target="_blank"}
+* [Catalog XML Schema](https://schemas.unidata.ucar.edu/thredds/InvCatalog.{{ site.inv_catalog_schema_version }}.xsd){:target="_blank"}
 * [Server-Side Catalog Specification](server_side_catalog_specification.html)
 
 ## Base Catalog Elements

--- a/docs/userguide/src/site/pages/thredds/InvCatalogServerSpec.md
+++ b/docs/userguide/src/site/pages/thredds/InvCatalogServerSpec.md
@@ -16,7 +16,7 @@ Also, see:
 
 * [DatasetScan](tds_dataset_scan_ref.html) reference
 * [FeatureCollection](feature_collections_ref.html) reference
-* [Catalog XML Schema](https://schemas.unidata.ucar.edu/thredds/InvCatalog.1.2.xsd){:target="_blank"}
+* [Catalog XML Schema](https://schemas.unidata.ucar.edu/thredds/InvCatalog.{{ site.inv_catalog_schema_version }}.xsd){:target="_blank"}
 * [Client-Side Catalog Specification](client_side_catalog_specification.html)
 
 ## Base Catalog Elements

--- a/docs/userguide/src/site/pages/thredds/InvCatalogServerSpec.md
+++ b/docs/userguide/src/site/pages/thredds/InvCatalogServerSpec.md
@@ -154,6 +154,7 @@ A `datasetScan` can be used wherever a `dataset` element is allowed.
         <xsd:attribute name="path" type="xsd:string" use="required"/>
         <xsd:attribute name="location" type="xsd:string"/>
         <xsd:attribute name="addLatest" type="xsd:boolean"/>
+        <xsd:attribute name="excludeEmptyDirs" type="xsd:boolean"/>
       </xsd:extension>
     </xsd:complexContent>
   </xsd:complexType>
@@ -161,11 +162,12 @@ A `datasetScan` can be used wherever a `dataset` element is allowed.
 ~~~
 
 * The `datasetScan` element generates nested THREDDS catalogs by scanning the directory named in the `location` attribute, and creating a `dataset` for each file found, and a `catalogRef` for each subdirectory. 
-* The location must be an absolute path. 
+  The location must be an absolute path. 
 * The `path` attribute is used to create the URL for these files and catalogs. 
-* The path must be globally unique over all paths for the TDS. 
-* Do not put leading or trailing slashes on the path.
+  The path must be globally unique over all paths for the TDS. 
+  Do not put leading or trailing slashes on the path.
 * The `addLatest` attribute adds a *latest resolver service* to the `datasetScan`.
+* The `excludeEmptyDirs` configures the `datasetScan` to skip adding `catalogRef`s for empty directories.
 
 A `datasetScan` element is in the `dataset substitutionGroup`, so it can be used wherever a `dataset` element can be used. 
 It is an extension of a `DatasetType`, so any of the `dataset` element nested elements and attributes can be used in it. 

--- a/docs/userguide/src/site/pages/thredds/InvCatalogServerSpec.md
+++ b/docs/userguide/src/site/pages/thredds/InvCatalogServerSpec.md
@@ -16,7 +16,7 @@ Also, see:
 
 * [DatasetScan](tds_dataset_scan_ref.html) reference
 * [FeatureCollection](feature_collections_ref.html) reference
-* [Catalog XML Schema](https://www.unidata.ucar.edu/schemas/thredds/InvCatalog.1.2.xsd){:target="_blank"}
+* [Catalog XML Schema](https://schemas.unidata.ucar.edu/thredds/InvCatalog.1.2.xsd){:target="_blank"}
 * [Client-Side Catalog Specification](client_side_catalog_specification.html)
 
 ## Base Catalog Elements

--- a/tdcommon/src/main/java/thredds/server/catalog/DatasetScan.java
+++ b/tdcommon/src/main/java/thredds/server/catalog/DatasetScan.java
@@ -5,6 +5,7 @@
 
 package thredds.server.catalog;
 
+import static thredds.util.MFileUtils.isEmpty;
 import static thredds.util.MFileUtils.isMfileZarr;
 
 import java.net.URISyntaxException;
@@ -222,7 +223,13 @@ public class DatasetScan extends CatalogRef {
       boolean isDir = mfile.isDirectory();
       boolean isZarr = isMfileZarr(mfile);
 
-      if (isDir) {
+      // if this is a directory, should it be skipped?
+      // skip the directory if datasetScan configured to skip empty dirs
+      // and the dir is empty
+      boolean skipDir = isDir && config.excludeEmptyDirs && isEmpty(mfile);
+
+      // handle directory
+      if (isDir && !skipDir) {
         CatalogRefBuilder catref = new CatalogRefBuilder(top);
         catref.setTitle(makeName(mfile));
         catref.setHref(mfile.getName() + "/catalog.xml");
@@ -273,7 +280,10 @@ public class DatasetScan extends CatalogRef {
         top.addDataset(ds);
       }
 
-      ds.put(Dataset.Id, parentId + mfile.getName());
+      // always add non-directory entries, otherwise, skip if it was
+      // determined that we should skip the directory
+      if (!isDir || !skipDir)
+        ds.put(Dataset.Id, parentId + mfile.getName());
     }
 
     if (config.addLatest != null && !config.addLatest.latestOnTop)

--- a/tdcommon/src/main/java/thredds/server/catalog/DatasetScanConfig.java
+++ b/tdcommon/src/main/java/thredds/server/catalog/DatasetScanConfig.java
@@ -1,33 +1,6 @@
 /*
- * Copyright (c) 1998 - 2014. University Corporation for Atmospheric Research/Unidata
- * Portions of this software were developed by the Unidata Program at the
- * University Corporation for Atmospheric Research.
- *
- * Access and use of this software shall impose the following obligations
- * and understandings on the user. The user is granted the right, without
- * any fee or cost, to use, copy, modify, alter, enhance and distribute
- * this software, and any derivative works thereof, and its supporting
- * documentation for any purpose whatsoever, provided that this entire
- * notice appears in all copies of the software, derivative works and
- * supporting documentation. Further, UCAR requests that the user credit
- * UCAR/Unidata in any publications that result from the use of this
- * software or in any product that includes this software. The names UCAR
- * and/or Unidata, however, may not be used in any advertising or publicity
- * to endorse or promote any products or commercial entity unless specific
- * written permission is obtained from UCAR/Unidata. The user also
- * understands that UCAR/Unidata is not obligated to provide the user with
- * any support, consulting, training or assistance of any kind with regard
- * to the use, operation and performance of this software nor to provide
- * the user with any updates, revisions, new versions or "bug fixes."
- *
- * THIS SOFTWARE IS PROVIDED BY UCAR/UNIDATA "AS IS" AND ANY EXPRESS OR
- * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL UCAR/UNIDATA BE LIABLE FOR ANY SPECIAL,
- * INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING
- * FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
- * NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION
- * WITH THE ACCESS, USE OR PERFORMANCE OF THIS SOFTWARE.
+ * Copyright (c) 1998-2026 University Corporation for Atmospheric Research/Unidata
+ * See LICENSE for license information.
  */
 
 package thredds.server.catalog;
@@ -56,13 +29,15 @@ public class DatasetScanConfig {
   public List<Namer> namers;
   public AddLatest addLatest;
   public AddTimeCoverage addTimeCoverage;
+  // include empty directories in scan to preserve behavior by default
+  public boolean excludeEmptyDirs = false;
 
   @Override
   public String toString() {
     return "DatasetScanConfig{" + "name='" + name + '\'' + ", path='" + path + '\'' + ", scanDir='" + scanDir + '\''
         + ", restrictAccess='" + restrictAccess + '\'' + ", isSortIncreasing=" + getSortFilesAscending()
         + ", ncmlElement=" + ncmlElement + ", filters=" + filters + ", namers=" + namers + ", proxies=" + addLatest
-        + ", addTimeCoverage=" + addTimeCoverage + '}';
+        + ", addTimeCoverage=" + addTimeCoverage + ", excludeEmptyDirs=" + excludeEmptyDirs + '}';
   }
 
   public boolean getSortFilesAscending() {

--- a/tdcommon/src/main/java/thredds/server/catalog/builder/DatasetScanConfigBuilder.java
+++ b/tdcommon/src/main/java/thredds/server/catalog/builder/DatasetScanConfigBuilder.java
@@ -83,6 +83,7 @@ public class DatasetScanConfigBuilder {
    * <xsd:attribute name="path" type="xsd:string" use="required"/>
    * <xsd:attribute name="location" type="xsd:string"/>
    * <xsd:attribute name="addLatest" type="xsd:boolean"/>
+   * <xsd:attribute name="excludeEmptyDirs" type="xsd:boolean"/>
    * <xsd:attribute name="filter" type="xsd:string"/> <!-- deprecated : use filter element -->
    * </xsd:extension>
    * </xsd:complexContent>
@@ -113,6 +114,9 @@ public class DatasetScanConfigBuilder {
     }
 
     result.restrictAccess = dsElem.getAttributeValue("restrictAccess");
+
+    // Handle excludeEmptyDirs attribute
+    result.excludeEmptyDirs = dsElem.getAttributeValue("excludeEmptyDirs", "false").equalsIgnoreCase("true");
 
     // look for ncml
     Element ncmlElem = dsElem.getChild("netcdf", Catalog.defNS);

--- a/tdcommon/src/main/java/thredds/util/MFileUtils.java
+++ b/tdcommon/src/main/java/thredds/util/MFileUtils.java
@@ -8,10 +8,11 @@ package thredds.util;
 import static ucar.nc2.util.IO.default_file_buffersize;
 
 import java.io.BufferedInputStream;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.file.DirectoryStream;
+import thredds.inventory.MControllers;
 import thredds.inventory.MFile;
 import ucar.nc2.iosp.zarr.ZarrKeys;
 import ucar.nc2.util.IO;
@@ -63,5 +64,23 @@ public class MFileUtils {
       InputStream in = new BufferedInputStream(fin);
       IO.copyB(in, out, bufferSize);
     }
+  }
+
+  /**
+   * Determine if a directory represented by an MFile is empty
+   *
+   * @param mfile MFile representing a possible directory
+   * @return true if mfile represents a directory and is empty, otherwise false
+   */
+  public static boolean isEmpty(MFile mfile) {
+    boolean isEmpty = false;
+    if (mfile.isDirectory()) {
+      try (DirectoryStream<MFile> mDirStream = MControllers.newDirectoryStream(mfile.getPath())) {
+        isEmpty = !mDirStream.iterator().hasNext();
+      } catch (IOException e) {
+        isEmpty = false;
+      }
+    }
+    return isEmpty;
   }
 }

--- a/tdcommon/src/main/resources/resources/thredds/schemas/InvCatalog.1.0.7.xsd
+++ b/tdcommon/src/main/resources/resources/thredds/schemas/InvCatalog.1.0.7.xsd
@@ -1,0 +1,954 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema
+    targetNamespace="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0"
+    xmlns="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    xmlns:ncml="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2"
+    elementFormDefault="qualified"
+    attributeFormDefault="unqualified"
+    version="1.0.7">
+
+  <!-- import other namespaces -->
+  <xsd:import namespace="http://www.w3.org/1999/xlink" schemaLocation="https://schemas.unidata.ucar.edu/other/xlink.xsd"/>
+  <xsd:import namespace="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2" schemaLocation="https://schemas.unidata.ucar.edu/netcdf/ncml-2.2.xsd"/>
+
+  <!-- xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx -->
+  <!-- Catalog element -->
+  <xsd:element name="catalog">
+
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element ref="service" minOccurs="0" maxOccurs="unbounded"/>
+        <xsd:element ref="datasetRoot" minOccurs="0" maxOccurs="unbounded"/>    <!-- server -->
+        <xsd:element ref="property" minOccurs="0" maxOccurs="unbounded"/>
+        <xsd:element ref="dataset" minOccurs="1" maxOccurs="unbounded"/>
+      </xsd:sequence>
+
+      <xsd:attribute name="base" type="xsd:anyURI"/>
+      <xsd:attribute name="name" type="xsd:string"/>
+      <xsd:attribute name="expires" type="dateType"/>
+      <xsd:attribute name="version" type="xsd:token" default="1.0.7"/>
+    </xsd:complexType>
+
+    <!-- Enforce dataset ID references:
+       1) Each dataset ID must be unique in the document.
+       2) Each dataset alias must reference a dataset ID in the document.
+       -->
+    <xsd:unique name="datasetID">
+      <xsd:selector xpath=".//dataset"/>
+      <xsd:field xpath="@ID"/>
+    </xsd:unique>
+
+    <xsd:keyref name="datasetAlias" refer="datasetID">
+      <xsd:selector xpath=".//dataset"/>
+      <xsd:field xpath="@alias"/>
+    </xsd:keyref>
+
+    <!-- Enforce references to services:
+        1) Each service name must be unique and is required.
+        2) Each dataset that references a service (i.e., has a serviceName
+            attribute) must reference a service that exists.
+        3) Each access that references a service (i.e., has a serviceName
+            attribute) must reference a service that exists.
+        4) Each serviceName element must reference a service that exists.
+      -->
+    <xsd:key name="serviceNameKey">
+      <xsd:selector xpath=".//service"/>
+      <xsd:field xpath="@name"/>
+    </xsd:key>
+
+    <xsd:keyref name="datasetServiceName" refer="serviceNameKey">
+      <xsd:selector xpath=".//dataset"/>
+      <xsd:field xpath="@serviceName"/>
+    </xsd:keyref>
+
+    <xsd:keyref name="accessServiceName" refer="serviceNameKey">
+      <xsd:selector xpath=".//access"/>
+      <xsd:field xpath="@serviceName"/>
+    </xsd:keyref>
+
+    <xsd:keyref name="serviceName" refer="serviceNameKey">
+      <xsd:selector xpath=".//serviceName"/>
+      <xsd:field xpath="."/>
+    </xsd:keyref>
+
+  </xsd:element>
+
+  <!-- xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx -->
+  <!-- Service element -->
+  <xsd:element name="service">
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element ref="property" minOccurs="0" maxOccurs="unbounded"/>
+        <xsd:element ref="service" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="name" type="xsd:string" use="required"/>
+      <xsd:attribute name="base" type="xsd:string" use="required"/>
+      <xsd:attribute name="serviceType" type="serviceTypes" use="required"/>
+      <xsd:attribute name="desc" type="xsd:string"/>
+      <xsd:attribute name="suffix" type="xsd:string"/>
+    </xsd:complexType>
+  </xsd:element>
+
+  <!-- xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx -->
+  <!-- Dataset element -->
+  <xsd:element name="dataset" type="DatasetType"/>
+  <xsd:complexType name="DatasetType">
+    <xsd:sequence>
+      <xsd:group ref="threddsMetadataGroup" minOccurs="0" maxOccurs="unbounded"/>   <!-- this means any of these elements can appear directly in the dataset element -->
+      <xsd:element ref="access" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element ref="ncml:netcdf" minOccurs="0"/>
+      <xsd:element ref="dataset" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+
+    <xsd:attribute name="name" type="xsd:string" use="required"/>
+    <xsd:attribute name="alias" type="xsd:token"/>
+    <xsd:attribute name="authority" type="xsd:string"/>   <!-- deprecated : use element -->
+    <xsd:attribute name="collectionType" type="collectionTypes"/>
+    <xsd:attribute name="dataType" type="dataTypes"/>    <!-- deprecated : use element -->
+    <xsd:attribute name="harvest" type="xsd:boolean"/>
+    <xsd:attribute name="ID" type="xsd:token"/>
+    <xsd:attribute name="restrictAccess" type="xsd:string"/>
+
+    <xsd:attribute name="serviceName" type="xsd:string"/>   <!-- deprecated : use element -->
+    <xsd:attribute name="urlPath" type="xsd:token"/>
+
+  </xsd:complexType>
+
+  <!-- xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx -->
+  <!-- Access element -->
+  <xsd:element name="access">
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element ref="dataSize" minOccurs="0"/>
+      </xsd:sequence>
+      <xsd:attribute name="urlPath" type="xsd:token" use="required"/>
+      <xsd:attribute name="serviceName" type="xsd:string"/>
+      <xsd:attribute name="dataFormat" type="dataFormatTypes"/>
+    </xsd:complexType>
+  </xsd:element>
+
+  <!-- xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx -->
+  <!-- CatalogRef element -->
+  <!-- external catalog gets added as a dataset -->
+  <xsd:element name="catalogRef" substitutionGroup="dataset">
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="DatasetType">
+          <xsd:attributeGroup ref="XLink"/>
+          <xsd:attribute name="useRemoteCatalogService" type="xsd:boolean"/>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+
+  <!-- xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx -->
+  <!-- DatasetScan element -->
+  <!-- scan a directory to add datasets to catalog -->
+  <xsd:element name="datasetScan" substitutionGroup="dataset">
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="DatasetType">
+          <xsd:sequence>
+            <xsd:element ref="filter" minOccurs="0" maxOccurs="1"/>
+            <xsd:element ref="namer" minOccurs="0" maxOccurs="1"/>
+            <xsd:element ref="sort" minOccurs="0" maxOccurs="1"/>          <!-- LOOK ?? -->
+            <xsd:element ref="addLatest" minOccurs="0" maxOccurs="1"/>
+            <xsd:element ref="addProxies" minOccurs="0" maxOccurs="1"/>
+            <xsd:element name="addDatasetSize" minOccurs="0" maxOccurs="1"/>
+            <xsd:element ref="addTimeCoverage" minOccurs="0" maxOccurs="1"/>
+          </xsd:sequence>
+
+          <xsd:attribute name="path" type="xsd:string" use="required"/>
+          <xsd:attribute name="location" type="xsd:string"/>
+          <xsd:attribute name="addLatest" type="xsd:boolean"/>    <!-- LOOK use again ?? -->
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="filter">
+    <xsd:complexType>
+      <xsd:choice>
+        <xsd:sequence minOccurs="0" maxOccurs="unbounded">
+          <xsd:element name="include" type="FilterSelectorType" minOccurs="0"/>
+          <xsd:element name="exclude" type="FilterSelectorType" minOccurs="0"/>
+        </xsd:sequence>
+      </xsd:choice>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:complexType name="FilterSelectorType">
+    <xsd:attribute name="regExp" type="xsd:string"/>
+    <xsd:attribute name="wildcard" type="xsd:string"/>
+    <xsd:attribute name="atomic" type="xsd:boolean"/>
+    <xsd:attribute name="collection" type="xsd:boolean"/>
+  </xsd:complexType>
+
+  <xsd:element name="namer">
+    <xsd:complexType>
+      <xsd:choice maxOccurs="unbounded">
+        <xsd:element name="regExpOnName" type="NamerSelectorType"/>
+        <xsd:element name="regExpOnPath" type="NamerSelectorType"/>
+      </xsd:choice>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:complexType name="NamerSelectorType">
+    <xsd:attribute name="regExp" type="xsd:string"/>
+    <xsd:attribute name="replaceString" type="xsd:string"/>
+  </xsd:complexType>
+
+  <xsd:element name="sort">
+    <xsd:complexType>
+      <xsd:choice>
+        <xsd:element name="lexigraphicByName">
+          <xsd:complexType>
+            <xsd:attribute name="increasing" type="xsd:boolean"/>
+          </xsd:complexType>
+        </xsd:element>
+      </xsd:choice>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="addLatest">
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element ref="simpleLatest" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+    </xsd:complexType>
+  </xsd:element>
+
+  <!-- Allow addition of proxy datasets (e.g., latest). -->
+  <xsd:element name="addProxies">
+    <xsd:complexType>
+      <xsd:choice minOccurs="0" maxOccurs="unbounded">
+        <xsd:element ref="simpleLatest"/>
+        <xsd:element ref="latestComplete"/>
+      </xsd:choice>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="simpleLatest">
+    <xsd:complexType>
+      <xsd:attribute name="name" type="xsd:string"/>
+      <xsd:attribute name="top" type="xsd:boolean"/>
+      <xsd:attribute name="isResolver" type="xsd:boolean"/>
+      <xsd:attribute name="serviceName" type="xsd:string"/>
+    </xsd:complexType>
+  </xsd:element>
+  <xsd:element name="latestComplete">
+    <xsd:complexType>
+      <xsd:attribute name="name" type="xsd:string"/>
+      <xsd:attribute name="top" type="xsd:boolean"/>
+      <xsd:attribute name="serviceName" type="xsd:string"/>
+      <xsd:attribute name="isResolver" type="xsd:boolean"/>
+      <xsd:attribute name="lastModifiedLimit" type="xsd:float"/>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="addTimeCoverage">
+    <xsd:complexType>
+      <xsd:attribute name="datasetNameMatchPattern" type="xsd:string"/>
+      <xsd:attribute name="datasetPathMatchPattern" type="xsd:string"/>
+      <xsd:attribute name="startTimeSubstitutionPattern" type="xsd:string"/>
+      <xsd:attribute name="duration" type="xsd:string"/>
+    </xsd:complexType>
+  </xsd:element>
+
+  <!-- datasetRoot element: associate a url path with a directory location -->
+  <xsd:element name="datasetRoot">
+    <xsd:complexType>
+      <xsd:attribute name="path" type="xsd:string" use="required"/>
+      <xsd:attribute name="location" type="xsd:string" use="required"/>
+      <xsd:attribute name="cache" type="xsd:boolean"/>                  <!-- no not use -->
+    </xsd:complexType>
+  </xsd:element>
+
+  <!-- xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx -->
+  <!-- featureCollection element -->
+  <xsd:element name="featureCollection" substitutionGroup="dataset">
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="DatasetType">
+          <xsd:sequence>
+            <xsd:element type="collectionType" name="collection"/>
+            <xsd:element type="updateType" name="update" minOccurs="0"/>
+            <xsd:element type="tdmType" name="tdm" minOccurs="0"/>
+            <xsd:element type="protoDatasetType" name="protoDataset" minOccurs="0"/>
+            <xsd:element type="fmrcConfigType" name="fmrcConfig" minOccurs="0"/>
+            <xsd:element type="pointConfigType" name="pointConfig" minOccurs="0"/>
+            <xsd:element type="gribConfigType" name="gribConfig" minOccurs="0"/>
+            <xsd:element ref="ncml:netcdf" minOccurs="0"/>
+          </xsd:sequence>
+          <xsd:attribute name="featureType" type="featureTypeChoice" use="required"/>
+          <xsd:attribute name="path" type="xsd:string" use="required"/>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:simpleType name="featureTypeChoice">
+    <xsd:union memberTypes="xsd:token">
+      <xsd:simpleType>
+        <xsd:restriction base="xsd:token">
+          <xsd:enumeration value="FMRC"/>
+          <xsd:enumeration value="GRIB"/>
+          <xsd:enumeration value="Station"/>
+          <xsd:enumeration value="Point"/>
+          <xsd:enumeration value="Station_Profile"/>
+        </xsd:restriction>
+      </xsd:simpleType>
+    </xsd:union>
+  </xsd:simpleType>
+
+  <xsd:complexType name="collectionType">
+    <xsd:attribute name="spec" type="xsd:string" use="required"/>
+    <xsd:attribute name="name" type="xsd:token"/>
+    <xsd:attribute name="olderThan" type="xsd:string"/>
+    <xsd:attribute name="dateFormatMark" type="xsd:string"/>
+    <xsd:attribute name="timePartition" type="xsd:string"/>
+    <xsd:attribute name="useIndexOnly" type="xsd:boolean"/>
+  </xsd:complexType>
+
+  <xsd:complexType name="updateType">
+    <xsd:attribute name="startup" type="xsd:string"/>
+    <xsd:attribute name="recheckAfter" type="xsd:string"/>
+    <xsd:attribute name="rescan" type="xsd:token"/>
+    <xsd:attribute name="rewrite" type="xsd:string"/>
+    <xsd:attribute name="trigger" type="xsd:token"/>
+  </xsd:complexType>
+
+  <xsd:complexType name="tdmType">
+    <xsd:sequence>
+      <xsd:element ref="manage" minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attribute name="rewrite" type="xsd:string"/>
+    <xsd:attribute name="rescan" type="xsd:token"/>
+  </xsd:complexType>
+
+  <xsd:element name="manage">
+    <xsd:complexType>
+      <xsd:attribute name="deleteAfter" type="xsd:string" use="required"/>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:complexType name="protoDatasetType">
+    <xsd:sequence>
+      <xsd:element ref="ncml:netcdf" minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attribute name="choice" type="protoChoices"/>
+    <xsd:attribute name="change" type="xsd:string"/>
+    <xsd:attribute name="param" type="xsd:string"/>
+  </xsd:complexType>
+
+  <xsd:simpleType name="protoChoices">
+    <xsd:union memberTypes="xsd:token">
+      <xsd:simpleType>
+        <xsd:restriction base="xsd:token">
+          <xsd:enumeration value="First"/>
+          <xsd:enumeration value="Random"/>
+          <xsd:enumeration value="Penultimate"/>
+          <xsd:enumeration value="Latest"/>
+          <xsd:enumeration value="Run"/>
+        </xsd:restriction>
+      </xsd:simpleType>
+    </xsd:union>
+  </xsd:simpleType>
+
+  <xsd:complexType name="fmrcConfigType">
+    <xsd:sequence>
+      <xsd:element name="dataset" minOccurs="0">
+        <xsd:complexType>
+          <xsd:attribute name="name" type="xsd:token" use="required"/>
+          <xsd:attribute name="offsetsGreaterEqual" type="xsd:int" use="required"/>
+        </xsd:complexType>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="regularize" type="xsd:boolean"/>
+    <xsd:attribute name="datasetTypes" type="fmrcDatasetTypes"/>
+  </xsd:complexType>
+
+  <xsd:simpleType name="fmrcDatasetTypes">
+    <xsd:union memberTypes="xsd:token">
+      <xsd:simpleType>
+        <xsd:restriction base="xsd:token">
+          <xsd:enumeration value="TwoD"/>
+          <xsd:enumeration value="Best"/>
+          <xsd:enumeration value="Files"/>
+          <xsd:enumeration value="Runs"/>
+          <xsd:enumeration value="ConstantForecasts"/>
+          <xsd:enumeration value="ConstantOffsets"/>
+        </xsd:restriction>
+      </xsd:simpleType>
+    </xsd:union>
+  </xsd:simpleType>
+
+  <xsd:complexType name="pointConfigType">
+    <xsd:attribute name="datasetTypes" type="xsd:string"/>
+  </xsd:complexType>
+
+  <xsd:complexType name="gribConfigType">
+    <xsd:sequence>
+
+      <xsd:element name="gdsHash" minOccurs="0">
+        <xsd:complexType>
+          <xsd:attribute name="from" type="xsd:int" use="required"/>
+          <xsd:attribute name="to" type="xsd:int" use="required"/>
+        </xsd:complexType>
+      </xsd:element>
+
+      <xsd:element name="gdsName" minOccurs="0" maxOccurs="unbounded">
+        <xsd:complexType>
+          <xsd:attribute name="hash" type="xsd:int"/>
+          <xsd:attribute name="groupName" type="xsd:string"/>
+        </xsd:complexType>
+      </xsd:element>
+
+      <xsd:element name="pdsHash" minOccurs="0" maxOccurs="unbounded">
+        <xsd:complexType>
+          <xsd:sequence>
+            <xsd:element name="useGenType" minOccurs="0" maxOccurs="1"/>
+            <xsd:element name="useTableVersion" minOccurs="0" maxOccurs="1"/>
+            <xsd:element name="mergeIntv" minOccurs="0" maxOccurs="1"/>
+          </xsd:sequence>
+        </xsd:complexType>
+      </xsd:element>
+
+      <xsd:element name="intvFilter" minOccurs="0" maxOccurs="unbounded">
+        <xsd:complexType>
+          <xsd:sequence>
+            <xsd:element name="variable" minOccurs="0" maxOccurs="unbounded">
+              <xsd:complexType>
+                <xsd:attribute name="id" type="xsd:string" use="required"/>
+                <xsd:attribute name="prob" type="xsd:string" use="optional"/>
+              </xsd:complexType>
+            </xsd:element>
+          </xsd:sequence>
+          <xsd:attribute name="excludeZero" type="xsd:boolean" use="optional"/>
+          <xsd:attribute name="intvLength" type="xsd:int" use="optional"/>
+        </xsd:complexType>
+      </xsd:element>
+
+      <xsd:element name="filter" minOccurs="0" maxOccurs="unbounded">
+        <xsd:complexType>
+          <xsd:sequence>
+            <xsd:element name="include" minOccurs="0" maxOccurs="unbounded">
+              <xsd:complexType>
+                <xsd:attribute name="name" type="xsd:string" use="required"/>
+                <xsd:attribute name="value" type="xsd:string" use="required"/>
+              </xsd:complexType>
+            </xsd:element>
+          </xsd:sequence>
+        </xsd:complexType>
+      </xsd:element>
+
+      <xsd:element name="timeUnitConvert" minOccurs="0">
+        <xsd:complexType>
+          <xsd:attribute name="from" type="xsd:int" use="required"/>
+          <xsd:attribute name="to" type="xsd:int" use="required"/>
+        </xsd:complexType>
+      </xsd:element>
+
+      <xsd:element name="option" minOccurs="0" maxOccurs="unbounded">
+         <xsd:complexType>
+           <xsd:attribute name="name" type="xsd:string" use="required"/>
+           <xsd:attribute name="value" type="xsd:string" use="required"/>
+         </xsd:complexType>
+       </xsd:element>
+
+      <xsd:element name="latestNamer" minOccurs="0" maxOccurs="1">
+        <xsd:complexType>
+          <xsd:attribute name="name" type="xsd:string" use="required"/>
+        </xsd:complexType>
+      </xsd:element>
+
+      <xsd:element name="bestNamer" minOccurs="0" maxOccurs="1">
+        <xsd:complexType>
+          <xsd:attribute name="name" type="xsd:string" use="required"/>
+        </xsd:complexType>
+      </xsd:element>
+
+      <xsd:element name="filesSort" minOccurs="0" maxOccurs="1">
+        <xsd:complexType>
+          <xsd:choice>
+            <xsd:element name="lexigraphicByName">
+              <xsd:complexType>
+                <xsd:attribute name="increasing" type="xsd:boolean"/>
+              </xsd:complexType>
+            </xsd:element>
+          </xsd:choice>
+          <xsd:attribute name="orderBy" type="xsd:string" use="optional"/>
+          <xsd:attribute name="increasing" type="xsd:boolean" use="optional"/>
+        </xsd:complexType>
+      </xsd:element>
+    </xsd:sequence>
+
+    <xsd:attribute name="datasetTypes" type="gribDatasetTypes"/>
+
+  </xsd:complexType>
+
+  <xsd:simpleType name="gribDatasetTypes">
+    <xsd:union memberTypes="xsd:token">
+      <xsd:simpleType>
+        <xsd:restriction base="xsd:token">
+          <xsd:enumeration value="TwoD"/>
+          <xsd:enumeration value="Best"/>
+          <xsd:enumeration value="Analysis"/>
+          <xsd:enumeration value="Files"/>
+          <xsd:enumeration value="Latest"/>
+          <xsd:enumeration value="LatestFile"/>    <!-- alias for Latest -->
+        </xsd:restriction>
+      </xsd:simpleType>
+    </xsd:union>
+  </xsd:simpleType>
+
+  <!-- xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx -->
+  <!-- DatasetFmrc element DEPRECATED - use featureCollection -->
+  <!-- Define a Forecast Model Run Collection dataset -->
+  <xsd:element name="datasetFmrc" substitutionGroup="dataset">
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="DatasetType">
+          <xsd:sequence>
+            <xsd:element ref="fmrcInventory" minOccurs="0"/>
+            <xsd:element ref="addTimeCoverage" minOccurs="0"/>
+          </xsd:sequence>
+          <xsd:attribute name="path" type="xsd:string" use="required"/>
+          <xsd:attribute name="runsOnly" type="xsd:boolean"/>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="fmrcInventory">
+    <xsd:complexType>
+      <xsd:attribute name="location" type="xsd:string" use="required"/>
+      <xsd:attribute name="suffix" type="xsd:string"/>
+      <xsd:attribute name="fmrcDefinition" type="xsd:string" use="required"/>
+      <xsd:attribute name="olderThan" type="xsd:string"/>
+    </xsd:complexType>
+  </xsd:element>
+
+  <!-- xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx -->
+  <!-- Documentation element -->
+  <!-- this is human readable info, as text or XHTML, or an Xlink to text or HTML -->
+  <xsd:complexType name="documentationType" mixed="true">
+    <xsd:sequence>
+      <xsd:any namespace="http://www.w3.org/1999/xhtml" minOccurs="0" maxOccurs="unbounded" processContents="strict"/>
+    </xsd:sequence>
+    <xsd:attribute name="type" type="documentationEnumTypes"/>
+    <xsd:attributeGroup ref="XLink"/>
+  </xsd:complexType>
+
+  <!-- Metadata element -->
+  <!-- this is machine readable info in XML, or an Xlink to XML -->
+  <xsd:element name="metadata">
+    <xsd:complexType>
+      <xsd:choice>
+        <xsd:group ref="threddsMetadataGroup" minOccurs="0" maxOccurs="unbounded"/>
+        <xsd:any namespace="##other" minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+      </xsd:choice>
+
+      <xsd:attribute name="inherited" type="xsd:boolean" default="false"/>
+      <xsd:attribute name="metadataType" type="metadataTypeEnum"/>
+      <xsd:attributeGroup ref="XLink"/>
+    </xsd:complexType>
+  </xsd:element>
+
+  <!-- Property element -->
+  <!-- name/value pair -->
+  <xsd:element name="property">
+    <xsd:complexType>
+      <xsd:attribute name="name" type="xsd:string" use="required"/>
+      <xsd:attribute name="value" type="xsd:string" use="required"/>
+    </xsd:complexType>
+  </xsd:element>
+
+  <!-- xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx -->
+  <!-- here is where we augment with new metadata types -->
+
+  <!-- group of elements can be used in a dataset or in metadata elements -->
+  <xsd:group name="threddsMetadataGroup">
+    <xsd:choice>
+      <xsd:element name="documentation" type="documentationType"/>
+      <xsd:element ref="metadata"/>
+      <xsd:element ref="property"/>
+
+      <xsd:element ref="contributor"/>
+      <xsd:element name="creator" type="sourceType"/>
+      <xsd:element name="date" type="dateTypeFormatted"/>
+      <xsd:element name="keyword" type="controlledVocabulary"/>
+      <xsd:element name="project" type="controlledVocabulary"/>
+      <xsd:element name="publisher" type="sourceType"/>
+
+      <xsd:element ref="geospatialCoverage"/>
+      <xsd:element name="timeCoverage" type="timeCoverageType"/>
+      <xsd:element ref="variables"/>
+      <xsd:element ref="variableMap"/>
+
+      <xsd:element name="dataType" type="dataTypes"/>
+      <xsd:element name="dataFormat" type="dataFormatTypes"/>
+      <xsd:element name="serviceName" type="xsd:string"/>
+      <xsd:element name="authority" type="xsd:string"/>
+      <xsd:element ref="dataSize"/>
+    </xsd:choice>
+  </xsd:group>
+
+  <xsd:complexType name="sourceType">
+    <xsd:sequence>
+      <xsd:element name="name" type="controlledVocabulary"/>
+
+      <xsd:element name="contact">
+        <xsd:complexType>
+          <xsd:attribute name="email" type="xsd:string" use="required"/>
+          <xsd:attribute name="url" type="xsd:anyURI"/>
+        </xsd:complexType>
+      </xsd:element>
+
+    </xsd:sequence>
+  </xsd:complexType>
+
+  <!-- contributorType extends dc:contributor to add role attribute -->
+  <xsd:element name="contributor">
+    <xsd:complexType>
+      <xsd:simpleContent>
+        <xsd:extension base="xsd:string">
+          <xsd:attribute name="role" type="xsd:string" use="required"/>
+        </xsd:extension>
+      </xsd:simpleContent>
+    </xsd:complexType>
+  </xsd:element>
+
+  <!-- size element -->
+  <xsd:element name="dataSize">
+    <xsd:complexType>
+      <xsd:simpleContent>
+        <xsd:extension base="xsd:string">
+          <xsd:attribute name="units" type="xsd:string" use="required"/>
+        </xsd:extension>
+      </xsd:simpleContent>
+    </xsd:complexType>
+  </xsd:element>
+
+  <!-- xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx -->
+  <!-- geospatialCoverageType element -->
+  <xsd:element name="geospatialCoverage">
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element name="northsouth" type="spatialRange" minOccurs="0"/>
+        <xsd:element name="eastwest" type="spatialRange" minOccurs="0"/>
+        <xsd:element name="updown" type="spatialRange" minOccurs="0"/>
+        <xsd:element name="name" type="controlledVocabulary" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+
+      <xsd:attribute name="zpositive" type="upOrDown" default="up"/>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:complexType name="spatialRange">
+    <xsd:sequence>
+      <xsd:element name="start" type="xsd:double"/>
+      <xsd:element name="size" type="xsd:double"/>
+      <xsd:element name="resolution" type="xsd:double" minOccurs="0"/>
+      <xsd:element name="units" type="xsd:string" minOccurs="0"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+  <xsd:simpleType name="upOrDown">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="up"/>
+      <xsd:enumeration value="down"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <!-- xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx -->
+  <!-- date and time-->
+  <xsd:complexType name="timeCoverageType">
+    <xsd:sequence>
+      <xsd:choice minOccurs="2" maxOccurs="3">
+        <xsd:element name="start" type="dateTypeFormatted"/>
+        <xsd:element name="end" type="dateTypeFormatted"/>
+        <xsd:element name="duration" type="duration"/>
+      </xsd:choice>
+
+      <xsd:element name="resolution" type="duration" minOccurs="0"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+  <!-- may be a dateType or have a format attribute  -->
+  <xsd:complexType name="dateTypeFormatted">
+    <xsd:simpleContent>
+      <xsd:extension base="dateType">
+        <xsd:attribute name="format" type="xsd:string"/>
+        <!-- follow java.text.SimpleDateFormat -->
+        <xsd:attribute name="type" type="dateEnumTypes"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+  <!-- may be a built in date or dateTIme, or a udunit encoded string -->
+  <xsd:simpleType name="dateType">
+    <xsd:union memberTypes="xsd:date xsd:dateTime udunitDate">
+      <xsd:simpleType>
+        <xsd:restriction base="xsd:token">
+          <xsd:enumeration value="present"/>
+        </xsd:restriction>
+      </xsd:simpleType>
+    </xsd:union>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="udunitDate">
+    <xsd:restriction base="xsd:string">
+      <xsd:annotation>
+        <xsd:documentation>Must conform to complete udunits date string, eg "20 days since 1991-01-01"</xsd:documentation>
+      </xsd:annotation>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="duration">
+    <xsd:union memberTypes="xsd:duration udunitDuration"/>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="udunitDuration">
+    <xsd:restriction base="xsd:string">
+      <xsd:annotation>
+        <xsd:documentation>Must conform to udunits time duration, eg "20.1 hours"</xsd:documentation>
+      </xsd:annotation>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <!-- xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx -->
+  <!-- variables element -->
+  <xsd:element name="variables">
+    <xsd:complexType>
+      <xsd:choice>
+        <xsd:element ref="variable" minOccurs="0" maxOccurs="unbounded"/>
+        <xsd:element ref="variableMap" minOccurs="0"/>
+      </xsd:choice>
+      <xsd:attribute name="vocabulary" type="variableNameVocabulary" use="optional"/>
+      <xsd:attributeGroup ref="XLink"/>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="variable">
+    <xsd:complexType mixed="true">
+      <xsd:attribute name="name" type="xsd:string" use="required"/>
+      <xsd:attribute name="vocabulary_name" type="xsd:string" use="optional"/>
+      <xsd:attribute name="vocabulary_id" type="xsd:string" use="optional"/>
+      <xsd:attribute name="units" type="xsd:string"/>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="variableMap">
+    <xsd:complexType>
+      <xsd:attributeGroup ref="XLink"/>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:simpleType name="variableNameVocabulary">
+    <xsd:union memberTypes="xsd:token">
+      <xsd:simpleType>
+        <xsd:restriction base="xsd:token">
+          <xsd:enumeration value="CF-1.0"/>
+          <xsd:enumeration value="DIF"/>
+          <xsd:enumeration value="GRIB-1"/>
+          <xsd:enumeration value="GRIB-2"/>
+        </xsd:restriction>
+      </xsd:simpleType>
+    </xsd:union>
+  </xsd:simpleType>
+
+  <!-- xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx -->
+  <!-- reusable types and groups -->
+
+  <!-- controlledVocabulary type allows optional vocabulary attribute-->
+  <xsd:complexType name="controlledVocabulary">
+    <xsd:simpleContent>
+      <xsd:extension base="xsd:string">
+        <xsd:attribute name="vocabulary" type="xsd:string"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+  <!-- Xlink attribute group -->
+  <xsd:attributeGroup name="XLink">
+    <xsd:attribute ref="xlink:type"/>
+    <xsd:attribute ref="xlink:href"/>
+    <xsd:attribute ref="xlink:title"/>
+    <xsd:attribute ref="xlink:show"/>
+  </xsd:attributeGroup>
+
+  <!-- Collection Types -->
+  <xsd:simpleType name="collectionTypes">
+    <xsd:union memberTypes="xsd:token">
+      <xsd:simpleType>
+        <xsd:restriction base="xsd:token">
+          <xsd:enumeration value="TimeSeries"/>
+          <xsd:enumeration value="Stations"/>
+          <xsd:enumeration value="ForecastModelRuns"/>
+        </xsd:restriction>
+      </xsd:simpleType>
+    </xsd:union>
+  </xsd:simpleType>
+
+  <!-- Data Types -->
+  <xsd:simpleType name="dataTypes">
+    <xsd:union memberTypes="xsd:token">
+      <xsd:simpleType>
+        <xsd:restriction base="xsd:token">
+          <xsd:enumeration value="Grid"/>
+          <xsd:enumeration value="Image"/>
+          <xsd:enumeration value="Point"/>
+          <xsd:enumeration value="Radial"/>
+          <xsd:enumeration value="Station"/>
+          <xsd:enumeration value="Swath"/>
+          <xsd:enumeration value="Trajectory"/>
+        </xsd:restriction>
+      </xsd:simpleType>
+    </xsd:union>
+  </xsd:simpleType>
+
+  <!-- DataFormat Types -->
+  <xsd:simpleType name="dataFormatTypes">
+    <xsd:union memberTypes="xsd:token mimeType">
+      <xsd:simpleType>
+        <xsd:restriction base="xsd:token">
+          <xsd:enumeration value="BUFR"/>
+          <xsd:enumeration value="ESML"/>
+          <xsd:enumeration value="GEMPAK"/>
+          <xsd:enumeration value="GINI"/>
+          <xsd:enumeration value="GRIB-1"/>
+          <xsd:enumeration value="GRIB-2"/>
+          <xsd:enumeration value="HDF4"/>
+          <xsd:enumeration value="HDF5"/>
+          <xsd:enumeration value="McIDAS-AREA"/>
+          <xsd:enumeration value="NcML"/>
+          <xsd:enumeration value="NetCDF"/>
+          <xsd:enumeration value="NetCDF-4"/>
+          <xsd:enumeration value="NEXRAD2"/>
+          <xsd:enumeration value="NIDS"/>
+
+          <xsd:enumeration value="image/gif"/>
+          <xsd:enumeration value="image/jpeg"/>
+          <xsd:enumeration value="image/tiff"/>
+          <xsd:enumeration value="text/csv"/>
+          <xsd:enumeration value="text/html"/>
+          <xsd:enumeration value="text/plain"/>
+          <xsd:enumeration value="text/tab-separated-values"/>
+          <xsd:enumeration value="text/xml"/>
+          <xsd:enumeration value="video/mpeg"/>
+          <xsd:enumeration value="video/quicktime"/>
+          <xsd:enumeration value="video/realtime"/>
+        </xsd:restriction>
+      </xsd:simpleType>
+    </xsd:union>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="mimeType">
+    <xsd:restriction base="xsd:token">
+      <xsd:annotation>
+        <xsd:documentation>any valid mime type (see http://www.iana.org/assignments/media-types/)</xsd:documentation>
+      </xsd:annotation>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <!-- Date Types -->
+  <xsd:simpleType name="dateEnumTypes">
+    <xsd:union memberTypes="xsd:token">
+      <xsd:simpleType>
+        <xsd:restriction base="xsd:token">
+          <xsd:enumeration value="created"/>
+          <xsd:enumeration value="modified"/>
+          <xsd:enumeration value="valid"/>
+          <xsd:enumeration value="issued"/>
+          <xsd:enumeration value="available"/>
+          <xsd:enumeration value="metadataCreated"/>
+        </xsd:restriction>
+      </xsd:simpleType>
+    </xsd:union>
+  </xsd:simpleType>
+
+  <!-- Documentation Types -->
+  <xsd:simpleType name="documentationEnumTypes">
+    <xsd:union memberTypes="xsd:token">
+      <xsd:simpleType>
+        <xsd:restriction base="xsd:token">
+          <xsd:enumeration value="funding"/>
+          <xsd:enumeration value="history"/>
+          <xsd:enumeration value="processing_level"/>
+          <xsd:enumeration value="rights"/>
+          <xsd:enumeration value="summary"/>
+        </xsd:restriction>
+      </xsd:simpleType>
+    </xsd:union>
+  </xsd:simpleType>
+
+  <!-- MetadataTypeEnum -->
+  <xsd:simpleType name="metadataTypeEnum">
+    <xsd:union memberTypes="xsd:token">
+      <xsd:simpleType>
+        <xsd:restriction base="xsd:token">
+          <xsd:enumeration value="THREDDS"/>
+          <xsd:enumeration value="ADN"/>
+          <xsd:enumeration value="Aggregation"/>
+          <xsd:enumeration value="CatalogGenConfig"/>
+          <xsd:enumeration value="DublinCore"/>
+          <xsd:enumeration value="DIF"/>
+          <xsd:enumeration value="FGDC"/>
+          <xsd:enumeration value="LAS"/>
+          <xsd:enumeration value="ESG"/>
+          <xsd:enumeration value="Other"/>
+        </xsd:restriction>
+      </xsd:simpleType>
+    </xsd:union>
+  </xsd:simpleType>
+
+  <!-- ServiceTypeEnum -->
+  <xsd:simpleType name="serviceTypes">
+    <xsd:union memberTypes="xsd:token">
+      <xsd:simpleType>
+        <xsd:restriction base="xsd:token">
+          <!-- client/server -->
+          <xsd:enumeration value="ADDE"/>
+          <xsd:enumeration value="DAP4"/>
+          <xsd:enumeration value="DODS"/> <!-- same as OpenDAP -->
+          <xsd:enumeration value="OpenDAP"/>
+          <xsd:enumeration value="OpenDAPG"/>
+          <xsd:enumeration value="NetcdfSubset"/>
+          <xsd:enumeration value="CdmRemote"/>
+          <xsd:enumeration value="CdmFeature"/>
+          <xsd:enumeration value="ncJSON"/>
+          <xsd:enumeration value="H5Service"/>
+
+          <!-- bulk transport -->
+          <xsd:enumeration value="HTTPServer"/>
+          <xsd:enumeration value="FTP"/>
+          <xsd:enumeration value="GridFTP"/>
+          <xsd:enumeration value="File"/>
+
+          <!-- web services -->
+          <xsd:enumeration value="ISO"/>
+          <xsd:enumeration value="LAS"/>
+          <xsd:enumeration value="LAS"/>
+          <xsd:enumeration value="NcML"/>
+          <xsd:enumeration value="UDDC"/>
+          <xsd:enumeration value="WCS"/>
+          <xsd:enumeration value="WMS"/>
+          <xsd:enumeration value="WSDL"/>
+
+          <!--offline -->
+          <xsd:enumeration value="WebForm"/>
+
+          <!-- THREDDS -->
+          <xsd:enumeration value="Catalog"/>
+          <xsd:enumeration value="Compound"/>
+          <xsd:enumeration value="Resolver"/>
+          <xsd:enumeration value="THREDDS"/>
+        </xsd:restriction>
+      </xsd:simpleType>
+    </xsd:union>
+  </xsd:simpleType>
+
+</xsd:schema>

--- a/tdcommon/src/main/resources/resources/thredds/schemas/InvCatalog.1.2.xsd
+++ b/tdcommon/src/main/resources/resources/thredds/schemas/InvCatalog.1.2.xsd
@@ -1,0 +1,930 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema
+    targetNamespace="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0"
+    xmlns="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    xmlns:ncml="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2"
+    elementFormDefault="qualified"
+    attributeFormDefault="unqualified"
+    version="1.2">
+
+  <!-- import other namespaces -->
+  <xsd:import namespace="http://www.w3.org/1999/xlink" schemaLocation="https://schemas.unidata.ucar.edu/other/xlink.xsd"/>
+  <xsd:import namespace="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2" schemaLocation="https://schemas.unidata.ucar.edu/netcdf/ncml-2.2.xsd"/>
+
+  <!-- xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx -->
+  <!-- Catalog element -->
+  <xsd:element name="catalog">
+
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element ref="service" minOccurs="0" maxOccurs="unbounded"/>
+        <xsd:element ref="datasetRoot" minOccurs="0" maxOccurs="unbounded"/>    <!-- server -->
+        <xsd:element ref="property" minOccurs="0" maxOccurs="unbounded"/>
+        <xsd:element ref="dataset" minOccurs="1" maxOccurs="unbounded"/>
+        <xsd:element ref="catalogScan" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+
+      <xsd:attribute name="base" type="xsd:anyURI"/>
+      <xsd:attribute name="name" type="xsd:string"/>
+      <xsd:attribute name="expires" type="dateType"/>
+      <xsd:attribute name="version" type="xsd:token" default="1.2"/>
+    </xsd:complexType>
+
+    <!-- Enforce dataset ID references:
+       1) Each dataset ID must be unique in the document.
+       2) Each dataset alias must reference a dataset ID in the document.
+       -->
+    <xsd:unique name="datasetID">
+      <xsd:selector xpath=".//dataset"/>
+      <xsd:field xpath="@ID"/>
+    </xsd:unique>
+
+    <xsd:keyref name="datasetAlias" refer="datasetID">
+      <xsd:selector xpath=".//dataset"/>
+      <xsd:field xpath="@alias"/>
+    </xsd:keyref>
+
+    <!-- Enforce references to services:
+        1) Each service name must be unique and is required.
+        2) Each dataset that references a service (i.e., has a serviceName
+            attribute) must reference a service that exists.
+        3) Each access that references a service (i.e., has a serviceName
+            attribute) must reference a service that exists.
+        4) Each serviceName element must reference a service that exists.
+      -->
+    <xsd:key name="serviceNameKey">
+      <xsd:selector xpath=".//service"/>
+      <xsd:field xpath="@name"/>
+    </xsd:key>
+
+    <xsd:keyref name="datasetServiceName" refer="serviceNameKey">
+      <xsd:selector xpath=".//dataset"/>
+      <xsd:field xpath="@serviceName"/>
+    </xsd:keyref>
+
+    <xsd:keyref name="accessServiceName" refer="serviceNameKey">
+      <xsd:selector xpath=".//access"/>
+      <xsd:field xpath="@serviceName"/>
+    </xsd:keyref>
+
+    <xsd:keyref name="serviceName" refer="serviceNameKey">
+      <xsd:selector xpath=".//serviceName"/>
+      <xsd:field xpath="."/>
+    </xsd:keyref>
+
+  </xsd:element>
+
+  <!-- xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx -->
+  <!-- Service element -->
+  <xsd:element name="service">
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element ref="property" minOccurs="0" maxOccurs="unbounded"/>
+        <xsd:element ref="service" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="name" type="xsd:string" use="required"/>
+      <xsd:attribute name="base" type="xsd:string" use="required"/>
+      <xsd:attribute name="serviceType" type="serviceTypes" use="required"/>
+      <xsd:attribute name="desc" type="xsd:string"/>
+      <xsd:attribute name="suffix" type="xsd:string"/>
+    </xsd:complexType>
+  </xsd:element>
+
+  <!-- xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx -->
+  <!-- Dataset element -->
+  <xsd:element name="dataset" type="DatasetType"/>
+  <xsd:complexType name="DatasetType">
+    <xsd:sequence>
+      <xsd:group ref="threddsMetadataGroup" minOccurs="0" maxOccurs="unbounded"/>   <!-- this means any of these elements can appear directly in the dataset element -->
+      <xsd:element ref="access" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element ref="ncml:netcdf" minOccurs="0"/>
+      <xsd:element ref="dataset" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+
+    <xsd:attribute name="name" type="xsd:string" use="required"/>
+    <xsd:attribute name="alias" type="xsd:token"/>
+    <xsd:attribute name="authority" type="xsd:string"/>
+    <xsd:attribute name="collectionType" type="collectionTypes"/>
+    <xsd:attribute name="dataType" type="dataTypes"/>
+    <xsd:attribute name="harvest" type="xsd:boolean"/>
+    <xsd:attribute name="ID" type="xsd:token"/>
+    <xsd:attribute name="restrictAccess" type="xsd:string"/>
+
+    <xsd:attribute name="serviceName" type="xsd:string"/>
+    <xsd:attribute name="urlPath" type="xsd:token"/>
+
+  </xsd:complexType>
+
+  <!-- xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx -->
+  <!-- Access element -->
+  <xsd:element name="access">
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element ref="dataSize" minOccurs="0"/>
+      </xsd:sequence>
+      <xsd:attribute name="urlPath" type="xsd:token" use="required"/>
+      <xsd:attribute name="serviceName" type="xsd:string"/>
+      <xsd:attribute name="dataFormat" type="dataFormatTypes"/>
+    </xsd:complexType>
+  </xsd:element>
+
+
+  <!-- xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx -->
+  <!-- CatalogRef element -->
+  <!-- external catalog gets added as a dataset -->
+  <xsd:element name="catalogRef" substitutionGroup="dataset">
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="DatasetType">
+          <xsd:attributeGroup ref="XLink"/>
+          <xsd:attribute name="useRemoteCatalogService" type="xsd:boolean"/>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+
+  <!-- xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx -->
+  <!-- Documentation element -->
+  <!-- this is human readable info, as text or XHTML, or an Xlink to text or HTML -->
+  <xsd:complexType name="documentationType" mixed="true">
+    <xsd:sequence>
+      <xsd:any namespace="http://www.w3.org/1999/xhtml" minOccurs="0" maxOccurs="unbounded" processContents="strict"/>
+    </xsd:sequence>
+    <xsd:attribute name="type" type="documentationEnumTypes"/>
+    <xsd:attributeGroup ref="XLink"/>
+  </xsd:complexType>
+
+  <!-- Metadata element -->
+  <!-- this is machine readable info in XML, or an Xlink to XML -->
+  <xsd:element name="metadata">
+    <xsd:complexType>
+      <xsd:choice>
+        <xsd:group ref="threddsMetadataGroup" minOccurs="0" maxOccurs="unbounded"/>
+        <xsd:any namespace="##other" minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+      </xsd:choice>
+
+      <xsd:attribute name="inherited" type="xsd:boolean" default="false"/>
+      <xsd:attribute name="metadataType" type="metadataTypeEnum"/>
+      <xsd:attributeGroup ref="XLink"/>
+    </xsd:complexType>
+  </xsd:element>
+
+  <!-- Property element -->
+  <!-- name/value pair -->
+  <xsd:element name="property">
+    <xsd:complexType>
+      <xsd:attribute name="name" type="xsd:string" use="required"/>
+      <xsd:attribute name="value" type="xsd:string" use="required"/>
+    </xsd:complexType>
+  </xsd:element>
+
+  <!-- xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx -->
+  <!-- here is where we augment with new metadata types -->
+
+  <!-- group of elements can be used in a dataset or in metadata elements -->
+  <xsd:group name="threddsMetadataGroup">
+    <xsd:choice>
+      <xsd:element name="documentation" type="documentationType"/>
+      <xsd:element ref="metadata"/>
+      <xsd:element ref="property"/>
+
+      <xsd:element ref="contributor"/>
+      <xsd:element name="creator" type="sourceType"/>
+      <xsd:element name="date" type="dateTypeFormatted"/>
+      <xsd:element name="keyword" type="controlledVocabulary"/>
+      <xsd:element name="project" type="controlledVocabulary"/>
+      <xsd:element name="publisher" type="sourceType"/>
+
+      <xsd:element ref="geospatialCoverage"/>
+      <xsd:element name="timeCoverage" type="timeCoverageType"/>
+      <xsd:element ref="variables"/>
+      <xsd:element ref="variableMap"/>
+
+      <xsd:element name="dataType" type="dataTypes"/>
+      <xsd:element name="dataFormat" type="dataFormatTypes"/>
+      <xsd:element name="serviceName" type="xsd:string"/>
+      <xsd:element name="authority" type="xsd:string"/>
+      <xsd:element ref="dataSize"/>
+    </xsd:choice>
+  </xsd:group>
+
+  <xsd:complexType name="sourceType">
+    <xsd:sequence>
+      <xsd:element name="name" type="controlledVocabulary"/>
+
+      <xsd:element name="contact">
+        <xsd:complexType>
+          <xsd:attribute name="email" type="xsd:string" use="required"/>
+          <xsd:attribute name="url" type="xsd:anyURI"/>
+        </xsd:complexType>
+      </xsd:element>
+
+    </xsd:sequence>
+  </xsd:complexType>
+
+  <!-- contributorType extends dc:contributor to add role attribute -->
+  <xsd:element name="contributor">
+    <xsd:complexType>
+      <xsd:simpleContent>
+        <xsd:extension base="xsd:string">
+          <xsd:attribute name="role" type="xsd:string" use="required"/>
+        </xsd:extension>
+      </xsd:simpleContent>
+    </xsd:complexType>
+  </xsd:element>
+
+  <!-- size element -->
+  <xsd:element name="dataSize">
+    <xsd:complexType>
+      <xsd:simpleContent>
+        <xsd:extension base="xsd:string">
+          <xsd:attribute name="units" type="xsd:string" use="required"/>
+        </xsd:extension>
+      </xsd:simpleContent>
+    </xsd:complexType>
+  </xsd:element>
+
+  <!-- xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx -->
+  <!-- geospatialCoverageType element -->
+  <xsd:element name="geospatialCoverage">
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element name="northsouth" type="spatialRange" minOccurs="0"/>
+        <xsd:element name="eastwest" type="spatialRange" minOccurs="0"/>
+        <xsd:element name="updown" type="spatialRange" minOccurs="0"/>
+        <xsd:element name="name" type="controlledVocabulary" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+
+      <xsd:attribute name="zpositive" type="upOrDown" default="up"/>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:complexType name="spatialRange">
+    <xsd:sequence>
+      <xsd:element name="start" type="xsd:double"/>
+      <xsd:element name="size" type="xsd:double"/>
+      <xsd:element name="resolution" type="xsd:double" minOccurs="0"/>
+      <xsd:element name="units" type="xsd:string" minOccurs="0"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+  <xsd:simpleType name="upOrDown">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="up"/>
+      <xsd:enumeration value="down"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <!-- xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx -->
+  <!-- date and time-->
+  <xsd:complexType name="timeCoverageType">
+    <xsd:sequence>
+      <xsd:attribute name="calendar" type="xsd:string"/>
+      <xsd:choice minOccurs="2" maxOccurs="3">
+        <xsd:element name="start" type="dateTypeFormatted"/>
+        <xsd:element name="end" type="dateTypeFormatted"/>
+        <xsd:element name="duration" type="duration"/>
+      </xsd:choice>
+      <xsd:element name="resolution" type="duration" minOccurs="0"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+  <!-- may be a dateType or have a format attribute  -->
+  <xsd:complexType name="dateTypeFormatted">
+    <xsd:simpleContent>
+      <xsd:extension base="dateType">
+        <xsd:attribute name="format" type="xsd:string"/>
+        <!-- follow java.text.SimpleDateFormat -->
+        <xsd:attribute name="type" type="dateEnumTypes"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+  <!-- may be a built in date or dateTIme, or a udunit encoded string -->
+  <xsd:simpleType name="dateType">
+    <xsd:union memberTypes="xsd:date xsd:dateTime udunitDate">
+      <xsd:simpleType>
+        <xsd:restriction base="xsd:token">
+          <xsd:enumeration value="present"/>
+        </xsd:restriction>
+      </xsd:simpleType>
+    </xsd:union>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="udunitDate">
+    <xsd:restriction base="xsd:string">
+      <xsd:annotation>
+        <xsd:documentation>Must conform to complete udunits date string, eg "20 days since 1991-01-01"</xsd:documentation>
+      </xsd:annotation>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="duration">
+    <xsd:union memberTypes="xsd:duration udunitDuration"/>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="udunitDuration">
+    <xsd:restriction base="xsd:string">
+      <xsd:annotation>
+        <xsd:documentation>Must conform to udunits time duration, eg "20.1 hours"</xsd:documentation>
+      </xsd:annotation>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <!-- xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx -->
+  <!-- variables element -->
+  <xsd:element name="variables">
+    <xsd:complexType>
+      <xsd:choice>
+        <xsd:element ref="variable" minOccurs="0" maxOccurs="unbounded"/>
+        <xsd:element ref="variableMap" minOccurs="0"/>
+      </xsd:choice>
+      <xsd:attribute name="vocabulary" type="variableNameVocabulary" use="optional"/>
+      <xsd:attributeGroup ref="XLink"/>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="variable">
+    <xsd:complexType mixed="true">
+      <xsd:attribute name="name" type="xsd:string" use="required"/>
+      <xsd:attribute name="vocabulary_name" type="xsd:string" use="optional"/>
+      <xsd:attribute name="vocabulary_id" type="xsd:string" use="optional"/>
+      <xsd:attribute name="units" type="xsd:string"/>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="variableMap">
+    <xsd:complexType>
+      <xsd:attributeGroup ref="XLink"/>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:simpleType name="variableNameVocabulary">
+    <xsd:union memberTypes="xsd:token">
+      <xsd:simpleType>
+        <xsd:restriction base="xsd:token">
+          <xsd:enumeration value="CF-1.0"/>
+          <xsd:enumeration value="DIF"/>
+          <xsd:enumeration value="GRIB-1"/>
+          <xsd:enumeration value="GRIB-2"/>
+        </xsd:restriction>
+      </xsd:simpleType>
+    </xsd:union>
+  </xsd:simpleType>
+
+  <!-- xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx -->
+  <!-- reusable types and groups -->
+
+  <!-- controlledVocabulary type allows optional vocabulary attribute-->
+  <xsd:complexType name="controlledVocabulary">
+    <xsd:simpleContent>
+      <xsd:extension base="xsd:string">
+        <xsd:attribute name="vocabulary" type="xsd:string"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+  <!-- Xlink attribute group -->
+  <xsd:attributeGroup name="XLink">
+    <xsd:attribute ref="xlink:type"/>
+    <xsd:attribute ref="xlink:href"/>
+    <xsd:attribute ref="xlink:title"/>
+    <xsd:attribute ref="xlink:show"/>
+  </xsd:attributeGroup>
+
+  <!-- Collection Types -->
+  <xsd:simpleType name="collectionTypes">
+    <xsd:union memberTypes="xsd:token">
+      <xsd:simpleType>
+        <xsd:restriction base="xsd:token">
+          <xsd:enumeration value="TimeSeries"/>
+          <xsd:enumeration value="Stations"/>
+          <xsd:enumeration value="ForecastModelRuns"/>
+        </xsd:restriction>
+      </xsd:simpleType>
+    </xsd:union>
+  </xsd:simpleType>
+
+  <!-- Data Types -->
+  <xsd:simpleType name="dataTypes">
+    <xsd:union memberTypes="xsd:token">
+      <xsd:simpleType>
+        <xsd:restriction base="xsd:token">
+          <xsd:enumeration value="Grid"/>
+          <xsd:enumeration value="Image"/>
+          <xsd:enumeration value="Point"/>
+          <xsd:enumeration value="Radial"/>
+          <xsd:enumeration value="Station"/>
+          <xsd:enumeration value="Swath"/>
+          <xsd:enumeration value="Trajectory"/>
+        </xsd:restriction>
+      </xsd:simpleType>
+    </xsd:union>
+  </xsd:simpleType>
+
+  <!-- DataFormat Types -->
+  <xsd:simpleType name="dataFormatTypes">
+    <xsd:union memberTypes="xsd:token mimeType">
+      <xsd:simpleType>
+        <xsd:restriction base="xsd:token">
+          <xsd:enumeration value="BUFR"/>
+          <xsd:enumeration value="ESML"/>
+          <xsd:enumeration value="GEMPAK"/>
+          <xsd:enumeration value="GINI"/>
+          <xsd:enumeration value="GRIB-1"/>
+          <xsd:enumeration value="GRIB-2"/>
+          <xsd:enumeration value="HDF4"/>
+          <xsd:enumeration value="HDF5"/>
+          <xsd:enumeration value="McIDAS-AREA"/>
+          <xsd:enumeration value="NcML"/>
+          <xsd:enumeration value="NetCDF"/>
+          <xsd:enumeration value="NetCDF-4"/>
+          <xsd:enumeration value="NEXRAD2"/>
+          <xsd:enumeration value="NIDS"/>
+
+          <xsd:enumeration value="image/gif"/>
+          <xsd:enumeration value="image/jpeg"/>
+          <xsd:enumeration value="image/tiff"/>
+          <xsd:enumeration value="text/csv"/>
+          <xsd:enumeration value="text/html"/>
+          <xsd:enumeration value="text/plain"/>
+          <xsd:enumeration value="text/tab-separated-values"/>
+          <xsd:enumeration value="text/xml"/>
+          <xsd:enumeration value="video/mpeg"/>
+          <xsd:enumeration value="video/quicktime"/>
+          <xsd:enumeration value="video/realtime"/>
+        </xsd:restriction>
+      </xsd:simpleType>
+    </xsd:union>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="mimeType">
+    <xsd:restriction base="xsd:token">
+      <xsd:annotation>
+        <xsd:documentation>any valid mime type (see http://www.iana.org/assignments/media-types/)</xsd:documentation>
+      </xsd:annotation>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <!-- Date Types -->
+  <xsd:simpleType name="dateEnumTypes">
+    <xsd:union memberTypes="xsd:token">
+      <xsd:simpleType>
+        <xsd:restriction base="xsd:token">
+          <xsd:enumeration value="created"/>
+          <xsd:enumeration value="modified"/>
+          <xsd:enumeration value="valid"/>
+          <xsd:enumeration value="issued"/>
+          <xsd:enumeration value="available"/>
+          <xsd:enumeration value="metadataCreated"/>
+        </xsd:restriction>
+      </xsd:simpleType>
+    </xsd:union>
+  </xsd:simpleType>
+
+  <!-- Documentation Types -->
+  <xsd:simpleType name="documentationEnumTypes">
+    <xsd:union memberTypes="xsd:token">
+      <xsd:simpleType>
+        <xsd:restriction base="xsd:token">
+          <xsd:enumeration value="funding"/>
+          <xsd:enumeration value="history"/>
+          <xsd:enumeration value="processing_level"/>
+          <xsd:enumeration value="rights"/>
+          <xsd:enumeration value="summary"/>
+        </xsd:restriction>
+      </xsd:simpleType>
+    </xsd:union>
+  </xsd:simpleType>
+
+  <!-- MetadataTypeEnum -->
+  <xsd:simpleType name="metadataTypeEnum">
+    <xsd:union memberTypes="xsd:token">
+      <xsd:simpleType>
+        <xsd:restriction base="xsd:token">
+          <xsd:enumeration value="THREDDS"/>
+          <xsd:enumeration value="ADN"/>
+          <xsd:enumeration value="Aggregation"/>
+          <xsd:enumeration value="CatalogGenConfig"/>
+          <xsd:enumeration value="DublinCore"/>
+          <xsd:enumeration value="DIF"/>
+          <xsd:enumeration value="FGDC"/>
+          <xsd:enumeration value="LAS"/>
+          <xsd:enumeration value="ESG"/>
+          <xsd:enumeration value="Other"/>
+        </xsd:restriction>
+      </xsd:simpleType>
+    </xsd:union>
+  </xsd:simpleType>
+
+  <!-- ServiceTypeEnum -->
+  <xsd:simpleType name="serviceTypes">
+    <xsd:union memberTypes="xsd:token">
+      <xsd:simpleType>
+        <xsd:restriction base="xsd:token">
+          <!-- client/server -->
+          <xsd:enumeration value="ADDE"/>
+          <xsd:enumeration value="DAP4"/>
+          <xsd:enumeration value="DODS"/> <!-- same as OpenDAP -->
+          <xsd:enumeration value="OpenDAP"/>
+          <xsd:enumeration value="OpenDAPG"/>
+          <xsd:enumeration value="NetcdfSubset"/>
+          <xsd:enumeration value="CdmRemote"/>
+          <xsd:enumeration value="CdmFeature"/>
+          <xsd:enumeration value="ncJSON"/>
+          <xsd:enumeration value="H5Service"/>
+
+          <!-- bulk transport -->
+          <xsd:enumeration value="HTTPServer"/>
+          <xsd:enumeration value="FTP"/>
+          <xsd:enumeration value="GridFTP"/>
+          <xsd:enumeration value="File"/>
+
+          <!-- web services -->
+          <xsd:enumeration value="ISO"/>
+          <xsd:enumeration value="LAS"/>
+          <xsd:enumeration value="LAS"/>
+          <xsd:enumeration value="NcML"/>
+          <xsd:enumeration value="UDDC"/>
+          <xsd:enumeration value="WCS"/>
+          <xsd:enumeration value="WMS"/>
+          <xsd:enumeration value="WSDL"/>
+
+          <!--offline -->
+          <xsd:enumeration value="WebForm"/>
+
+          <!-- THREDDS -->
+          <xsd:enumeration value="Catalog"/>
+          <xsd:enumeration value="Compound"/>
+          <xsd:enumeration value="Resolver"/>
+          <xsd:enumeration value="THREDDS"/>
+        </xsd:restriction>
+      </xsd:simpleType>
+    </xsd:union>
+  </xsd:simpleType>
+
+  <!-- xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx -->
+  <!-- server-side Configuration Catalog elements  -->
+  <!-- xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx -->
+
+  <!-- datasetRoot element: associate a url path with a directory location -->
+  <xsd:element name="datasetRoot">
+    <xsd:complexType>
+      <xsd:attribute name="path" type="xsd:string" use="required"/>
+      <xsd:attribute name="location" type="xsd:string" use="required"/>
+      <xsd:attribute name="cache" type="xsd:boolean"/>                  <!-- no not use -->
+    </xsd:complexType>
+  </xsd:element>
+
+  <!-- CatalogScan element -->
+  <!-- scan a directory and read all catalogs. optionally watch for changes while TDS is running -->
+  <xsd:element name="catalogScan">
+    <xsd:complexType>
+      <xsd:attribute name="name" type="xsd:string"/>
+      <xsd:attribute name="path" type="xsd:string"/>
+      <xsd:attribute name="location" type="xsd:string"/>
+      <xsd:attribute name="watch" type="xsd:boolean"/>
+    </xsd:complexType>
+  </xsd:element>
+
+  <!-- DatasetScan element -->
+  <!-- scan a directory to add datasets to catalog -->
+  <xsd:element name="datasetScan" substitutionGroup="dataset">
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="DatasetType">
+          <xsd:sequence>
+            <xsd:element ref="filter" minOccurs="0"/>
+            <xsd:element ref="namer" minOccurs="0"/>
+            <xsd:element name="filesSort" type="fileSortType" minOccurs="0"/>
+            <xsd:element ref="sort" minOccurs="0"/>           <!-- deprecated, use filesSort -->
+            <xsd:element name="addLatest" type="addLatestType" minOccurs="0"/>
+            <xsd:element ref="addProxies" minOccurs="0"/>      <!-- deprecated, use addLatest -->
+            <xsd:element ref="addTimeCoverage" minOccurs="0"/>
+          </xsd:sequence>
+
+          <xsd:attribute name="path" type="xsd:string" use="required"/>
+          <xsd:attribute name="location" type="xsd:string"/>
+          <xsd:attribute name="addLatest" type="xsd:boolean"/>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="filter">
+    <xsd:complexType>
+      <xsd:choice>
+        <xsd:sequence minOccurs="0" maxOccurs="unbounded">
+          <xsd:element name="include" type="FilterSelectorType" minOccurs="0"/>
+          <xsd:element name="exclude" type="FilterSelectorType" minOccurs="0"/>
+        </xsd:sequence>
+      </xsd:choice>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:complexType name="FilterSelectorType">
+    <xsd:attribute name="regExp" type="xsd:string"/>
+    <xsd:attribute name="wildcard" type="xsd:string"/>
+    <xsd:attribute name="atomic" type="xsd:boolean"/>
+    <xsd:attribute name="collection" type="xsd:boolean"/>
+  </xsd:complexType>
+
+  <xsd:element name="namer">
+    <xsd:complexType>
+      <xsd:choice maxOccurs="unbounded">
+        <xsd:element name="regExpOnName" type="NamerSelectorType"/>
+        <xsd:element name="regExpOnPath" type="NamerSelectorType"/>
+      </xsd:choice>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:complexType name="NamerSelectorType">
+    <xsd:attribute name="regExp" type="xsd:string"/>
+    <xsd:attribute name="replaceString" type="xsd:string"/>
+  </xsd:complexType>
+
+  <xsd:element name="sort">
+    <xsd:complexType>
+      <xsd:choice>
+        <xsd:element name="lexigraphicByName">
+          <xsd:complexType>
+            <xsd:attribute name="increasing" type="xsd:boolean"/>
+          </xsd:complexType>
+        </xsd:element>
+      </xsd:choice>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:complexType name="addLatestType">
+    <xsd:attribute name="name" type="xsd:string"/>
+    <xsd:attribute name="top" type="xsd:boolean"/>
+    <xsd:attribute name="serviceName" type="xsd:string"/>
+    <xsd:attribute name="lastModifiedLimit" type="xsd:float"/> <!-- minutes -->
+  </xsd:complexType>
+
+  <xsd:element name="addTimeCoverage">
+    <xsd:complexType>
+      <xsd:attribute name="datasetNameMatchPattern" type="xsd:string"/>
+      <xsd:attribute name="datasetPathMatchPattern" type="xsd:string"/>
+      <xsd:attribute name="startTimeSubstitutionPattern" type="xsd:string"/>
+      <xsd:attribute name="duration" type="xsd:string"/>
+    </xsd:complexType>
+  </xsd:element>
+
+  <!-- legacy -->
+  <xsd:element name="addProxies">
+    <xsd:complexType>
+      <xsd:choice minOccurs="0" maxOccurs="unbounded">
+        <xsd:element name="simpleLatest" type="addLatestType"/>
+        <xsd:element name="latestComplete" type="addLatestType"/>
+      </xsd:choice>
+    </xsd:complexType>
+  </xsd:element>
+
+  <!-- xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx -->
+  <!-- featureCollection element -->
+  <xsd:element name="featureCollection" substitutionGroup="dataset">
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="DatasetType">
+          <xsd:sequence>
+            <xsd:element type="collectionType" name="collection"/>
+            <xsd:element type="updateType" name="update" minOccurs="0"/>
+            <xsd:element type="tdmType" name="tdm" minOccurs="0"/>
+            <xsd:element type="protoDatasetType" name="protoDataset" minOccurs="0"/>
+            <xsd:element type="fmrcConfigType" name="fmrcConfig" minOccurs="0"/>
+            <xsd:element type="pointConfigType" name="pointConfig" minOccurs="0"/>
+            <xsd:element type="gribConfigType" name="gribConfig" minOccurs="0"/>
+            <xsd:element type="fileSortType" name="filesSort" minOccurs="0" />
+            <xsd:element ref="ncml:netcdf" minOccurs="0"/>
+          </xsd:sequence>
+          <xsd:attribute name="featureType" type="featureTypeChoice" use="required"/>
+          <xsd:attribute name="path" type="xsd:string" use="required"/>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:complexType name="fileSortType">
+    <xsd:attribute name="increasing" type="xsd:boolean" use="optional"/>
+  </xsd:complexType>
+
+  <xsd:simpleType name="featureTypeChoice">
+    <xsd:union memberTypes="xsd:token">
+      <xsd:simpleType>
+        <xsd:restriction base="xsd:token">
+          <xsd:enumeration value="FMRC"/>
+          <xsd:enumeration value="GRIB1"/>
+          <xsd:enumeration value="GRIB2"/>
+          <xsd:enumeration value="Point"/>
+          <xsd:enumeration value="Station"/>
+        </xsd:restriction>
+      </xsd:simpleType>
+    </xsd:union>
+  </xsd:simpleType>
+
+  <xsd:complexType name="collectionType">
+    <xsd:attribute name="spec" type="xsd:string" use="required"/>
+    <xsd:attribute name="name" type="xsd:token"/>
+    <xsd:attribute name="olderThan" type="xsd:string"/>
+    <xsd:attribute name="dateFormatMark" type="xsd:string"/>
+    <xsd:attribute name="timePartition" type="xsd:string"/>
+    <xsd:attribute name="useIndexOnly" type="xsd:boolean"/>
+  </xsd:complexType>
+
+  <xsd:complexType name="updateType">
+    <xsd:attribute name="recheckAfter" type="xsd:string"/>
+    <xsd:attribute name="rescan" type="xsd:token"/>
+    <xsd:attribute name="rewrite" type="collectionUpdateType"/>
+    <xsd:attribute name="startup" type="collectionUpdateType"/>
+    <xsd:attribute name="trigger" type="xsd:string"/>
+  </xsd:complexType>
+
+  <xsd:complexType name="tdmType">
+    <xsd:sequence>
+      <xsd:element ref="manage" minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attribute name="rewrite" type="collectionUpdateType"/>
+    <xsd:attribute name="rescan" type="xsd:token"/>
+  </xsd:complexType>
+
+  <xsd:simpleType name="collectionUpdateType">
+    <xsd:union memberTypes="xsd:token">
+      <xsd:simpleType>
+        <xsd:restriction base="xsd:token">
+          <xsd:enumeration value="never"/>
+          <xsd:enumeration value="nocheck"/>
+          <xsd:enumeration value="testIndexOnly"/>
+          <xsd:enumeration value="test"/>
+          <xsd:enumeration value="always"/>
+        </xsd:restriction>
+      </xsd:simpleType>
+    </xsd:union>
+  </xsd:simpleType>
+
+  <xsd:element name="manage">
+    <xsd:complexType>
+      <xsd:attribute name="deleteAfter" type="xsd:string" use="required"/>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:complexType name="protoDatasetType">
+    <xsd:sequence>
+      <xsd:element ref="ncml:netcdf" minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attribute name="choice" type="protoChoices"/>
+    <xsd:attribute name="change" type="xsd:string"/>
+    <xsd:attribute name="param" type="xsd:string"/>
+  </xsd:complexType>
+
+  <xsd:simpleType name="protoChoices">
+    <xsd:union memberTypes="xsd:token">
+      <xsd:simpleType>
+        <xsd:restriction base="xsd:token">
+          <xsd:enumeration value="First"/>
+          <xsd:enumeration value="Random"/>
+          <xsd:enumeration value="Penultimate"/>
+          <xsd:enumeration value="Latest"/>
+          <xsd:enumeration value="Run"/>
+        </xsd:restriction>
+      </xsd:simpleType>
+    </xsd:union>
+  </xsd:simpleType>
+
+  <xsd:complexType name="fmrcConfigType">
+    <xsd:sequence>
+      <xsd:element name="bestDataset" minOccurs="0">
+        <xsd:complexType>
+          <xsd:attribute name="name" type="xsd:token" use="required"/>
+          <xsd:attribute name="offsetsGreaterEqual" type="xsd:int" use="required"/>
+        </xsd:complexType>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="regularize" type="xsd:boolean"/>
+    <xsd:attribute name="datasetTypes" type="fmrcDatasetTypes"/>
+  </xsd:complexType>
+
+  <xsd:simpleType name="fmrcDatasetTypes">
+    <xsd:union memberTypes="xsd:token">
+      <xsd:simpleType>
+        <xsd:restriction base="xsd:token">
+          <xsd:enumeration value="TwoD"/>
+          <xsd:enumeration value="Best"/>
+          <xsd:enumeration value="Files"/>
+          <xsd:enumeration value="Runs"/>
+          <xsd:enumeration value="ConstantForecasts"/>
+          <xsd:enumeration value="ConstantOffsets"/>
+        </xsd:restriction>
+      </xsd:simpleType>
+    </xsd:union>
+  </xsd:simpleType>
+
+  <xsd:complexType name="pointConfigType">
+    <xsd:attribute name="datasetTypes" type="xsd:string"/>
+  </xsd:complexType>
+
+  <xsd:complexType name="gribConfigType">
+    <xsd:sequence>
+
+      <xsd:element name="gdsHash" minOccurs="0">
+        <xsd:complexType>
+          <xsd:attribute name="from" type="xsd:int" use="required"/>
+          <xsd:attribute name="to" type="xsd:int" use="required"/>
+        </xsd:complexType>
+      </xsd:element>
+
+      <xsd:element name="gdsName" minOccurs="0" maxOccurs="unbounded">
+        <xsd:complexType>
+          <xsd:attribute name="hash" type="xsd:int"/>
+          <xsd:attribute name="groupName" type="xsd:string"/>
+        </xsd:complexType>
+      </xsd:element>
+
+      <xsd:element name="pdsHash" minOccurs="0" maxOccurs="unbounded">
+        <xsd:complexType>
+          <xsd:sequence>
+            <xsd:element name="useGenType" minOccurs="0"/>
+            <xsd:element name="useTableVersion" minOccurs="0"/>
+            <xsd:element name="mergeIntv" minOccurs="0"/>
+          </xsd:sequence>
+        </xsd:complexType>
+      </xsd:element>
+
+      <xsd:element name="intvFilter" minOccurs="0" maxOccurs="unbounded">
+        <xsd:complexType>
+          <xsd:sequence>
+            <xsd:element name="variable" minOccurs="0" maxOccurs="unbounded">
+              <xsd:complexType>
+                <xsd:attribute name="id" type="xsd:string" use="required"/>
+                <xsd:attribute name="prob" type="xsd:string" use="optional"/>
+              </xsd:complexType>
+            </xsd:element>
+          </xsd:sequence>
+          <xsd:attribute name="excludeZero" type="xsd:boolean" use="optional"/>
+          <xsd:attribute name="intvLength" type="xsd:int" use="optional"/>
+        </xsd:complexType>
+      </xsd:element>
+
+      <xsd:element name="filter" minOccurs="0" maxOccurs="unbounded">
+        <xsd:complexType>
+          <xsd:sequence>
+            <xsd:element name="include" minOccurs="0" maxOccurs="unbounded">
+              <xsd:complexType>
+                <xsd:attribute name="name" type="xsd:string" use="required"/>
+                <xsd:attribute name="value" type="xsd:string" use="required"/>
+              </xsd:complexType>
+            </xsd:element>
+          </xsd:sequence>
+        </xsd:complexType>
+      </xsd:element>
+
+      <xsd:element name="timeUnitConvert" minOccurs="0">
+        <xsd:complexType>
+          <xsd:attribute name="from" type="xsd:int" use="required"/>
+          <xsd:attribute name="to" type="xsd:int" use="required"/>
+        </xsd:complexType>
+      </xsd:element>
+
+      <xsd:element name="option" minOccurs="0" maxOccurs="unbounded">
+         <xsd:complexType>
+           <xsd:attribute name="name" type="xsd:string" use="required"/>
+           <xsd:attribute name="value" type="xsd:string" use="required"/>
+         </xsd:complexType>
+       </xsd:element>
+
+      <xsd:element name="latestNamer" minOccurs="0">
+        <xsd:complexType>
+          <xsd:attribute name="name" type="xsd:string" use="required"/>
+        </xsd:complexType>
+      </xsd:element>
+
+      <xsd:element name="bestNamer" minOccurs="0">
+        <xsd:complexType>
+          <xsd:attribute name="name" type="xsd:string" use="required"/>
+        </xsd:complexType>
+      </xsd:element>
+
+    </xsd:sequence>
+
+    <xsd:attribute name="datasetTypes" type="gribDatasetTypes"/>
+
+  </xsd:complexType>
+
+  <xsd:simpleType name="gribDatasetTypes">
+    <xsd:union memberTypes="xsd:token">
+      <xsd:simpleType>
+        <xsd:restriction base="xsd:token">
+          <xsd:enumeration value="TwoD"/>
+          <xsd:enumeration value="Best"/>
+          <xsd:enumeration value="Analysis"/>
+          <xsd:enumeration value="Files"/>
+          <xsd:enumeration value="Latest"/>
+          <xsd:enumeration value="LatestFile"/>    <!-- alias for Latest -->
+        </xsd:restriction>
+      </xsd:simpleType>
+    </xsd:union>
+  </xsd:simpleType>
+
+</xsd:schema>

--- a/tdcommon/src/main/resources/resources/thredds/schemas/InvCatalog.1.3.xsd
+++ b/tdcommon/src/main/resources/resources/thredds/schemas/InvCatalog.1.3.xsd
@@ -1,0 +1,931 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema
+    targetNamespace="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0"
+    xmlns="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    xmlns:ncml="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2"
+    elementFormDefault="qualified"
+    attributeFormDefault="unqualified"
+    version="1.3">
+
+  <!-- import other namespaces -->
+  <xsd:import namespace="http://www.w3.org/1999/xlink" schemaLocation="https://schemas.unidata.ucar.edu/other/xlink.xsd"/>
+  <xsd:import namespace="http://www.unidata.ucar.edu/namespaces/netcdf/ncml-2.2" schemaLocation="https://schemas.unidata.ucar.edu/netcdf/ncml-2.2.xsd"/>
+
+  <!-- xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx -->
+  <!-- Catalog element -->
+  <xsd:element name="catalog">
+
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element ref="service" minOccurs="0" maxOccurs="unbounded"/>
+        <xsd:element ref="datasetRoot" minOccurs="0" maxOccurs="unbounded"/>    <!-- server -->
+        <xsd:element ref="property" minOccurs="0" maxOccurs="unbounded"/>
+        <xsd:element ref="dataset" minOccurs="1" maxOccurs="unbounded"/>
+        <xsd:element ref="catalogScan" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+
+      <xsd:attribute name="base" type="xsd:anyURI"/>
+      <xsd:attribute name="name" type="xsd:string"/>
+      <xsd:attribute name="expires" type="dateType"/>
+      <xsd:attribute name="version" type="xsd:token" default="1.3"/>
+    </xsd:complexType>
+
+    <!-- Enforce dataset ID references:
+       1) Each dataset ID must be unique in the document.
+       2) Each dataset alias must reference a dataset ID in the document.
+       -->
+    <xsd:unique name="datasetID">
+      <xsd:selector xpath=".//dataset"/>
+      <xsd:field xpath="@ID"/>
+    </xsd:unique>
+
+    <xsd:keyref name="datasetAlias" refer="datasetID">
+      <xsd:selector xpath=".//dataset"/>
+      <xsd:field xpath="@alias"/>
+    </xsd:keyref>
+
+    <!-- Enforce references to services:
+        1) Each service name must be unique and is required.
+        2) Each dataset that references a service (i.e., has a serviceName
+            attribute) must reference a service that exists.
+        3) Each access that references a service (i.e., has a serviceName
+            attribute) must reference a service that exists.
+        4) Each serviceName element must reference a service that exists.
+      -->
+    <xsd:key name="serviceNameKey">
+      <xsd:selector xpath=".//service"/>
+      <xsd:field xpath="@name"/>
+    </xsd:key>
+
+    <xsd:keyref name="datasetServiceName" refer="serviceNameKey">
+      <xsd:selector xpath=".//dataset"/>
+      <xsd:field xpath="@serviceName"/>
+    </xsd:keyref>
+
+    <xsd:keyref name="accessServiceName" refer="serviceNameKey">
+      <xsd:selector xpath=".//access"/>
+      <xsd:field xpath="@serviceName"/>
+    </xsd:keyref>
+
+    <xsd:keyref name="serviceName" refer="serviceNameKey">
+      <xsd:selector xpath=".//serviceName"/>
+      <xsd:field xpath="."/>
+    </xsd:keyref>
+
+  </xsd:element>
+
+  <!-- xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx -->
+  <!-- Service element -->
+  <xsd:element name="service">
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element ref="property" minOccurs="0" maxOccurs="unbounded"/>
+        <xsd:element ref="service" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="name" type="xsd:string" use="required"/>
+      <xsd:attribute name="base" type="xsd:string" use="required"/>
+      <xsd:attribute name="serviceType" type="serviceTypes" use="required"/>
+      <xsd:attribute name="desc" type="xsd:string"/>
+      <xsd:attribute name="suffix" type="xsd:string"/>
+    </xsd:complexType>
+  </xsd:element>
+
+  <!-- xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx -->
+  <!-- Dataset element -->
+  <xsd:element name="dataset" type="DatasetType"/>
+  <xsd:complexType name="DatasetType">
+    <xsd:sequence>
+      <xsd:group ref="threddsMetadataGroup" minOccurs="0" maxOccurs="unbounded"/>   <!-- this means any of these elements can appear directly in the dataset element -->
+      <xsd:element ref="access" minOccurs="0" maxOccurs="unbounded"/>
+      <xsd:element ref="ncml:netcdf" minOccurs="0"/>
+      <xsd:element ref="dataset" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+
+    <xsd:attribute name="name" type="xsd:string" use="required"/>
+    <xsd:attribute name="alias" type="xsd:token"/>
+    <xsd:attribute name="authority" type="xsd:string"/>
+    <xsd:attribute name="collectionType" type="collectionTypes"/>
+    <xsd:attribute name="dataType" type="dataTypes"/>
+    <xsd:attribute name="harvest" type="xsd:boolean"/>
+    <xsd:attribute name="ID" type="xsd:token"/>
+    <xsd:attribute name="restrictAccess" type="xsd:string"/>
+
+    <xsd:attribute name="serviceName" type="xsd:string"/>
+    <xsd:attribute name="urlPath" type="xsd:token"/>
+
+  </xsd:complexType>
+
+  <!-- xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx -->
+  <!-- Access element -->
+  <xsd:element name="access">
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element ref="dataSize" minOccurs="0"/>
+      </xsd:sequence>
+      <xsd:attribute name="urlPath" type="xsd:token" use="required"/>
+      <xsd:attribute name="serviceName" type="xsd:string"/>
+      <xsd:attribute name="dataFormat" type="dataFormatTypes"/>
+    </xsd:complexType>
+  </xsd:element>
+
+
+  <!-- xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx -->
+  <!-- CatalogRef element -->
+  <!-- external catalog gets added as a dataset -->
+  <xsd:element name="catalogRef" substitutionGroup="dataset">
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="DatasetType">
+          <xsd:attributeGroup ref="XLink"/>
+          <xsd:attribute name="useRemoteCatalogService" type="xsd:boolean"/>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+
+  <!-- xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx -->
+  <!-- Documentation element -->
+  <!-- this is human readable info, as text or XHTML, or an Xlink to text or HTML -->
+  <xsd:complexType name="documentationType" mixed="true">
+    <xsd:sequence>
+      <xsd:any namespace="http://www.w3.org/1999/xhtml" minOccurs="0" maxOccurs="unbounded" processContents="strict"/>
+    </xsd:sequence>
+    <xsd:attribute name="type" type="documentationEnumTypes"/>
+    <xsd:attributeGroup ref="XLink"/>
+  </xsd:complexType>
+
+  <!-- Metadata element -->
+  <!-- this is machine readable info in XML, or an Xlink to XML -->
+  <xsd:element name="metadata">
+    <xsd:complexType>
+      <xsd:choice>
+        <xsd:group ref="threddsMetadataGroup" minOccurs="0" maxOccurs="unbounded"/>
+        <xsd:any namespace="##other" minOccurs="0" maxOccurs="unbounded" processContents="lax"/>
+      </xsd:choice>
+
+      <xsd:attribute name="inherited" type="xsd:boolean" default="false"/>
+      <xsd:attribute name="metadataType" type="metadataTypeEnum"/>
+      <xsd:attributeGroup ref="XLink"/>
+    </xsd:complexType>
+  </xsd:element>
+
+  <!-- Property element -->
+  <!-- name/value pair -->
+  <xsd:element name="property">
+    <xsd:complexType>
+      <xsd:attribute name="name" type="xsd:string" use="required"/>
+      <xsd:attribute name="value" type="xsd:string" use="required"/>
+    </xsd:complexType>
+  </xsd:element>
+
+  <!-- xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx -->
+  <!-- here is where we augment with new metadata types -->
+
+  <!-- group of elements can be used in a dataset or in metadata elements -->
+  <xsd:group name="threddsMetadataGroup">
+    <xsd:choice>
+      <xsd:element name="documentation" type="documentationType"/>
+      <xsd:element ref="metadata"/>
+      <xsd:element ref="property"/>
+
+      <xsd:element ref="contributor"/>
+      <xsd:element name="creator" type="sourceType"/>
+      <xsd:element name="date" type="dateTypeFormatted"/>
+      <xsd:element name="keyword" type="controlledVocabulary"/>
+      <xsd:element name="project" type="controlledVocabulary"/>
+      <xsd:element name="publisher" type="sourceType"/>
+
+      <xsd:element ref="geospatialCoverage"/>
+      <xsd:element name="timeCoverage" type="timeCoverageType"/>
+      <xsd:element ref="variables"/>
+      <xsd:element ref="variableMap"/>
+
+      <xsd:element name="dataType" type="dataTypes"/>
+      <xsd:element name="dataFormat" type="dataFormatTypes"/>
+      <xsd:element name="serviceName" type="xsd:string"/>
+      <xsd:element name="authority" type="xsd:string"/>
+      <xsd:element ref="dataSize"/>
+    </xsd:choice>
+  </xsd:group>
+
+  <xsd:complexType name="sourceType">
+    <xsd:sequence>
+      <xsd:element name="name" type="controlledVocabulary"/>
+
+      <xsd:element name="contact">
+        <xsd:complexType>
+          <xsd:attribute name="email" type="xsd:string" use="required"/>
+          <xsd:attribute name="url" type="xsd:anyURI"/>
+        </xsd:complexType>
+      </xsd:element>
+
+    </xsd:sequence>
+  </xsd:complexType>
+
+  <!-- contributorType extends dc:contributor to add role attribute -->
+  <xsd:element name="contributor">
+    <xsd:complexType>
+      <xsd:simpleContent>
+        <xsd:extension base="xsd:string">
+          <xsd:attribute name="role" type="xsd:string" use="required"/>
+        </xsd:extension>
+      </xsd:simpleContent>
+    </xsd:complexType>
+  </xsd:element>
+
+  <!-- size element -->
+  <xsd:element name="dataSize">
+    <xsd:complexType>
+      <xsd:simpleContent>
+        <xsd:extension base="xsd:string">
+          <xsd:attribute name="units" type="xsd:string" use="required"/>
+        </xsd:extension>
+      </xsd:simpleContent>
+    </xsd:complexType>
+  </xsd:element>
+
+  <!-- xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx -->
+  <!-- geospatialCoverageType element -->
+  <xsd:element name="geospatialCoverage">
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element name="northsouth" type="spatialRange" minOccurs="0"/>
+        <xsd:element name="eastwest" type="spatialRange" minOccurs="0"/>
+        <xsd:element name="updown" type="spatialRange" minOccurs="0"/>
+        <xsd:element name="name" type="controlledVocabulary" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+
+      <xsd:attribute name="zpositive" type="upOrDown" default="up"/>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:complexType name="spatialRange">
+    <xsd:sequence>
+      <xsd:element name="start" type="xsd:double"/>
+      <xsd:element name="size" type="xsd:double"/>
+      <xsd:element name="resolution" type="xsd:double" minOccurs="0"/>
+      <xsd:element name="units" type="xsd:string" minOccurs="0"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+  <xsd:simpleType name="upOrDown">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="up"/>
+      <xsd:enumeration value="down"/>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <!-- xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx -->
+  <!-- date and time-->
+  <xsd:complexType name="timeCoverageType">
+    <xsd:sequence>
+      <xsd:attribute name="calendar" type="xsd:string"/>
+      <xsd:choice minOccurs="2" maxOccurs="3">
+        <xsd:element name="start" type="dateTypeFormatted"/>
+        <xsd:element name="end" type="dateTypeFormatted"/>
+        <xsd:element name="duration" type="duration"/>
+      </xsd:choice>
+      <xsd:element name="resolution" type="duration" minOccurs="0"/>
+    </xsd:sequence>
+  </xsd:complexType>
+
+  <!-- may be a dateType or have a format attribute  -->
+  <xsd:complexType name="dateTypeFormatted">
+    <xsd:simpleContent>
+      <xsd:extension base="dateType">
+        <xsd:attribute name="format" type="xsd:string"/>
+        <!-- follow java.text.SimpleDateFormat -->
+        <xsd:attribute name="type" type="dateEnumTypes"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+  <!-- may be a built in date or dateTIme, or a udunit encoded string -->
+  <xsd:simpleType name="dateType">
+    <xsd:union memberTypes="xsd:date xsd:dateTime udunitDate">
+      <xsd:simpleType>
+        <xsd:restriction base="xsd:token">
+          <xsd:enumeration value="present"/>
+        </xsd:restriction>
+      </xsd:simpleType>
+    </xsd:union>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="udunitDate">
+    <xsd:restriction base="xsd:string">
+      <xsd:annotation>
+        <xsd:documentation>Must conform to complete udunits date string, eg "20 days since 1991-01-01"</xsd:documentation>
+      </xsd:annotation>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="duration">
+    <xsd:union memberTypes="xsd:duration udunitDuration"/>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="udunitDuration">
+    <xsd:restriction base="xsd:string">
+      <xsd:annotation>
+        <xsd:documentation>Must conform to udunits time duration, eg "20.1 hours"</xsd:documentation>
+      </xsd:annotation>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <!-- xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx -->
+  <!-- variables element -->
+  <xsd:element name="variables">
+    <xsd:complexType>
+      <xsd:choice>
+        <xsd:element ref="variable" minOccurs="0" maxOccurs="unbounded"/>
+        <xsd:element ref="variableMap" minOccurs="0"/>
+      </xsd:choice>
+      <xsd:attribute name="vocabulary" type="variableNameVocabulary" use="optional"/>
+      <xsd:attributeGroup ref="XLink"/>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="variable">
+    <xsd:complexType mixed="true">
+      <xsd:attribute name="name" type="xsd:string" use="required"/>
+      <xsd:attribute name="vocabulary_name" type="xsd:string" use="optional"/>
+      <xsd:attribute name="vocabulary_id" type="xsd:string" use="optional"/>
+      <xsd:attribute name="units" type="xsd:string"/>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="variableMap">
+    <xsd:complexType>
+      <xsd:attributeGroup ref="XLink"/>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:simpleType name="variableNameVocabulary">
+    <xsd:union memberTypes="xsd:token">
+      <xsd:simpleType>
+        <xsd:restriction base="xsd:token">
+          <xsd:enumeration value="CF-1.0"/>
+          <xsd:enumeration value="DIF"/>
+          <xsd:enumeration value="GRIB-1"/>
+          <xsd:enumeration value="GRIB-2"/>
+        </xsd:restriction>
+      </xsd:simpleType>
+    </xsd:union>
+  </xsd:simpleType>
+
+  <!-- xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx -->
+  <!-- reusable types and groups -->
+
+  <!-- controlledVocabulary type allows optional vocabulary attribute-->
+  <xsd:complexType name="controlledVocabulary">
+    <xsd:simpleContent>
+      <xsd:extension base="xsd:string">
+        <xsd:attribute name="vocabulary" type="xsd:string"/>
+      </xsd:extension>
+    </xsd:simpleContent>
+  </xsd:complexType>
+
+  <!-- Xlink attribute group -->
+  <xsd:attributeGroup name="XLink">
+    <xsd:attribute ref="xlink:type"/>
+    <xsd:attribute ref="xlink:href"/>
+    <xsd:attribute ref="xlink:title"/>
+    <xsd:attribute ref="xlink:show"/>
+  </xsd:attributeGroup>
+
+  <!-- Collection Types -->
+  <xsd:simpleType name="collectionTypes">
+    <xsd:union memberTypes="xsd:token">
+      <xsd:simpleType>
+        <xsd:restriction base="xsd:token">
+          <xsd:enumeration value="TimeSeries"/>
+          <xsd:enumeration value="Stations"/>
+          <xsd:enumeration value="ForecastModelRuns"/>
+        </xsd:restriction>
+      </xsd:simpleType>
+    </xsd:union>
+  </xsd:simpleType>
+
+  <!-- Data Types -->
+  <xsd:simpleType name="dataTypes">
+    <xsd:union memberTypes="xsd:token">
+      <xsd:simpleType>
+        <xsd:restriction base="xsd:token">
+          <xsd:enumeration value="Grid"/>
+          <xsd:enumeration value="Image"/>
+          <xsd:enumeration value="Point"/>
+          <xsd:enumeration value="Radial"/>
+          <xsd:enumeration value="Station"/>
+          <xsd:enumeration value="Swath"/>
+          <xsd:enumeration value="Trajectory"/>
+        </xsd:restriction>
+      </xsd:simpleType>
+    </xsd:union>
+  </xsd:simpleType>
+
+  <!-- DataFormat Types -->
+  <xsd:simpleType name="dataFormatTypes">
+    <xsd:union memberTypes="xsd:token mimeType">
+      <xsd:simpleType>
+        <xsd:restriction base="xsd:token">
+          <xsd:enumeration value="BUFR"/>
+          <xsd:enumeration value="ESML"/>
+          <xsd:enumeration value="GEMPAK"/>
+          <xsd:enumeration value="GINI"/>
+          <xsd:enumeration value="GRIB-1"/>
+          <xsd:enumeration value="GRIB-2"/>
+          <xsd:enumeration value="HDF4"/>
+          <xsd:enumeration value="HDF5"/>
+          <xsd:enumeration value="McIDAS-AREA"/>
+          <xsd:enumeration value="NcML"/>
+          <xsd:enumeration value="NetCDF"/>
+          <xsd:enumeration value="NetCDF-4"/>
+          <xsd:enumeration value="NEXRAD2"/>
+          <xsd:enumeration value="NIDS"/>
+
+          <xsd:enumeration value="image/gif"/>
+          <xsd:enumeration value="image/jpeg"/>
+          <xsd:enumeration value="image/tiff"/>
+          <xsd:enumeration value="text/csv"/>
+          <xsd:enumeration value="text/html"/>
+          <xsd:enumeration value="text/plain"/>
+          <xsd:enumeration value="text/tab-separated-values"/>
+          <xsd:enumeration value="text/xml"/>
+          <xsd:enumeration value="video/mpeg"/>
+          <xsd:enumeration value="video/quicktime"/>
+          <xsd:enumeration value="video/realtime"/>
+        </xsd:restriction>
+      </xsd:simpleType>
+    </xsd:union>
+  </xsd:simpleType>
+
+  <xsd:simpleType name="mimeType">
+    <xsd:restriction base="xsd:token">
+      <xsd:annotation>
+        <xsd:documentation>any valid mime type (see http://www.iana.org/assignments/media-types/)</xsd:documentation>
+      </xsd:annotation>
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <!-- Date Types -->
+  <xsd:simpleType name="dateEnumTypes">
+    <xsd:union memberTypes="xsd:token">
+      <xsd:simpleType>
+        <xsd:restriction base="xsd:token">
+          <xsd:enumeration value="created"/>
+          <xsd:enumeration value="modified"/>
+          <xsd:enumeration value="valid"/>
+          <xsd:enumeration value="issued"/>
+          <xsd:enumeration value="available"/>
+          <xsd:enumeration value="metadataCreated"/>
+        </xsd:restriction>
+      </xsd:simpleType>
+    </xsd:union>
+  </xsd:simpleType>
+
+  <!-- Documentation Types -->
+  <xsd:simpleType name="documentationEnumTypes">
+    <xsd:union memberTypes="xsd:token">
+      <xsd:simpleType>
+        <xsd:restriction base="xsd:token">
+          <xsd:enumeration value="funding"/>
+          <xsd:enumeration value="history"/>
+          <xsd:enumeration value="processing_level"/>
+          <xsd:enumeration value="rights"/>
+          <xsd:enumeration value="summary"/>
+        </xsd:restriction>
+      </xsd:simpleType>
+    </xsd:union>
+  </xsd:simpleType>
+
+  <!-- MetadataTypeEnum -->
+  <xsd:simpleType name="metadataTypeEnum">
+    <xsd:union memberTypes="xsd:token">
+      <xsd:simpleType>
+        <xsd:restriction base="xsd:token">
+          <xsd:enumeration value="THREDDS"/>
+          <xsd:enumeration value="ADN"/>
+          <xsd:enumeration value="Aggregation"/>
+          <xsd:enumeration value="CatalogGenConfig"/>
+          <xsd:enumeration value="DublinCore"/>
+          <xsd:enumeration value="DIF"/>
+          <xsd:enumeration value="FGDC"/>
+          <xsd:enumeration value="LAS"/>
+          <xsd:enumeration value="ESG"/>
+          <xsd:enumeration value="Other"/>
+        </xsd:restriction>
+      </xsd:simpleType>
+    </xsd:union>
+  </xsd:simpleType>
+
+  <!-- ServiceTypeEnum -->
+  <xsd:simpleType name="serviceTypes">
+    <xsd:union memberTypes="xsd:token">
+      <xsd:simpleType>
+        <xsd:restriction base="xsd:token">
+          <!-- client/server -->
+          <xsd:enumeration value="ADDE"/>
+          <xsd:enumeration value="DAP4"/>
+          <xsd:enumeration value="DODS"/> <!-- same as OpenDAP -->
+          <xsd:enumeration value="OpenDAP"/>
+          <xsd:enumeration value="OpenDAPG"/>
+          <xsd:enumeration value="NetcdfSubset"/>
+          <xsd:enumeration value="CdmRemote"/>
+          <xsd:enumeration value="CdmFeature"/>
+          <xsd:enumeration value="ncJSON"/>
+          <xsd:enumeration value="H5Service"/>
+
+          <!-- bulk transport -->
+          <xsd:enumeration value="HTTPServer"/>
+          <xsd:enumeration value="FTP"/>
+          <xsd:enumeration value="GridFTP"/>
+          <xsd:enumeration value="File"/>
+
+          <!-- web services -->
+          <xsd:enumeration value="ISO"/>
+          <xsd:enumeration value="LAS"/>
+          <xsd:enumeration value="LAS"/>
+          <xsd:enumeration value="NcML"/>
+          <xsd:enumeration value="UDDC"/>
+          <xsd:enumeration value="WCS"/>
+          <xsd:enumeration value="WMS"/>
+          <xsd:enumeration value="WSDL"/>
+
+          <!--offline -->
+          <xsd:enumeration value="WebForm"/>
+
+          <!-- THREDDS -->
+          <xsd:enumeration value="Catalog"/>
+          <xsd:enumeration value="Compound"/>
+          <xsd:enumeration value="Resolver"/>
+          <xsd:enumeration value="THREDDS"/>
+        </xsd:restriction>
+      </xsd:simpleType>
+    </xsd:union>
+  </xsd:simpleType>
+
+  <!-- xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx -->
+  <!-- server-side Configuration Catalog elements  -->
+  <!-- xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx -->
+
+  <!-- datasetRoot element: associate a url path with a directory location -->
+  <xsd:element name="datasetRoot">
+    <xsd:complexType>
+      <xsd:attribute name="path" type="xsd:string" use="required"/>
+      <xsd:attribute name="location" type="xsd:string" use="required"/>
+      <xsd:attribute name="cache" type="xsd:boolean"/>                  <!-- no not use -->
+    </xsd:complexType>
+  </xsd:element>
+
+  <!-- CatalogScan element -->
+  <!-- scan a directory and read all catalogs. optionally watch for changes while TDS is running -->
+  <xsd:element name="catalogScan">
+    <xsd:complexType>
+      <xsd:attribute name="name" type="xsd:string"/>
+      <xsd:attribute name="path" type="xsd:string"/>
+      <xsd:attribute name="location" type="xsd:string"/>
+      <xsd:attribute name="watch" type="xsd:boolean"/>
+    </xsd:complexType>
+  </xsd:element>
+
+  <!-- DatasetScan element -->
+  <!-- scan a directory to add datasets to catalog -->
+  <xsd:element name="datasetScan" substitutionGroup="dataset">
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="DatasetType">
+          <xsd:sequence>
+            <xsd:element ref="filter" minOccurs="0"/>
+            <xsd:element ref="namer" minOccurs="0"/>
+            <xsd:element name="filesSort" type="fileSortType" minOccurs="0"/>
+            <xsd:element ref="sort" minOccurs="0"/>           <!-- deprecated, use filesSort -->
+            <xsd:element name="addLatest" type="addLatestType" minOccurs="0"/>
+            <xsd:element ref="addProxies" minOccurs="0"/>      <!-- deprecated, use addLatest -->
+            <xsd:element ref="addTimeCoverage" minOccurs="0"/>
+          </xsd:sequence>
+
+          <xsd:attribute name="path" type="xsd:string" use="required"/>
+          <xsd:attribute name="location" type="xsd:string"/>
+          <xsd:attribute name="addLatest" type="xsd:boolean"/>
+          <xsd:attribute name="excludeEmptyDirs" type="xsd:boolean"/>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="filter">
+    <xsd:complexType>
+      <xsd:choice>
+        <xsd:sequence minOccurs="0" maxOccurs="unbounded">
+          <xsd:element name="include" type="FilterSelectorType" minOccurs="0"/>
+          <xsd:element name="exclude" type="FilterSelectorType" minOccurs="0"/>
+        </xsd:sequence>
+      </xsd:choice>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:complexType name="FilterSelectorType">
+    <xsd:attribute name="regExp" type="xsd:string"/>
+    <xsd:attribute name="wildcard" type="xsd:string"/>
+    <xsd:attribute name="atomic" type="xsd:boolean"/>
+    <xsd:attribute name="collection" type="xsd:boolean"/>
+  </xsd:complexType>
+
+  <xsd:element name="namer">
+    <xsd:complexType>
+      <xsd:choice maxOccurs="unbounded">
+        <xsd:element name="regExpOnName" type="NamerSelectorType"/>
+        <xsd:element name="regExpOnPath" type="NamerSelectorType"/>
+      </xsd:choice>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:complexType name="NamerSelectorType">
+    <xsd:attribute name="regExp" type="xsd:string"/>
+    <xsd:attribute name="replaceString" type="xsd:string"/>
+  </xsd:complexType>
+
+  <xsd:element name="sort">
+    <xsd:complexType>
+      <xsd:choice>
+        <xsd:element name="lexigraphicByName">
+          <xsd:complexType>
+            <xsd:attribute name="increasing" type="xsd:boolean"/>
+          </xsd:complexType>
+        </xsd:element>
+      </xsd:choice>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:complexType name="addLatestType">
+    <xsd:attribute name="name" type="xsd:string"/>
+    <xsd:attribute name="top" type="xsd:boolean"/>
+    <xsd:attribute name="serviceName" type="xsd:string"/>
+    <xsd:attribute name="lastModifiedLimit" type="xsd:float"/> <!-- minutes -->
+  </xsd:complexType>
+
+  <xsd:element name="addTimeCoverage">
+    <xsd:complexType>
+      <xsd:attribute name="datasetNameMatchPattern" type="xsd:string"/>
+      <xsd:attribute name="datasetPathMatchPattern" type="xsd:string"/>
+      <xsd:attribute name="startTimeSubstitutionPattern" type="xsd:string"/>
+      <xsd:attribute name="duration" type="xsd:string"/>
+    </xsd:complexType>
+  </xsd:element>
+
+  <!-- legacy -->
+  <xsd:element name="addProxies">
+    <xsd:complexType>
+      <xsd:choice minOccurs="0" maxOccurs="unbounded">
+        <xsd:element name="simpleLatest" type="addLatestType"/>
+        <xsd:element name="latestComplete" type="addLatestType"/>
+      </xsd:choice>
+    </xsd:complexType>
+  </xsd:element>
+
+  <!-- xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx -->
+  <!-- featureCollection element -->
+  <xsd:element name="featureCollection" substitutionGroup="dataset">
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="DatasetType">
+          <xsd:sequence>
+            <xsd:element type="collectionType" name="collection"/>
+            <xsd:element type="updateType" name="update" minOccurs="0"/>
+            <xsd:element type="tdmType" name="tdm" minOccurs="0"/>
+            <xsd:element type="protoDatasetType" name="protoDataset" minOccurs="0"/>
+            <xsd:element type="fmrcConfigType" name="fmrcConfig" minOccurs="0"/>
+            <xsd:element type="pointConfigType" name="pointConfig" minOccurs="0"/>
+            <xsd:element type="gribConfigType" name="gribConfig" minOccurs="0"/>
+            <xsd:element type="fileSortType" name="filesSort" minOccurs="0" />
+            <xsd:element ref="ncml:netcdf" minOccurs="0"/>
+          </xsd:sequence>
+          <xsd:attribute name="featureType" type="featureTypeChoice" use="required"/>
+          <xsd:attribute name="path" type="xsd:string" use="required"/>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:complexType name="fileSortType">
+    <xsd:attribute name="increasing" type="xsd:boolean" use="optional"/>
+  </xsd:complexType>
+
+  <xsd:simpleType name="featureTypeChoice">
+    <xsd:union memberTypes="xsd:token">
+      <xsd:simpleType>
+        <xsd:restriction base="xsd:token">
+          <xsd:enumeration value="FMRC"/>
+          <xsd:enumeration value="GRIB1"/>
+          <xsd:enumeration value="GRIB2"/>
+          <xsd:enumeration value="Point"/>
+          <xsd:enumeration value="Station"/>
+        </xsd:restriction>
+      </xsd:simpleType>
+    </xsd:union>
+  </xsd:simpleType>
+
+  <xsd:complexType name="collectionType">
+    <xsd:attribute name="spec" type="xsd:string" use="required"/>
+    <xsd:attribute name="name" type="xsd:token"/>
+    <xsd:attribute name="olderThan" type="xsd:string"/>
+    <xsd:attribute name="dateFormatMark" type="xsd:string"/>
+    <xsd:attribute name="timePartition" type="xsd:string"/>
+    <xsd:attribute name="useIndexOnly" type="xsd:boolean"/>
+  </xsd:complexType>
+
+  <xsd:complexType name="updateType">
+    <xsd:attribute name="recheckAfter" type="xsd:string"/>
+    <xsd:attribute name="rescan" type="xsd:token"/>
+    <xsd:attribute name="rewrite" type="collectionUpdateType"/>
+    <xsd:attribute name="startup" type="collectionUpdateType"/>
+    <xsd:attribute name="trigger" type="xsd:string"/>
+  </xsd:complexType>
+
+  <xsd:complexType name="tdmType">
+    <xsd:sequence>
+      <xsd:element ref="manage" minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attribute name="rewrite" type="collectionUpdateType"/>
+    <xsd:attribute name="rescan" type="xsd:token"/>
+  </xsd:complexType>
+
+  <xsd:simpleType name="collectionUpdateType">
+    <xsd:union memberTypes="xsd:token">
+      <xsd:simpleType>
+        <xsd:restriction base="xsd:token">
+          <xsd:enumeration value="never"/>
+          <xsd:enumeration value="nocheck"/>
+          <xsd:enumeration value="testIndexOnly"/>
+          <xsd:enumeration value="test"/>
+          <xsd:enumeration value="always"/>
+        </xsd:restriction>
+      </xsd:simpleType>
+    </xsd:union>
+  </xsd:simpleType>
+
+  <xsd:element name="manage">
+    <xsd:complexType>
+      <xsd:attribute name="deleteAfter" type="xsd:string" use="required"/>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:complexType name="protoDatasetType">
+    <xsd:sequence>
+      <xsd:element ref="ncml:netcdf" minOccurs="0"/>
+    </xsd:sequence>
+    <xsd:attribute name="choice" type="protoChoices"/>
+    <xsd:attribute name="change" type="xsd:string"/>
+    <xsd:attribute name="param" type="xsd:string"/>
+  </xsd:complexType>
+
+  <xsd:simpleType name="protoChoices">
+    <xsd:union memberTypes="xsd:token">
+      <xsd:simpleType>
+        <xsd:restriction base="xsd:token">
+          <xsd:enumeration value="First"/>
+          <xsd:enumeration value="Random"/>
+          <xsd:enumeration value="Penultimate"/>
+          <xsd:enumeration value="Latest"/>
+          <xsd:enumeration value="Run"/>
+        </xsd:restriction>
+      </xsd:simpleType>
+    </xsd:union>
+  </xsd:simpleType>
+
+  <xsd:complexType name="fmrcConfigType">
+    <xsd:sequence>
+      <xsd:element name="bestDataset" minOccurs="0">
+        <xsd:complexType>
+          <xsd:attribute name="name" type="xsd:token" use="required"/>
+          <xsd:attribute name="offsetsGreaterEqual" type="xsd:int" use="required"/>
+        </xsd:complexType>
+      </xsd:element>
+    </xsd:sequence>
+    <xsd:attribute name="regularize" type="xsd:boolean"/>
+    <xsd:attribute name="datasetTypes" type="fmrcDatasetTypes"/>
+  </xsd:complexType>
+
+  <xsd:simpleType name="fmrcDatasetTypes">
+    <xsd:union memberTypes="xsd:token">
+      <xsd:simpleType>
+        <xsd:restriction base="xsd:token">
+          <xsd:enumeration value="TwoD"/>
+          <xsd:enumeration value="Best"/>
+          <xsd:enumeration value="Files"/>
+          <xsd:enumeration value="Runs"/>
+          <xsd:enumeration value="ConstantForecasts"/>
+          <xsd:enumeration value="ConstantOffsets"/>
+        </xsd:restriction>
+      </xsd:simpleType>
+    </xsd:union>
+  </xsd:simpleType>
+
+  <xsd:complexType name="pointConfigType">
+    <xsd:attribute name="datasetTypes" type="xsd:string"/>
+  </xsd:complexType>
+
+  <xsd:complexType name="gribConfigType">
+    <xsd:sequence>
+
+      <xsd:element name="gdsHash" minOccurs="0">
+        <xsd:complexType>
+          <xsd:attribute name="from" type="xsd:int" use="required"/>
+          <xsd:attribute name="to" type="xsd:int" use="required"/>
+        </xsd:complexType>
+      </xsd:element>
+
+      <xsd:element name="gdsName" minOccurs="0" maxOccurs="unbounded">
+        <xsd:complexType>
+          <xsd:attribute name="hash" type="xsd:int"/>
+          <xsd:attribute name="groupName" type="xsd:string"/>
+        </xsd:complexType>
+      </xsd:element>
+
+      <xsd:element name="pdsHash" minOccurs="0" maxOccurs="unbounded">
+        <xsd:complexType>
+          <xsd:sequence>
+            <xsd:element name="useGenType" minOccurs="0"/>
+            <xsd:element name="useTableVersion" minOccurs="0"/>
+            <xsd:element name="mergeIntv" minOccurs="0"/>
+          </xsd:sequence>
+        </xsd:complexType>
+      </xsd:element>
+
+      <xsd:element name="intvFilter" minOccurs="0" maxOccurs="unbounded">
+        <xsd:complexType>
+          <xsd:sequence>
+            <xsd:element name="variable" minOccurs="0" maxOccurs="unbounded">
+              <xsd:complexType>
+                <xsd:attribute name="id" type="xsd:string" use="required"/>
+                <xsd:attribute name="prob" type="xsd:string" use="optional"/>
+              </xsd:complexType>
+            </xsd:element>
+          </xsd:sequence>
+          <xsd:attribute name="excludeZero" type="xsd:boolean" use="optional"/>
+          <xsd:attribute name="intvLength" type="xsd:int" use="optional"/>
+        </xsd:complexType>
+      </xsd:element>
+
+      <xsd:element name="filter" minOccurs="0" maxOccurs="unbounded">
+        <xsd:complexType>
+          <xsd:sequence>
+            <xsd:element name="include" minOccurs="0" maxOccurs="unbounded">
+              <xsd:complexType>
+                <xsd:attribute name="name" type="xsd:string" use="required"/>
+                <xsd:attribute name="value" type="xsd:string" use="required"/>
+              </xsd:complexType>
+            </xsd:element>
+          </xsd:sequence>
+        </xsd:complexType>
+      </xsd:element>
+
+      <xsd:element name="timeUnitConvert" minOccurs="0">
+        <xsd:complexType>
+          <xsd:attribute name="from" type="xsd:int" use="required"/>
+          <xsd:attribute name="to" type="xsd:int" use="required"/>
+        </xsd:complexType>
+      </xsd:element>
+
+      <xsd:element name="option" minOccurs="0" maxOccurs="unbounded">
+         <xsd:complexType>
+           <xsd:attribute name="name" type="xsd:string" use="required"/>
+           <xsd:attribute name="value" type="xsd:string" use="required"/>
+         </xsd:complexType>
+       </xsd:element>
+
+      <xsd:element name="latestNamer" minOccurs="0">
+        <xsd:complexType>
+          <xsd:attribute name="name" type="xsd:string" use="required"/>
+        </xsd:complexType>
+      </xsd:element>
+
+      <xsd:element name="bestNamer" minOccurs="0">
+        <xsd:complexType>
+          <xsd:attribute name="name" type="xsd:string" use="required"/>
+        </xsd:complexType>
+      </xsd:element>
+
+    </xsd:sequence>
+
+    <xsd:attribute name="datasetTypes" type="gribDatasetTypes"/>
+
+  </xsd:complexType>
+
+  <xsd:simpleType name="gribDatasetTypes">
+    <xsd:union memberTypes="xsd:token">
+      <xsd:simpleType>
+        <xsd:restriction base="xsd:token">
+          <xsd:enumeration value="TwoD"/>
+          <xsd:enumeration value="Best"/>
+          <xsd:enumeration value="Analysis"/>
+          <xsd:enumeration value="Files"/>
+          <xsd:enumeration value="Latest"/>
+          <xsd:enumeration value="LatestFile"/>    <!-- alias for Latest -->
+        </xsd:restriction>
+      </xsd:simpleType>
+    </xsd:union>
+  </xsd:simpleType>
+
+</xsd:schema>

--- a/tdcommon/src/main/resources/resources/thredds/schemas/xlink.xsd
+++ b/tdcommon/src/main/resources/resources/thredds/schemas/xlink.xsd
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- METS XLink Schema, v. 2, Nov. 15, 2004 fragment from http://www.loc.gov/standards/mets/xlink.xsd -->
+<schema targetNamespace="http://www.w3.org/1999/xlink"
+        xmlns="http://www.w3.org/2001/XMLSchema"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        elementFormDefault="qualified">
+
+  <attribute name="type" type="string"/>
+  <attribute name="href" type="anyURI"/>
+  <attribute name="show" type="string"/>
+  <attribute name="title" type="string"/>
+</schema>
+

--- a/tds/src/integrationTests/java/thredds/server/catalog/TestTdsDatasetScan.java
+++ b/tds/src/integrationTests/java/thredds/server/catalog/TestTdsDatasetScan.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998-2025 University Corporation for Atmospheric Research/Unidata
+ * Copyright (c) 1998-2026 University Corporation for Atmospheric Research/Unidata
  * See LICENSE for license information.
  */
 
@@ -8,6 +8,9 @@ package thredds.server.catalog;
 import static com.google.common.truth.Truth.assertThat;
 
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.slf4j.Logger;
@@ -202,4 +205,58 @@ public class TestTdsDatasetScan {
     assertThat(hasFileServer).isTrue();
   }
 
+  @Test
+  public void testEmptyDir() throws IOException {
+    // Create an empty directory in a dataset scan catalog, check that a catalogRef is not created.
+    // Next, add a file to the directory and make sure a new catalogRef is added to the catalog.
+    // Finally, remove the file and make sure the catalogRef count returns to the initial count.
+    // In all cases, the default scan behavior should see one additional catalogRef once the
+    // empty directory is created.
+    final String scanExcludeEmptyDirs = "catalog/scanLocalExcludeEmpty/catalog.xml";
+    final String scanDefaultExcludeEmptyDirs = "catalog/scanLocal/catalog.xml";
+    final int initialCatalogRefCount = 2;
+    checkCatalogRefCount(scanDefaultExcludeEmptyDirs, initialCatalogRefCount);
+    checkCatalogRefCount(scanExcludeEmptyDirs, initialCatalogRefCount);
+
+    final Path contentTestDataPath = Paths.get("src/test/content/thredds/public/testdata");
+    assertThat(Files.exists(contentTestDataPath)).isTrue();
+
+    // used during testing
+    final Path emptyDir = contentTestDataPath.resolve("empty");
+    final Path fileToAddToEmptyDir = emptyDir.resolve("empty.txt");
+
+    try {
+      // create empty directory, check that catalogRefs do not increase for
+      // scan that excludes empty directories
+      Files.createDirectory(emptyDir);
+      checkCatalogRefCount(scanDefaultExcludeEmptyDirs, initialCatalogRefCount + 1);
+      checkCatalogRefCount(scanExcludeEmptyDirs, initialCatalogRefCount);
+      // add file to empty directory, check that catalogRefs increases by 1 for
+      // scan that excludes empty directories
+      Files.createFile(fileToAddToEmptyDir);
+      checkCatalogRefCount(scanDefaultExcludeEmptyDirs, initialCatalogRefCount + 1);
+      checkCatalogRefCount(scanExcludeEmptyDirs, initialCatalogRefCount + 1);
+      // remove file from the empty directory, check that catalogRefs returns to initial count
+      // for scan that excludes empty directories
+      Files.deleteIfExists(fileToAddToEmptyDir);
+      checkCatalogRefCount(scanDefaultExcludeEmptyDirs, initialCatalogRefCount + 1);
+      checkCatalogRefCount(scanExcludeEmptyDirs, initialCatalogRefCount);
+    } finally {
+      // clean up in case of failures
+      Files.deleteIfExists(fileToAddToEmptyDir);
+      Files.deleteIfExists(emptyDir);
+    }
+  }
+
+  private static void checkCatalogRefCount(String catalogLocation, int expectedRefs) {
+    Catalog cat = TdsLocalCatalog.open(catalogLocation);
+    assertThat(cat).isNotNull();
+    int count = 0;
+    for (Dataset ds : cat.getAllDatasets()) {
+      if (ds instanceof CatalogRef) {
+        count++;
+      }
+    }
+    assertThat(count).isEqualTo(expectedRefs);
+  }
 }

--- a/tds/src/main/resources/resources/thredds/schemas/queryCapability.0.4.xsd
+++ b/tds/src/main/resources/resources/thredds/schemas/queryCapability.0.4.xsd
@@ -1,0 +1,297 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema targetNamespace="http://www.unidata.ucar.edu/namespaces/thredds/queryCapability/v0.4"
+  xmlns="http://www.unidata.ucar.edu/namespaces/thredds/queryCapability/v0.4"
+  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+  xmlns:cat="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0"
+  xmlns:xlink="http://www.w3.org/1999/xlink"
+  elementFormDefault="qualified">
+
+  <xsd:import namespace="http://www.unidata.ucar.edu/namespaces/thredds/InvCatalog/v1.0"
+    schemaLocation="https://schemas.unidata.ucar.edu/thredds/InvCatalog.1.0.xsd" />
+
+  <!--
+    The queryCapability element.
+  -->
+  <xsd:element name="queryCapability">
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element ref="query"/>
+        <!-- Require a selectService, more allowed because of selector elements. -->
+        <xsd:element ref="selectService"/>
+        <xsd:element ref="selector" minOccurs="1" maxOccurs="unbounded"/>
+        <xsd:element ref="userInterface" minOccurs="0" maxOccurs="unbounded"/>
+      </xsd:sequence>
+      <xsd:attribute name="version" type="xsd:token" default="0.4"/>
+      <xsd:attribute name="name" type="xsd:token"/>
+    </xsd:complexType>
+
+    <!-- The id attribute of the selector element must be unique. -->
+    <xsd:unique name="selectorID">
+      <xsd:selector xpath=".//selector"/>
+      <xsd:field xpath="@id"/>
+    </xsd:unique>
+  </xsd:element>
+
+  <!--
+    The query element.
+  -->
+  <xsd:element name="query">
+    <xsd:complexType>
+      <xsd:attribute name="base" type="xsd:string" use="required"/>
+    </xsd:complexType>
+  </xsd:element>
+
+  <!--
+    An abstract base class for all selector elements.
+  -->
+  <xsd:element name="selector" type="selectorType" abstract="true"/>
+  <xsd:complexType name="selectorType">
+    <xsd:sequence>
+      <xsd:element name="description" type="cat:documentationType" minOccurs="0" maxOccurs="1"/>
+    </xsd:sequence>
+    <xsd:attribute name="id" type="xsd:token" use="required"/>
+    <xsd:attribute name="title" type="xsd:token" use="required"/>
+    <xsd:attribute name="template" type="xsd:token"/>
+    <xsd:attribute name="required" type="xsd:boolean" default="true"/>
+  </xsd:complexType>
+
+  <!--
+    compound selectors.
+  -->
+  <xsd:element name="compound" substitutionGroup="selector">
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="selectorType">
+          <xsd:sequence>
+            <xsd:element ref="selector"/>
+            <xsd:element name="or"/>
+            <xsd:element ref="selector"/>
+          </xsd:sequence>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:simpleType name="operator">
+    <xsd:union memberTypes="xsd:token">
+      <xsd:simpleType>
+        <xsd:restriction base="xsd:token">
+          <xsd:enumeration value="and"/>
+          <xsd:enumeration value="or"/>
+        </xsd:restriction>
+      </xsd:simpleType>
+    </xsd:union>
+  </xsd:simpleType>
+
+  <!--
+    The selectList element defines a list of choices from which a user can
+    select one or more entries.
+  -->
+  <!-- When the construct method is set to "template", the
+       template string must contain exactly one replacement string.
+       The template string does not have to be related to the id
+       of the selector, if one is given. No matter the actual
+       replacement string used, it will be replaced with the value
+       of the selection. When the "paramValue" construct method
+       is chosen, the parameter name will be the value of the id
+       or "item" if no id is given, i.e., "<id>=<value>" or
+       "item=<value>".
+    -->
+  <xsd:element name="selectList" substitutionGroup="selector">
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="selectorType">
+          <xsd:sequence>
+            <xsd:element ref="choice" minOccurs="1" maxOccurs="unbounded"/>
+          </xsd:sequence>
+          <xsd:attribute name="multiple" type="xsd:boolean" default="false"/>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="choice" type="choiceType"/>
+  <xsd:complexType name="choiceType">
+    <xsd:sequence>
+      <xsd:element name="description" type="cat:documentationType" minOccurs="0" maxOccurs="1"/>
+      <xsd:element ref="selectList" minOccurs="0" maxOccurs="unbounded"/>
+    </xsd:sequence>
+    <xsd:attribute name="name" type="xsd:string" use="required"/>
+    <xsd:attribute name="value" type="xsd:string" use="required"/>
+  </xsd:complexType>
+
+  <!--
+    A selectService element defines the list of serviceTypes available through
+    a query. The user can select the service type(s) they understand and limit the
+    datasets returned to only those service types..
+  -->
+  <xsd:element name="selectService" substitutionGroup="selector">
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="selectorType">
+          <xsd:sequence>
+            <xsd:element name="serviceType" minOccurs="1" maxOccurs="unbounded">
+              <xsd:complexType>
+                <xsd:simpleContent>
+                  <xsd:extension base="cat:serviceTypes">
+                    <xsd:attribute name="title" type="xsd:token"/>
+                    <xsd:attribute name="dataFormatType" type="cat:dataFormatTypes"/>
+                    <xsd:attribute name="returns" type="xsd:token" use="required"/>
+                    <xsd:attribute name="value" type="xsd:token" use="required"/>
+                  </xsd:extension>
+                </xsd:simpleContent>
+              </xsd:complexType>
+            </xsd:element>
+          </xsd:sequence>
+          <xsd:attribute name="multiple" type="xsd:boolean" default="false"/>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+
+  <!--
+    A selectStation element defines a list of stations from which a user can select.
+  -->
+  <!-- When the construct method is set to "template", the
+       template string must contain exactly one replacement string.
+       The template string does not have to be related to the id
+       of the selector, if one is given. No matter the actual
+       replacement string used, it will be replaced with the value
+       of the selection. When the "paramValue" construct method
+       is chosen, the parameter name will be the value of the id
+       or "stn" if no id is given, i.e., "<id>=<value>" or
+       "stn=<value>".
+    -->
+  <xsd:element name="selectStation" substitutionGroup="selector">
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="selectorType">
+          <xsd:sequence>
+            <xsd:element ref="station" minOccurs="1" maxOccurs="unbounded"/>
+          </xsd:sequence>
+          <xsd:attribute name="multiple" type="xsd:boolean" default="false"/>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="station" substitutionGroup="choice">
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="choiceType">
+          <xsd:sequence>
+            <xsd:element ref="location"/>
+          </xsd:sequence>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="location" type="locationType"/>
+  <xsd:complexType name="locationType">
+    <xsd:attribute name="latitude" type="xsd:float" use="required"/>
+    <xsd:attribute name="longitude" type="xsd:float" use="required"/>
+    <xsd:attribute name="latitude_units" type="xsd:token" default="degrees_north"/>
+    <xsd:attribute name="longitude_units" type="xsd:token" default="degrees_east"/>
+  </xsd:complexType>
+
+  <xsd:element name="location3D" substitutionGroup="location">
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="locationType">
+          <xsd:attribute name="elevation" type="xsd:float" use="required"/>
+          <xsd:attribute name="elevation_units" type="xsd:token" default="msl"/>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+
+  <!--
+    A selectFromRange element defines a range from which a user may select
+    a point or a range.
+
+    To select a point, a single replacement string is required: {point}. To
+    select a range, two replacement strings are required: {min} and {max}.
+  -->
+  <xsd:element name="selectFromRange" substitutionGroup="selector">
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="selectorType">
+          <xsd:attribute name="min" type="xsd:decimal" use="required"/>
+          <xsd:attribute name="max" type="xsd:decimal" use="required"/>
+          <xsd:attribute name="units" type="xsd:string"/>
+          <xsd:attribute name="modulo" type="xsd:boolean" default="false"/>
+          <xsd:attribute name="resolution" type="xsd:float" use="required"/>
+          <xsd:attribute name="selectType" type="rangeSelectTypeEnum" default="subrange" />
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+
+  <!-- Enumeration of allowed types of selections from a range. -->
+  <xsd:simpleType name="rangeSelectTypeEnum">
+    <xsd:restriction base="xsd:token">
+      <xsd:enumeration value="point"/>
+      <xsd:enumeration value="subrange"/>
+      <!--xsd:enumeration value="pointOrRange"/-->
+    </xsd:restriction>
+  </xsd:simpleType>
+
+  <!--
+    A selectFromDateRange element defines a date range from which a user may
+    select a point or a date range.
+
+    To select a point, a single replacement string is required: {point}. To
+    select a range, two replacement strings are required: {min} and {max}.
+  -->
+  <xsd:element name="selectFromDateRange" substitutionGroup="selector">
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="selectorType">
+          <xsd:attribute name="start" type="cat:dateType"/>
+          <xsd:attribute name="end" type="cat:dateType"/>
+          <xsd:attribute name="duration" type="cat:duration"/>
+          <xsd:attribute name="resolution" type="cat:duration" use="required"/>
+          <xsd:attribute name="selectType" type="rangeSelectTypeEnum" default="subrange"/>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+
+  <!--
+     The selectFromGeoRegion element defines a geographic region from which the
+     user can select a geographic region, currently limited to a bounding box.
+    -->
+  <xsd:element name="selectFromGeoRegion" substitutionGroup="selector">
+    <xsd:complexType>
+      <xsd:complexContent>
+        <xsd:extension base="selectorType">
+          <xsd:sequence>
+            <xsd:element ref="geoBoundingBox"/>
+          </xsd:sequence>
+        </xsd:extension>
+      </xsd:complexContent>
+    </xsd:complexType>
+  </xsd:element>
+
+  <xsd:element name="geoBoundingBox">
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:element name="lowerLeft" type="locationType"/>
+        <xsd:element name="upperRight" type="locationType"/>
+      </xsd:sequence>
+    </xsd:complexType>
+  </xsd:element>
+
+  <!--
+    The userInterface element definition.
+  -->
+  <xsd:element name="userInterface">
+    <xsd:complexType>
+      <xsd:sequence>
+        <xsd:any minOccurs="0" maxOccurs="unbounded" processContents="skip"/>
+      </xsd:sequence>
+    </xsd:complexType>
+  </xsd:element>
+
+</xsd:schema>

--- a/tds/src/test/content/thredds/catalog.xml
+++ b/tds/src/test/content/thredds/catalog.xml
@@ -129,6 +129,17 @@
     </sort>
   </datasetScan>
 
+  <datasetScan name="Test Scan Local Exclude Empty Dirs (no ID)" path="scanLocalExcludeEmpty"
+               location="content/testdata/"
+               excludeEmptyDirs="true">
+    <metadata inherited="true">
+      <serviceName>all</serviceName>
+    </metadata>
+    <sort>
+      <lexigraphicByName increasing="true"/>
+    </sort>
+  </datasetScan>
+
   <!-- a scan on the entire /upc/share/cdmUnitTest directory; not all services will make sense -->
   <datasetScan name="Test scan cdmUnitTest (ID)" ID="scanCdmUnitTests" path="scanCdmUnitTests" location="${cdmUnitTest}/">
     <metadata inherited="true">


### PR DESCRIPTION
This PR also moves management of the InvCatalog, xlink, and queryCapability.0.4 schemas from netCDF-Java's `cdm-core`.

Closes Unidata/tds#641