### PR TITLE
Allow minimum WMS NUMCOLORBANDS value of 1

### DIFF
--- a/tds/src/main/java/thredds/server/wms/config/LayerSettings.java
+++ b/tds/src/main/java/thredds/server/wms/config/LayerSettings.java
@@ -72,7 +72,7 @@ public class LayerSettings {
       throw new WmsConfigException("defaultPaletteName must contain a value");
     }
     this.defaultNumColorBands =
-        getInteger(parentElement, "defaultNumColorBands", Extents.newExtent(5, ColourPalette.MAX_NUM_COLOURS));
+        getInteger(parentElement, "defaultNumColorBands", Extents.newExtent(1, ColourPalette.MAX_NUM_COLOURS));
     this.logScaling = getBoolean(parentElement, "logScaling");
     this.intervalTime = getBoolean(parentElement, "intervalTime");
     if (this.intervalTime == null) {


### PR DESCRIPTION
The minimum NUMCOLORBANDS prior to this change was 5, but can now go as low as 1. The default remains unchanged in the default wmsConfig.xml settings file as 20.

Addresses unidata/tds#682